### PR TITLE
Materialize admitted snapshots into artifact bundles

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@ A multi-agent cybersecurity gymnasium on [OpenEnv](https://github.com/meta-pytor
 
 ## How It Works
 
-A **manifest** declares a family of legal enterprise worlds — topology, services, identities, vulnerability classes, difficulty. A shared **ManagedSnapshotRuntime** inside the shipped OpenEnv server process owns the snapshot pool. It loads admitted snapshots from disk or preloads a deterministic pool from the manifest, then optionally refills that pool in the background. `reset()` selects one frozen admitted snapshot. `step()` runs commands inside it.
+A **manifest** declares a family of legal enterprise worlds — topology, services, identities, vulnerability classes, difficulty. A shared **ManagedSnapshotRuntime** inside the shipped OpenEnv server process owns the snapshot pool. It loads admitted snapshots from disk or preloads a deterministic pool from the manifest, renders each admitted snapshot into concrete Docker artifacts under `snapshots/<id>/artifacts`, then optionally refills that pool in the background. `reset()` selects one frozen admitted snapshot. `step()` runs commands inside it.
 
 ```mermaid
 flowchart LR
@@ -66,7 +66,7 @@ uv run pytest tests/ -v --tb=short
 
 **Manifest** — YAML defining the legal world: hosts, zones, services, users, NPCs, data assets, credential policies, monitoring coverage, trust relationships, and which vulnerability classes the Builder may plant. Three example manifests ship (healthcare, fintech, SaaS) at tiers 1-3.
 
-**ManagedSnapshotRuntime** — Shared singleton created at server startup. Owns the `SnapshotStore`, builder/mutator, validator gate, snapshot preload, optional background refill, and episode-result feedback. This is the hidden orchestrator behind the env; callers still only see `reset()`, `step()`, and `state()`.
+**ManagedSnapshotRuntime** — Shared singleton created at server startup. Owns the `SnapshotStore`, builder/mutator, validator gate, `SnapshotRenderer`, snapshot preload, optional background refill, and episode-result feedback. This is the hidden orchestrator behind the env; callers still only see `reset()`, `step()`, and `state()`.
 
 **Builder** — Takes a manifest + curriculum context, outputs a `SnapshotSpec`: topology graph, truth graph (planted vulns + exploit chain), evidence graph (what Blue can find), flags, golden path, NPC traffic, and task briefings. Three implementations: `LLMSnapshotBuilder` (production, via litellm), `TemplateOnlyBuilder` (deterministic shipped default), `FileBuilder` (load from disk).
 

--- a/docs/builder-validator.md
+++ b/docs/builder-validator.md
@@ -4,7 +4,7 @@
 
 **LLM generates, renderer materializes, rules validate.** The builder uses LiteLLM to generate candidate snapshot specs as structured JSON. The renderer turns specs into Docker artifacts via Jinja2 templates. The validator runs a 10-check admission pipeline (8 mechanical + 2 LLM advisory) before admitting a snapshot.
 
-Snapshot creation happens **inside a shared `ManagedSnapshotRuntime` in the server process**. That runtime preloads admitted snapshots at startup and can optionally refill them between episodes. `reset()` picks a pre-validated frozen snapshot from the `SnapshotStore`. No LLM calls in the hot path.
+Snapshot creation happens **inside a shared `ManagedSnapshotRuntime` in the server process**. That runtime preloads admitted snapshots at startup, renders each admitted `SnapshotSpec` into Docker artifacts under `snapshots/<id>/artifacts`, and can optionally refill the pool between episodes. `reset()` picks a pre-validated frozen snapshot from the `SnapshotStore`. No LLM calls in the hot path.
 
 ```mermaid
 flowchart LR

--- a/src/open_range/builder/snapshot_store.py
+++ b/src/open_range/builder/snapshot_store.py
@@ -69,6 +69,7 @@ class SnapshotStore:
             "golden_path_steps": len(snapshot.golden_path),
             "flag_count": len(snapshot.flags),
             "npc_count": len(snapshot.npc_personas),
+            "has_compose": bool(snapshot.compose),
             "stored_at": time.time(),
         }
         meta_path = snap_dir / "metadata.json"

--- a/src/open_range/server/runtime.py
+++ b/src/open_range/server/runtime.py
@@ -11,6 +11,7 @@ import asyncio
 import json
 import logging
 import os
+import shutil
 import threading
 import time
 from dataclasses import dataclass, field
@@ -21,6 +22,7 @@ import yaml
 
 from open_range.builder.builder import LLMSnapshotBuilder, TemplateOnlyBuilder
 from open_range.builder.mutator import Mutator
+from open_range.builder.renderer import SnapshotRenderer
 from open_range.builder.snapshot_store import SnapshotStore
 from open_range.protocols import (
     BuildContext,
@@ -279,6 +281,7 @@ class ManagedSnapshotRuntime:
         self.builder = builder or _default_builder()
         self.mutator = Mutator(self.builder)
         self.validator = validator or _default_validator()
+        self.renderer = SnapshotRenderer()
         self.curriculum = CurriculumTracker()
         self.pool_size = max(1, pool_size)
         self.selection_strategy = selection_strategy
@@ -320,6 +323,7 @@ class ManagedSnapshotRuntime:
             existing = self.snapshot_count()
             if existing < self.pool_size:
                 self._top_up_pool(self.pool_size - existing)
+            self._ensure_existing_artifacts()
 
             available = self.snapshot_count()
             if available == 0:
@@ -432,6 +436,18 @@ class ManagedSnapshotRuntime:
         for _ in range(max(0, missing)):
             self._generate_and_store_snapshot()
 
+    def _ensure_existing_artifacts(self) -> None:
+        for meta in self.list_snapshots():
+            snapshot_id = str(meta.get("snapshot_id", ""))
+            if not snapshot_id:
+                continue
+            artifacts_dir = self._artifacts_dir(snapshot_id)
+            if artifacts_dir.exists():
+                continue
+            stored = _run_coro_sync(self.store.get_entry(snapshot_id))
+            materialized = self._materialize_snapshot(stored.snapshot, snapshot_id)
+            _run_coro_sync(self.store.store(materialized, snapshot_id=snapshot_id))
+
     def _generate_and_store_snapshot(self) -> str:
         last_error: str | None = None
         for attempt in range(1, self.generation_retries + 1):
@@ -445,7 +461,11 @@ class ManagedSnapshotRuntime:
             )
             validation = self._validate_snapshot(snapshot)
             if validation.passed:
-                snapshot_id = _run_coro_sync(self.store.store(snapshot))
+                snapshot_id = self._snapshot_id(snapshot)
+                materialized = self._materialize_snapshot(snapshot, snapshot_id)
+                snapshot_id = _run_coro_sync(
+                    self.store.store(materialized, snapshot_id=snapshot_id)
+                )
                 logger.info(
                     "ManagedSnapshotRuntime admitted snapshot %s on attempt %d",
                     snapshot_id,
@@ -490,3 +510,37 @@ class ManagedSnapshotRuntime:
             for check in failed
         ]
         return json.dumps(payload, sort_keys=True)
+
+    def _snapshot_id(self, snapshot: SnapshotSpec) -> str:
+        vuln_types = [v.type for v in snapshot.truth_graph.vulns]
+        prefix = "snap_" + "_".join(vuln_types[:3]) if vuln_types else "snap_generated"
+        return f"{prefix}_{int(time.time() * 1000)}"
+
+    def _snapshot_dir(self, snapshot_id: str) -> Path:
+        return self.store_dir / snapshot_id
+
+    def _artifacts_dir(self, snapshot_id: str) -> Path:
+        return self._snapshot_dir(snapshot_id) / "artifacts"
+
+    def _materialize_snapshot(
+        self,
+        snapshot: SnapshotSpec,
+        snapshot_id: str,
+    ) -> SnapshotSpec:
+        rendered = snapshot.model_copy(deep=True)
+
+        topology = dict(rendered.topology)
+        topology["snapshot_id"] = snapshot_id
+        rendered.topology = topology
+
+        snapshot_dir = self._snapshot_dir(snapshot_id)
+        artifacts_dir = self._artifacts_dir(snapshot_id)
+        if artifacts_dir.exists():
+            shutil.rmtree(artifacts_dir)
+        artifacts_dir.mkdir(parents=True, exist_ok=True)
+
+        self.renderer.render(rendered, artifacts_dir)
+
+        compose_path = artifacts_dir / "docker-compose.yml"
+        rendered.compose = yaml.safe_load(compose_path.read_text(encoding="utf-8")) or {}
+        return rendered

--- a/tests/test_runtime.py
+++ b/tests/test_runtime.py
@@ -25,6 +25,25 @@ class TestManagedSnapshotRuntime:
         finally:
             runtime.stop()
 
+    def test_start_materializes_rendered_artifacts(self, tier1_manifest, tmp_path):
+        runtime = ManagedSnapshotRuntime(
+            manifest=tier1_manifest,
+            store_dir=tmp_path / "snapshots",
+            pool_size=1,
+            refill_enabled=False,
+        )
+
+        runtime.start()
+        try:
+            admitted = runtime.acquire_snapshot()
+            artifacts_dir = tmp_path / "snapshots" / admitted.snapshot_id / "artifacts"
+            assert (artifacts_dir / "docker-compose.yml").exists()
+            assert (artifacts_dir / "Dockerfile.web").exists()
+            assert admitted.snapshot.compose
+            assert "services" in admitted.snapshot.compose
+        finally:
+            runtime.stop()
+
     def test_acquire_snapshot_returns_admitted_snapshot(self, tier1_manifest, tmp_path):
         runtime = ManagedSnapshotRuntime(
             manifest=tier1_manifest,
@@ -57,6 +76,7 @@ class TestManagedSnapshotRuntime:
             loaded = runtime.get_snapshot(first.snapshot_id)
             assert loaded.snapshot_id == first.snapshot_id
             assert loaded.snapshot.flags[0].value == first.snapshot.flags[0].value
+            assert loaded.snapshot.compose == first.snapshot.compose
         finally:
             runtime.stop()
 


### PR DESCRIPTION
## Summary
- render each admitted snapshot into `snapshots/<id>/artifacts` via `SnapshotRenderer`
- persist rendered compose data back into the stored snapshot and backfill artifacts for existing snapshots in the pool
- extend runtime tests to validate artifact materialization and stored compose metadata

## Validation
- `env PYTHONPATH=src .venv/bin/python -m pytest tests/test_runtime.py tests/test_renderer.py tests/test_builder.py tests/test_environment.py -q`
- `env UV_CACHE_DIR=/tmp/uv-cache .venv/bin/openenv validate`

## Scope
This is the real artifact build step behind the managed runtime. It still does not boot the rendered bundle or run the live container-backed validator pipeline yet.