### PR TITLE
Sanitize validator shell and SQL interpolation

### DIFF
--- a/src/open_range/validator/evidence.py
+++ b/src/open_range/validator/evidence.py
@@ -2,6 +2,8 @@
 
 from __future__ import annotations
 
+import shlex
+
 from open_range.protocols import CheckResult, ContainerSet, SnapshotSpec
 
 
@@ -30,16 +32,20 @@ class EvidenceCheck:
                 host, path = "siem", loc
 
             try:
+                quoted_path = shlex.quote(path)
                 if item.type in ("log_entry", "alert"):
                     # grep for pattern in the file
-                    cmd = f"grep -c '{pattern}' {path}" if pattern else f"test -f {path} && echo ok"
+                    if pattern:
+                        cmd = f"grep -c {shlex.quote(pattern)} {quoted_path}"
+                    else:
+                        cmd = f"test -f {quoted_path} && echo ok"
                     output = await containers.exec(host, cmd)
                     # grep -c returns "0" if no matches — that means missing
                     if pattern and output.strip() in ("0", ""):
                         missing.append({"item": item.type, "location": loc, "pattern": pattern})
                 else:
                     # file existence check
-                    output = await containers.exec(host, f"test -f {path} && echo exists")
+                    output = await containers.exec(host, f"test -f {quoted_path} && echo exists")
                     if "exists" not in output:
                         missing.append({"item": item.type, "location": loc})
             except Exception as exc:  # noqa: BLE001

--- a/src/open_range/validator/isolation.py
+++ b/src/open_range/validator/isolation.py
@@ -2,7 +2,11 @@
 
 from __future__ import annotations
 
+import re
+
 from open_range.protocols import CheckResult, ContainerSet, SnapshotSpec
+
+_SAFE_HOSTNAME_RE = re.compile(r"^[A-Za-z0-9._-]+$")
 
 # Common service ports to probe for zone isolation violations.
 _PROBE_PORTS = (22, 80, 443, 3306, 445, 389, 636, 8080)
@@ -30,6 +34,9 @@ class IsolationCheck:
                 continue
             for target in hosts:
                 target_name = target if isinstance(target, str) else target.get("name", "")
+                if not target_name or not _SAFE_HOSTNAME_RE.match(target_name):
+                    issues.append(f"invalid hostname in topology: {target_name!r}")
+                    continue
                 open_ports: list[int] = []
                 for port in _PROBE_PORTS:
                     try:

--- a/src/open_range/validator/reward_grounding.py
+++ b/src/open_range/validator/reward_grounding.py
@@ -2,14 +2,19 @@
 
 from __future__ import annotations
 
+import re
+import shlex
+
 from open_range.protocols import CheckResult, ContainerSet, SnapshotSpec
+
+_SAFE_IDENTIFIER_RE = re.compile(r"^[A-Za-z0-9_]+$")
 
 
 def _parse_db_path(path: str) -> tuple[str, str, str] | None:
     """Parse a DB flag path like ``db:database.table.column``.
 
     Returns ``(database, table, column)`` or *None* if the path is not a
-    valid DB reference.
+    valid DB reference or contains unsafe identifier characters.
     """
     prefix = path.split(":", 1)
     if len(prefix) != 2:
@@ -20,6 +25,9 @@ def _parse_db_path(path: str) -> tuple[str, str, str] | None:
     parts = rest.split(".")
     if len(parts) != 3:
         return None
+    for part in parts:
+        if not _SAFE_IDENTIFIER_RE.match(part):
+            return None
     return parts[0], parts[1], parts[2]
 
 
@@ -54,7 +62,7 @@ class RewardGroundingCheck:
                 database, table, column = db_ref
                 mysql_cmd = (
                     f'mysql -u root -p$MYSQL_ROOT_PASSWORD -N '
-                    f'-e "SELECT {column} FROM {database}.{table} LIMIT 1"'
+                    f'-e "SELECT `{column}` FROM `{database}`.`{table}` LIMIT 1"'
                 )
                 try:
                     output = await containers.exec(host, mysql_cmd)
@@ -81,7 +89,7 @@ class RewardGroundingCheck:
                 continue
 
             try:
-                output = await containers.exec(host, f"cat {path}")
+                output = await containers.exec(host, f"cat {shlex.quote(path)}")
                 output = output.strip()
             except Exception as exc:  # noqa: BLE001
                 bad.append({"flag": flag.id, "error": str(exc)})


### PR DESCRIPTION
## Summary
- **evidence.py**: use `shlex.quote()` for grep patterns and file paths passed to `containers.exec()`
- **reward_grounding.py**: validate DB identifiers against `[A-Za-z0-9_]+`, backtick-quote MySQL identifiers, and `shlex.quote()` file paths in `cat` commands
- **isolation.py**: validate hostnames against `[A-Za-z0-9._-]+` before interpolating into `/dev/tcp` probe commands

Closes #58