### PR TITLE
Fix manifest-axis runner gaps and harden runtime/validator issue set

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -33,6 +33,7 @@ server = "open_range.server.app:main"
 [tool.setuptools]
 include-package-data = true
 packages = [
+    "manifests",
     "open_range",
     "open_range.agents",
     "open_range.builder",

--- a/src/manifests/schema.py
+++ b/src/manifests/schema.py
@@ -1,0 +1,397 @@
+"""Pydantic models for OpenRange manifest validation.
+
+A manifest declares the *world* of a cyber range: the fictional company, its
+people, data, business processes, network topology, and the vulnerability
+families the Builder may plant.  This rich context lets the Builder LLM
+generate scenarios where vulns, NPCs, and data flows make narrative sense --
+not just "a web server with SQLi" but "a patient-referral portal where the
+search endpoint trusts user input because the original dev left six months ago
+and nobody reviewed it since."
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+from typing import Any, Literal
+
+import yaml
+from pydantic import BaseModel, Field, model_validator
+
+
+# ---------------------------------------------------------------------------
+# Company context -- gives the Builder a story to build from
+# ---------------------------------------------------------------------------
+
+class Company(BaseModel):
+    """The fictional company that owns this range."""
+
+    name: str = Field(..., description="Company name, e.g. 'Meridian Health Partners'")
+    domain: str = Field(..., description="Internal FQDN domain, e.g. 'meridianhealth.local'")
+    industry: str = Field(..., description="Industry vertical, e.g. 'healthcare'")
+    description: str = Field(
+        ..., description="What the company does -- 2-3 sentences the Builder uses for narrative"
+    )
+
+
+class Department(BaseModel):
+    """An organizational unit with its own access profile."""
+
+    name: str
+    description: str = ""
+    hosts_accessed: list[str] = Field(
+        default_factory=list,
+        description="Hostnames staff in this dept routinely access",
+    )
+
+
+# ---------------------------------------------------------------------------
+# People: users and NPC personas
+# ---------------------------------------------------------------------------
+
+class User(BaseModel):
+    """A user account that exists in the range (LDAP/local)."""
+
+    username: str
+    full_name: str = ""
+    department: str = ""
+    role: str = ""
+    email: str = ""
+    hosts: list[str] = Field(
+        default_factory=list,
+        description="Hosts where this user has an account",
+    )
+
+
+class NPCProfile(BaseModel, extra="allow"):
+    """An NPC persona the Builder should generate traffic and behavior for."""
+
+    username: str = Field(..., description="Must reference a User.username")
+    security_awareness: float = Field(
+        default=0.5, ge=0.0, le=1.0,
+        description="0=clueless, 1=CISO-level. Determines susceptibility to social engineering",
+    )
+    daily_activities: list[str] = Field(
+        default_factory=list,
+        description="What this person does all day -- generates realistic traffic patterns",
+    )
+    susceptibility: dict[str, float] = Field(
+        default_factory=dict,
+        description="Attack-type -> probability of falling for it, e.g. {'phishing_email': 0.7}",
+    )
+
+
+# ---------------------------------------------------------------------------
+# Data and business processes -- tells the Builder what to protect
+# ---------------------------------------------------------------------------
+
+class DataAsset(BaseModel):
+    """A piece of sensitive data that exists somewhere in the range."""
+
+    name: str = Field(..., description="Human name, e.g. 'Patient referral records'")
+    classification: Literal["public", "internal", "confidential", "restricted"] = "internal"
+    host: str = Field(..., description="Host where this data lives")
+    location: str = Field(
+        default="", description="Path or service, e.g. '/srv/shares/hr' or 'mysql:app_db.patients'"
+    )
+    description: str = ""
+
+
+class BusinessProcess(BaseModel):
+    """A cross-service data flow the Builder should keep realistic."""
+
+    name: str
+    description: str = ""
+    data_flow: list[str] = Field(
+        default_factory=list,
+        description="Ordered list of host:service hops, e.g. ['web:nginx', 'db:mysql', 'siem:rsyslog']",
+    )
+
+
+# ---------------------------------------------------------------------------
+# Infrastructure realism -- software, config, and operational context
+# ---------------------------------------------------------------------------
+
+class TechStack(BaseModel, extra="allow"):
+    """Specific software versions and known technical debt.
+
+    Accepts both flat string fields and nested dicts for flexibility.
+    """
+
+    known_debt: list[str] = Field(default_factory=list)
+
+
+class CredentialPolicy(BaseModel, extra="allow"):
+    """How credentials work (and fail) in this organization.
+
+    Accepts flexible formats: flat strings or structured dicts.
+    """
+
+    enforcement_gaps: list[Any] = Field(default_factory=list)
+
+
+class MonitoringCoverage(BaseModel, extra="allow"):
+    """What Blue can actually see — and the blind spots Red can exploit."""
+
+    logged: list[Any] = Field(default_factory=list)
+    blind_spots: list[str] = Field(default_factory=list)
+    alert_rules: list[Any] = Field(default_factory=list)
+    retention_days: int = Field(default=90)
+
+
+class TrustRelationship(BaseModel, extra="allow"):
+    """Who trusts whom — the social graph Red can exploit for lateral movement.
+
+    Accepts 'from'/'to' (YAML-friendly) or 'source'/'target' field names.
+    """
+
+    type: str = Field(
+        ..., description="Relationship type: reports_to, delegates_access, shares_credentials, trusts_email"
+    )
+
+    # Accept either naming convention
+    source: str = ""
+    target: str = ""
+
+    # 'from' and 'to' are Python keywords, handle via model_validator
+    @model_validator(mode="before")
+    @classmethod
+    def _normalize_field_names(cls, data: Any) -> Any:
+        if isinstance(data, dict):
+            # Normalize various naming conventions to source/target
+            for src_key in ("from", "from_user"):
+                if src_key in data and not data.get("source"):
+                    data["source"] = data.pop(src_key)
+            for tgt_key in ("to", "to_user"):
+                if tgt_key in data and not data.get("target"):
+                    data["target"] = data.pop(tgt_key)
+            # Accept 'description', 'detail', or 'context' as the explanation field
+            for alt in ("description", "detail"):
+                if alt in data and "context" not in data:
+                    data["context"] = data.pop(alt)
+        return data
+
+    context: str = Field(
+        default="", description="Why this trust exists"
+    )
+
+
+class OperationalContext(BaseModel, extra="allow"):
+    """How this company actually operates day-to-day.
+
+    Accepts flexible formats for all fields.
+    """
+
+    recent_incidents: list[Any] = Field(default_factory=list)
+    audit_findings: list[Any] = Field(default_factory=list)
+    maintenance_windows: list[Any] | Any = Field(default_factory=list)
+    vendor_access: list[Any] = Field(default_factory=list)
+    recent_changes: list[Any] = Field(default_factory=list)
+
+    @model_validator(mode="before")
+    @classmethod
+    def _normalize_fields(cls, data: Any) -> Any:
+        if isinstance(data, dict):
+            # Accept 'compliance' as alias for 'compliance_frameworks'
+            if "compliance" in data and "compliance_frameworks" not in data:
+                data["compliance_frameworks"] = data.pop("compliance")
+            # Normalize maintenance_windows dict to list
+            mw = data.get("maintenance_windows")
+            if isinstance(mw, dict):
+                data["maintenance_windows"] = [f"{k}: {v}" for k, v in mw.items()]
+            elif isinstance(mw, str):
+                data["maintenance_windows"] = [mw]
+            # Normalize list-of-dicts to list-of-strings where needed
+            for field in ("recent_incidents", "vendor_access", "recent_changes"):
+                items = data.get(field, [])
+                if items and isinstance(items[0], dict):
+                    data[field] = [
+                        item.get("description", "") or " | ".join(f"{k}: {v}" for k, v in item.items())
+                        for item in items
+                    ]
+        return data
+
+    compliance_frameworks: list[str] = Field(default_factory=list)
+
+
+# ---------------------------------------------------------------------------
+# Topology primitives
+# ---------------------------------------------------------------------------
+
+class ExposurePolicy(BaseModel):
+    """Per-host exposure configuration."""
+
+    level: Literal["public", "hidden", "authenticated", "misconfigured"] = "public"
+    auth_required: bool = False
+    notes: str = ""
+
+
+class Host(BaseModel):
+    """A single host (container) in the range topology."""
+
+    name: str = Field(..., description="Unique hostname, e.g. 'web', 'db'")
+    zone: str = Field(..., description="Network zone this host belongs to")
+    purpose: str = Field(
+        default="",
+        description="Why this host exists in the company, e.g. 'Customer-facing referral portal'",
+    )
+    hostname: str = Field(
+        default="",
+        description="FQDN in the company domain, e.g. 'portal.meridianhealth.local'",
+    )
+    services: list[str] = Field(
+        default_factory=list,
+        description="Services running on this host, e.g. ['nginx', 'php', 'sshd']",
+    )
+    connects_to: list[str] = Field(
+        default_factory=list,
+        description="Hostnames this host initiates connections to",
+    )
+    os: str = Field(
+        default="ubuntu:22.04",
+        description="Base OS image for the container",
+    )
+    exposure: ExposurePolicy = Field(default_factory=ExposurePolicy)
+
+
+class Network(BaseModel):
+    """A named network zone with an optional CIDR."""
+
+    name: str = Field(..., description="Zone name, e.g. 'dmz', 'internal'")
+    cidr: str | None = Field(
+        default=None,
+        description="Subnet CIDR, e.g. '10.0.1.0/24'",
+    )
+
+
+class FirewallRule(BaseModel):
+    """A directional firewall rule between two zones."""
+
+    action: Literal["allow", "deny"] = Field(
+        ..., description="Whether traffic is allowed or denied"
+    )
+    from_zone: str = Field(..., description="Source zone")
+    to_zone: str = Field(..., description="Destination zone")
+    ports: list[int] = Field(
+        default_factory=list,
+        description="TCP ports this rule applies to (empty = all ports)",
+    )
+
+
+class Topology(BaseModel):
+    """Full network topology: hosts, networks, and firewall rules."""
+
+    hosts: list[Host] = Field(..., min_length=1)
+    networks: list[Network] = Field(..., min_length=1)
+    firewall_rules: list[FirewallRule] = Field(default_factory=list)
+
+    @model_validator(mode="after")
+    def _hosts_reference_valid_zones(self) -> "Topology":
+        zone_names = {n.name for n in self.networks}
+        for host in self.hosts:
+            if host.zone not in zone_names:
+                raise ValueError(
+                    f"Host '{host.name}' references zone '{host.zone}' "
+                    f"which is not defined in networks: {sorted(zone_names)}"
+                )
+        return self
+
+    @model_validator(mode="after")
+    def _firewall_rules_reference_valid_zones(self) -> "Topology":
+        zone_names = {n.name for n in self.networks}
+        for rule in self.firewall_rules:
+            for attr in ("from_zone", "to_zone"):
+                zone = getattr(rule, attr)
+                if zone not in zone_names:
+                    raise ValueError(
+                        f"Firewall rule references zone '{zone}' "
+                        f"which is not defined in networks: {sorted(zone_names)}"
+                    )
+        return self
+
+
+# ---------------------------------------------------------------------------
+# Difficulty envelope
+# ---------------------------------------------------------------------------
+
+class Difficulty(BaseModel):
+    """Difficulty constraints the Validator enforces on generated ranges."""
+
+    max_steps: int = Field(
+        ..., gt=0, description="Maximum golden-path steps allowed"
+    )
+    min_vulns: int = Field(
+        default=1, ge=1, description="Minimum planted vulnerabilities"
+    )
+    max_vulns: int = Field(
+        default=3, ge=1, description="Maximum planted vulnerabilities"
+    )
+
+    @model_validator(mode="after")
+    def _min_le_max(self) -> "Difficulty":
+        if self.min_vulns > self.max_vulns:
+            raise ValueError(
+                f"min_vulns ({self.min_vulns}) must be <= max_vulns ({self.max_vulns})"
+            )
+        return self
+
+
+# ---------------------------------------------------------------------------
+# Top-level manifest
+# ---------------------------------------------------------------------------
+
+class Manifest(BaseModel):
+    """Top-level range manifest -- the contract between humans and the Builder.
+
+    Required fields define the network and vuln envelope.  Optional fields
+    (company, users, NPCs, data, processes) provide narrative context that
+    lets the Builder generate realistic, interconnected scenarios.
+    """
+
+    name: str = Field(..., description="Human-readable range name")
+    tier: int = Field(..., ge=1, le=5, description="Complexity tier (1-5)")
+
+    # Company context (optional but strongly encouraged)
+    company: Company | None = None
+    departments: list[Department] = Field(default_factory=list)
+    users: list[User] = Field(default_factory=list)
+    npc_personas: list[NPCProfile] = Field(default_factory=list)
+    data_inventory: list[DataAsset] = Field(default_factory=list)
+    business_processes: list[BusinessProcess] = Field(default_factory=list)
+
+    # Infrastructure realism (optional — enriches Builder context)
+    tech_stack: TechStack | Any | None = None
+    credential_policy: CredentialPolicy | Any | None = None
+    monitoring_coverage: MonitoringCoverage | Any | None = None
+    trust_relationships: list[TrustRelationship] = Field(default_factory=list)
+    operational_context: OperationalContext | Any | None = None
+
+    # Core topology and vuln envelope
+    topology: Topology
+    bug_families: list[str] = Field(
+        ...,
+        min_length=1,
+        description="Vulnerability classes the Builder may plant (LLM generates details from these type names)",
+    )
+    task_families: list[str] = Field(
+        default=["exploit", "investigate", "patch", "report"],
+        description="Task types agents may be asked to perform",
+    )
+    difficulty: Difficulty
+
+
+# ---------------------------------------------------------------------------
+# Loader
+# ---------------------------------------------------------------------------
+
+def load_manifest(path: str | Path) -> Manifest:
+    """Load a YAML manifest file and return a validated ``Manifest``.
+
+    Raises ``FileNotFoundError`` if the file does not exist.
+    Raises ``pydantic.ValidationError`` if the content is invalid.
+    """
+    path = Path(path)
+    if not path.exists():
+        raise FileNotFoundError(f"Manifest not found: {path}")
+    with open(path) as fh:
+        raw = yaml.safe_load(fh)
+    return Manifest(**raw)

--- a/src/open_range/builder/builder.py
+++ b/src/open_range/builder/builder.py
@@ -40,6 +40,7 @@ from open_range.protocols import (
 )
 
 from open_range.builder.prompts import BUILDER_SYSTEM_PROMPT
+from open_range.builder.manifest_graph import compile_manifest_topology
 
 logger = logging.getLogger(__name__)
 
@@ -928,14 +929,26 @@ class TemplateOnlyBuilder:
         manifest: dict,
         context: BuildContext,
     ) -> SnapshotSpec:
-        """Build a snapshot deterministically from the vuln pool."""
+        """Build a canonicalized snapshot deterministically from templates."""
         rng = random.Random(context.seed if context.seed is not None else 42)
 
         # Filter pool to allowed bug_families
-        allowed = set(manifest.get("bug_families", []))
-        candidates = [v for v in self.vuln_pool if v["type"] in allowed]
-        if not candidates:
+        allowed = {
+            str(v).strip()
+            for v in manifest.get("bug_families", [])
+            if str(v).strip()
+        }
+        if allowed:
+            candidates = [v for v in self.vuln_pool if v["type"] in allowed]
+        else:
             candidates = list(self.vuln_pool)
+        if allowed and not candidates:
+            available = sorted({str(v.get("type", "")).strip() for v in self.vuln_pool if v.get("type")})
+            requested = sorted(allowed)
+            raise ValueError(
+                "No template vulnerabilities match manifest bug_families. "
+                f"requested={requested}, available={available}"
+            )
 
         if "prefer_live_admission_compatible_vulns" in context.narrative_hints:
             live_supported = {"sqli", "idor", "path_traversal", "weak_creds"}
@@ -1092,6 +1105,7 @@ class TemplateOnlyBuilder:
             npc_traffic=npc_traffic,
             task=task,
         )
+        snapshot.topology = compile_manifest_topology(manifest, snapshot.topology)
         snapshot.files = render_template_payloads(snapshot, manifest=manifest)
         logger.info(
             "TemplateOnlyBuilder: built snapshot with %d vulns (seed=%s)",
@@ -1197,10 +1211,15 @@ def render_template_payloads(
             _flag_value_for_type(snapshot, "sqli")
         )
 
-    if vuln_types.intersection({"path_traversal", "credential_reuse"}):
+    if "path_traversal" in vuln_types:
         files["web:/var/www/portal/download.php"] = _download_php(
             path_flag=_flag_value_for_type(snapshot, "path_traversal"),
             flag_names=_flag_names_for_type(snapshot, "path_traversal"),
+        )
+    elif "credential_reuse" in vuln_types:
+        files["web:/var/www/portal/download.php"] = _download_php(
+            path_flag="",
+            flag_names=[],
         )
 
     if "idor" in vuln_types:
@@ -1357,7 +1376,7 @@ if (stripos($q, "union") !== false || stripos($q, "flag") !== false) {{
 
 def _download_php(path_flag: str, flag_names: list[str] | None = None) -> str:
     flag = path_flag or "FLAG{placeholder}"
-    raw_names = flag_names or ["flag1.txt"]
+    raw_names = ["flag1.txt"] if flag_names is None else flag_names
     cases = "\n".join(
         f"""elseif (strpos($file, "{name}") !== false) {{
     echo "{flag}";

--- a/src/open_range/builder/service_manifest.py
+++ b/src/open_range/builder/service_manifest.py
@@ -235,14 +235,14 @@ def generate_service_specs(
         services dict (or the topology hosts list as fallback).
     """
     specs: list[ServiceSpec] = []
-    seen_daemons: set[str] = set()
+    seen_identities: set[tuple[str, str]] = set()
 
     services = compose.get("services", {}) if compose else {}
 
     if services:
-        specs = _from_compose(services, seen_daemons)
+        specs = _from_compose(services, seen_identities)
     else:
-        specs = _from_topology(topology, seen_daemons)
+        specs = _from_topology(topology, seen_identities)
 
     return specs
 
@@ -322,7 +322,7 @@ def _build_service_spec(
 
 def _from_compose(
     services: dict[str, Any],
-    seen_daemons: set[str],
+    seen_identities: set[tuple[str, str]],
 ) -> list[ServiceSpec]:
     """Generate specs from the compose services section."""
     specs: list[ServiceSpec] = []
@@ -348,9 +348,10 @@ def _from_compose(
             continue
 
         daemon = hint[0]
-        if daemon in seen_daemons:
+        identity = (svc_name, daemon)
+        if identity in seen_identities:
             continue
-        seen_daemons.add(daemon)
+        seen_identities.add(identity)
 
         env_vars = _env_from_compose_service(svc_def)
         spec = _build_service_spec(
@@ -365,7 +366,7 @@ def _from_compose(
 
 def _from_topology(
     topology: dict[str, Any],
-    seen_daemons: set[str],
+    seen_identities: set[tuple[str, str]],
 ) -> list[ServiceSpec]:
     """Generate specs from the topology hosts list (fallback path)."""
     specs: list[ServiceSpec] = []
@@ -385,9 +386,10 @@ def _from_topology(
             continue
 
         daemon = hint[0]
-        if daemon in seen_daemons:
+        identity = (host_name, daemon)
+        if identity in seen_identities:
             continue
-        seen_daemons.add(daemon)
+        seen_identities.add(identity)
 
         spec = _build_service_spec(host=host_name, hint=hint)
         specs.append(spec)

--- a/src/open_range/server/environment.py
+++ b/src/open_range/server/environment.py
@@ -1111,22 +1111,35 @@ class RangeEnvironment(Environment[RangeAction, RangeObservation, RangeState]):
         """Determine which container to route the command to.
 
         Reads from the snapshot topology to find the appropriate host:
-        - Red: host with role=attacker or zone=external.
-        - Blue: host with role=siem or zone=management.
+        - Red: host with role=attacker or zone=external
+        - Blue: host with role=siem or zone=management
 
-        The snapshot topology must define hosts with roles or zones.
-        For string-only host lists, matches by name then falls back to
-        positional convention (first host for Red, last for Blue).
+        Resolution priority:
+        1. host_catalog metadata (compiled from manifest)
+        2. dict entries in topology["hosts"] with role/zone
+        3. literal host-name match ("attacker"/"siem")
+        4. zone membership fallback via topology["zones"]
+        5. positional fallback (first host for Red, last for Blue)
         """
         if not self._snapshot or not isinstance(self._snapshot.topology, dict):
             raise RuntimeError("Cannot resolve target — no snapshot topology loaded")
 
-        hosts = self._snapshot.topology.get("hosts", [])
+        topology = self._snapshot.topology
+        hosts = topology.get("hosts", [])
         if not hosts:
             raise RuntimeError("Cannot resolve target — snapshot topology has no hosts")
 
         target_role = "attacker" if action.mode == "red" else "siem"
         target_zone = "external" if action.mode == "red" else "management"
+
+        host_catalog = topology.get("host_catalog", {})
+        if isinstance(host_catalog, dict):
+            for host_name, meta in host_catalog.items():
+                if not isinstance(meta, dict):
+                    continue
+                if meta.get("role") == target_role or meta.get("zone") == target_zone:
+                    if host_name:
+                        return self._container_name(str(host_name))
 
         # Look for a host with matching role or zone
         for h in hosts:
@@ -1141,6 +1154,15 @@ class RangeEnvironment(Environment[RangeAction, RangeObservation, RangeState]):
             name = h if isinstance(h, str) else h.get("name", "")
             if name == target_role:
                 return self._container_name(name)
+
+        zones = topology.get("zones", {})
+        if isinstance(zones, dict):
+            candidates = zones.get(target_zone, [])
+            if isinstance(candidates, list):
+                for candidate in candidates:
+                    host_name = str(candidate).strip()
+                    if host_name:
+                        return self._container_name(host_name)
 
         # Use positional convention: first host for Red, last for Blue
         fallback = hosts[0] if action.mode == "red" else hosts[-1]

--- a/src/open_range/training/runner.py
+++ b/src/open_range/training/runner.py
@@ -13,6 +13,7 @@ Usage::
 
 from __future__ import annotations
 
+import asyncio
 import argparse
 import json
 import logging
@@ -21,6 +22,8 @@ import time
 from dataclasses import dataclass, field
 from pathlib import Path
 from typing import Any, Protocol, runtime_checkable
+
+import yaml
 
 logger = logging.getLogger(__name__)
 
@@ -159,6 +162,8 @@ class CurriculumRunner:
         self.blue = blue
         self.config = config
         self._results: list[EpisodeRecord] = []
+        self._manifest_cache: dict[str, dict[str, Any]] = {}
+        self._snapshot_builder: Any = None
 
     @property
     def results(self) -> list[EpisodeRecord]:
@@ -204,8 +209,13 @@ class CurriculumRunner:
 
         start = time.time()
 
+        reset_kwargs: dict[str, Any] = {"seed": seed, "manifest_path": manifest_path}
+        snapshot = self._build_snapshot_for_manifest(manifest_path, seed)
+        if snapshot is not None:
+            reset_kwargs["snapshot"] = snapshot
+
         try:
-            obs = self.env.reset(seed=seed)
+            obs = self.env.reset(**reset_kwargs)
         except Exception as exc:
             logger.error("Reset failed: %s", exc)
             return EpisodeRecord(
@@ -213,7 +223,7 @@ class CurriculumRunner:
                 seed=seed,
                 episode=episode_num,
                 outcome="error",
-                metadata={"error": str(exc)},
+                metadata={"error": str(exc), "reset_kwargs": sorted(reset_kwargs.keys())},
             )
 
         briefing = getattr(obs, "stdout", str(obs))
@@ -276,6 +286,50 @@ class CurriculumRunner:
             reward=total_reward,
             duration_s=duration,
         )
+
+    def _build_snapshot_for_manifest(self, manifest_path: str, seed: int) -> Any | None:
+        """Build a deterministic snapshot from the manifest for this episode.
+
+        This grounds the manifest axis in real environment input rather than
+        using manifest names only for reporting metadata.
+        """
+        from open_range.builder.builder import TemplateOnlyBuilder
+        from open_range.protocols import BuildContext
+
+        manifest = self._manifest_cache.get(manifest_path)
+        if manifest is None:
+            manifest_file = Path(manifest_path)
+            if not manifest_file.exists():
+                logger.debug(
+                    "Manifest path %s not found; skipping snapshot build and relying on env.reset kwargs only",
+                    manifest_path,
+                )
+                return None
+            with open(manifest_file) as f:
+                manifest = yaml.safe_load(f)
+            if not isinstance(manifest, dict):
+                raise ValueError(f"Manifest {manifest_path!r} did not parse to a mapping")
+            self._manifest_cache[manifest_path] = manifest
+
+        if self._snapshot_builder is None:
+            self._snapshot_builder = TemplateOnlyBuilder()
+
+        tier = int(manifest.get("tier", 1) or 1)
+        context = BuildContext(seed=seed, tier=tier)
+        return self._run_coro_sync(self._snapshot_builder.build(manifest, context))
+
+    @staticmethod
+    def _run_coro_sync(coro: Any) -> Any:
+        """Run an async coroutine in sync code, including notebook event loops."""
+        try:
+            asyncio.get_running_loop()
+        except RuntimeError:
+            return asyncio.run(coro)
+
+        from concurrent.futures import ThreadPoolExecutor
+
+        with ThreadPoolExecutor(max_workers=1) as pool:
+            return pool.submit(lambda: asyncio.run(coro)).result()
 
     def save_results(self, path: str | Path) -> int:
         """Save results to a JSONL file.

--- a/src/open_range/validator/reward_grounding.py
+++ b/src/open_range/validator/reward_grounding.py
@@ -2,7 +2,12 @@
 
 from __future__ import annotations
 
+import re
+import shlex
+
 from open_range.protocols import CheckResult, ContainerSet, SnapshotSpec
+
+_IDENTIFIER_RE = re.compile(r"^[A-Za-z_][A-Za-z0-9_]*$")
 
 
 def _parse_db_path(path: str) -> tuple[str, str, str] | None:
@@ -19,6 +24,8 @@ def _parse_db_path(path: str) -> tuple[str, str, str] | None:
         return None
     parts = rest.split(".")
     if len(parts) != 3:
+        return None
+    if not all(_IDENTIFIER_RE.fullmatch(part) for part in parts):
         return None
     return parts[0], parts[1], parts[2]
 
@@ -48,13 +55,19 @@ class RewardGroundingCheck:
                 # Deployment artifacts like "db:sql" are not flag locations.
                 db_ref = _parse_db_path(path)
                 if db_ref is None:
-                    # Unparseable DB path (e.g. "db:sql") — skip silently.
+                    if path in {"db:sql", "mysql:sql"}:
+                        continue
+                    bad.append({
+                        "flag": flag.id,
+                        "error": f"invalid db flag path format: {path}",
+                    })
                     continue
 
                 database, table, column = db_ref
+                query = f"SELECT `{column}` FROM `{database}`.`{table}` LIMIT 1"
                 mysql_cmd = (
-                    f'mysql -u root -p$MYSQL_ROOT_PASSWORD -N '
-                    f'-e "SELECT {column} FROM {database}.{table} LIMIT 1"'
+                    "mysql -u root -p$MYSQL_ROOT_PASSWORD -N "
+                    f"-e {shlex.quote(query)}"
                 )
                 try:
                     output = await containers.exec(host, mysql_cmd)
@@ -81,7 +94,7 @@ class RewardGroundingCheck:
                 continue
 
             try:
-                output = await containers.exec(host, f"cat {path}")
+                output = await containers.exec(host, f"cat -- {shlex.quote(path)}")
                 output = output.strip()
             except Exception as exc:  # noqa: BLE001
                 bad.append({"flag": flag.id, "error": str(exc)})

--- a/src/open_range/validator/reward_grounding.py
+++ b/src/open_range/validator/reward_grounding.py
@@ -30,6 +30,16 @@ def _parse_db_path(path: str) -> tuple[str, str, str] | None:
     return parts[0], parts[1], parts[2]
 
 
+def _mysql_root_password(snapshot: SnapshotSpec) -> str:
+    """Return the MySQL root password to use for validator DB checks."""
+    topology = snapshot.topology
+    if isinstance(topology, dict):
+        value = topology.get("mysql_root_password")
+        if isinstance(value, str) and value:
+            return value
+    return "root"
+
+
 class RewardGroundingCheck:
     """For every declared flag, verify its value exists at the expected
     location.  File-based flags are checked via ``cat``.  DB-stored flags
@@ -65,8 +75,10 @@ class RewardGroundingCheck:
 
                 database, table, column = db_ref
                 query = f"SELECT `{column}` FROM `{database}`.`{table}` LIMIT 1"
+                mysql_pwd = _mysql_root_password(snapshot)
                 mysql_cmd = (
-                    "mysql -u root -p$MYSQL_ROOT_PASSWORD -N "
+                    f"MYSQL_PWD={shlex.quote(mysql_pwd)} "
+                    "mysql -u root -N "
                     f"-e {shlex.quote(query)}"
                 )
                 try:

--- a/tests/test_builder.py
+++ b/tests/test_builder.py
@@ -83,6 +83,33 @@ async def test_template_builder_clamps_min_vulns_to_candidate_pool(tier1_manifes
 
 
 @pytest.mark.asyncio
+async def test_template_builder_fails_when_bug_family_has_no_template_match(tier1_manifest):
+    from open_range.builder.builder import TemplateOnlyBuilder
+
+    builder = TemplateOnlyBuilder()
+    manifest = {
+        **tier1_manifest,
+        "bug_families": ["totally_fake_bug_family"],
+    }
+    with pytest.raises(ValueError, match="No template vulnerabilities match manifest bug_families"):
+        await builder.build(manifest, BuildContext(seed=7, tier=1))
+
+
+@pytest.mark.asyncio
+async def test_template_builder_empty_bug_families_uses_default_pool(tier1_manifest):
+    from open_range.builder.builder import TemplateOnlyBuilder
+
+    builder = TemplateOnlyBuilder()
+    manifest = {
+        **tier1_manifest,
+        "bug_families": [],
+        "difficulty": {**tier1_manifest.get("difficulty", {}), "min_vulns": 1, "max_vulns": 1},
+    }
+    spec = await builder.build(manifest, BuildContext(seed=7, tier=1))
+    assert len(spec.truth_graph.vulns) == 1
+
+
+@pytest.mark.asyncio
 async def test_template_builder_avoids_previous_vulns(tier1_manifest):
     from open_range.builder.builder import TemplateOnlyBuilder
 
@@ -166,6 +193,55 @@ async def test_template_builder_uses_manifest_company_context(tier1_manifest):
     assert company["name"] in spec.task.blue_briefing
     assert ldap_dn in spec.files["web:/var/www/config.php"]
     assert company["name"] in spec.files["web:/var/www/portal/index.php"]
+
+
+@pytest.mark.asyncio
+async def test_template_builder_output_is_manifest_canonicalized(tier1_manifest):
+    from open_range.builder.builder import TemplateOnlyBuilder
+
+    builder = TemplateOnlyBuilder()
+    spec = await builder.build(tier1_manifest, BuildContext(seed=1, tier=1))
+    assert "host_catalog" in spec.topology
+    assert "host_details" in spec.topology
+    assert "dependency_edges" in spec.topology
+    assert "principal_catalog" in spec.topology
+
+
+def test_render_payloads_credential_reuse_not_coupled_to_path_traversal_flag():
+    from open_range.builder.builder import render_template_payloads
+    from open_range.protocols import TruthGraph, Vulnerability
+
+    snapshot = SnapshotSpec(
+        topology={"tier": 1, "hosts": ["web"], "org_name": "OpenRange", "domain": "corp.local"},
+        truth_graph=TruthGraph(
+            vulns=[Vulnerability(id="v1", type="credential_reuse", host="ldap")]
+        ),
+        flags=[FlagSpec(id="f1", value="FLAG{cred_only}", path="/var/flags/flag1.txt", host="db")],
+        golden_path=[],
+    )
+    files = render_template_payloads(snapshot)
+    download = files["web:/var/www/portal/download.php"]
+    assert "config.php" in download
+    assert "FLAG{cred_only}" not in download
+    assert "flag1.txt" not in download
+
+
+def test_render_payloads_path_traversal_keeps_flag_wiring():
+    from open_range.builder.builder import render_template_payloads
+    from open_range.protocols import TruthGraph, Vulnerability
+
+    snapshot = SnapshotSpec(
+        topology={"tier": 1, "hosts": ["web"], "org_name": "OpenRange", "domain": "corp.local"},
+        truth_graph=TruthGraph(
+            vulns=[Vulnerability(id="v1", type="path_traversal", host="web")]
+        ),
+        flags=[FlagSpec(id="f1", value="FLAG{path}", path="/var/flags/path_flag.txt", host="web")],
+        golden_path=[],
+    )
+    files = render_template_payloads(snapshot)
+    download = files["web:/var/www/portal/download.php"]
+    assert "FLAG{path}" in download
+    assert "path_flag.txt" in download
 
 
 @pytest.mark.asyncio

--- a/tests/test_environment.py
+++ b/tests/test_environment.py
@@ -67,6 +67,46 @@ class TestReset:
         assert env.snapshot is not None
 
 
+class TestTargetResolution:
+    """Target selection should honor manifest-compiled metadata."""
+
+    def test_resolve_target_uses_host_catalog_roles(self):
+        env = RangeEnvironment(docker_available=False)
+        env.reset(
+            snapshot=SnapshotSpec(
+                topology={
+                    "hosts": ["web", "kali1", "socbox"],
+                    "host_catalog": {
+                        "web": {"role": "web", "zone": "dmz"},
+                        "kali1": {"role": "attacker", "zone": "external"},
+                        "socbox": {"role": "siem", "zone": "management"},
+                    },
+                },
+                task=TaskSpec(red_briefing="Go.", blue_briefing="Watch."),
+            )
+        )
+        assert env._resolve_target(RangeAction(command="id", mode="red")) == "kali1"
+        assert env._resolve_target(RangeAction(command="id", mode="blue")) == "socbox"
+
+    def test_resolve_target_uses_zone_mapping_for_string_hosts(self):
+        env = RangeEnvironment(docker_available=False)
+        env.reset(
+            snapshot=SnapshotSpec(
+                topology={
+                    "hosts": ["web", "kali1", "socbox"],
+                    "zones": {
+                        "dmz": ["web"],
+                        "external": ["kali1"],
+                        "management": ["socbox"],
+                    },
+                },
+                task=TaskSpec(red_briefing="Go.", blue_briefing="Watch."),
+            )
+        )
+        assert env._resolve_target(RangeAction(command="id", mode="red")) == "kali1"
+        assert env._resolve_target(RangeAction(command="id", mode="blue")) == "socbox"
+
+
 class TestRedStep:
     """Red agent actions."""
 

--- a/tests/test_lint.py
+++ b/tests/test_lint.py
@@ -2,7 +2,12 @@
 
 from __future__ import annotations
 
+import os
 from pathlib import Path
+import shutil
+import subprocess
+import sys
+import tomllib
 
 import pytest
 import yaml
@@ -283,3 +288,37 @@ class TestLintFile:
         result = lint_file(good_file)
         assert result["valid"] is True
         assert result["schema_error"] is None
+
+
+class TestPackagingAndInvocation:
+    def test_pyproject_includes_manifests_package(self):
+        pyproject = tomllib.loads((ROOT / "pyproject.toml").read_text())
+        packages = pyproject["tool"]["setuptools"]["packages"]
+        assert "manifests" in packages
+
+    def test_lint_module_runs_outside_repo_with_packaged_layout(self, tmp_path):
+        site_root = tmp_path / "site"
+        shutil.copytree(ROOT / "src" / "open_range", site_root / "open_range")
+        shutil.copytree(ROOT / "src" / "manifests", site_root / "manifests")
+
+        outside = tmp_path / "outside"
+        outside.mkdir()
+
+        env = os.environ.copy()
+        env["PYTHONPATH"] = str(site_root)
+        proc = subprocess.run(
+            [
+                sys.executable,
+                "-m",
+                "open_range.lint",
+                str(ROOT / "manifests" / "tier1_basic.yaml"),
+            ],
+            cwd=outside,
+            env=env,
+            capture_output=True,
+            text=True,
+            check=False,
+        )
+
+        assert proc.returncode == 0, proc.stderr or proc.stdout
+        assert "All checks passed." in proc.stdout

--- a/tests/test_runner.py
+++ b/tests/test_runner.py
@@ -46,10 +46,12 @@ class MockEnvironment:
         self._flags = flags or []
         self._step_count = 0
         self._state = _MockState()
+        self.reset_calls: list[dict[str, Any]] = []
 
     def reset(self, seed: int | None = None, **kwargs: Any) -> _MockObs:
         self._step_count = 0
         self._state = _MockState()
+        self.reset_calls.append({"seed": seed, **kwargs})
         return _MockObs(stdout=f"Range ready. Seed={seed}")
 
     def step(self, action: Any) -> _MockObs:
@@ -212,6 +214,30 @@ class TestCurriculumRunner:
         results = runner.run()
         assert len(results) == 3
         assert all(r.episode in (1, 2, 3) for r in results)
+
+    def test_manifest_axis_is_passed_to_reset_with_snapshot(self):
+        root = Path(__file__).resolve().parent.parent
+        manifests = [
+            str(root / "manifests" / "tier1_basic.yaml"),
+            str(root / "manifests" / "tier2_corporate.yaml"),
+        ]
+        env = MockEnvironment(max_env_steps=1)
+        red = MockAgent()
+        blue = MockAgent()
+        config = RunConfig(
+            manifests=manifests,
+            seeds=[7],
+            episodes_per_seed=1,
+            max_steps=1,
+        )
+        runner = CurriculumRunner(env, red, blue, config)
+        runner.run()
+
+        assert len(env.reset_calls) == 2
+        assert env.reset_calls[0]["manifest_path"].endswith("tier1_basic.yaml")
+        assert env.reset_calls[1]["manifest_path"].endswith("tier2_corporate.yaml")
+        assert env.reset_calls[0]["snapshot"].topology["tier"] == 1
+        assert env.reset_calls[1]["snapshot"].topology["tier"] == 2
 
 
 # ---------------------------------------------------------------------------

--- a/tests/test_service_spec.py
+++ b/tests/test_service_spec.py
@@ -281,8 +281,8 @@ class TestGenerateFromCompose:
         assert specs[0].env_vars["MYSQL_ROOT_PASSWORD"] == "secret"
         assert specs[0].env_vars["MYSQL_DATABASE"] == "app"
 
-    def test_no_duplicate_daemons(self):
-        """If two compose services map to the same daemon, only one spec is produced."""
+    def test_repeated_daemons_on_different_hosts_are_preserved(self):
+        """Two hosts may intentionally run the same daemon family."""
         compose = {
             "services": {
                 "siem": {"image": "rsyslog:latest"},
@@ -290,8 +290,21 @@ class TestGenerateFromCompose:
             }
         }
         specs = generate_service_specs(compose, {"hosts": []})
-        assert len(specs) == 1
-        assert specs[0].daemon == "rsyslogd"
+        assert len(specs) == 2
+        assert {spec.host for spec in specs} == {"siem", "firewall"}
+        assert all(spec.daemon == "rsyslogd" for spec in specs)
+
+    def test_same_daemon_across_multiple_web_hosts(self):
+        compose = {
+            "services": {
+                "web1": {"image": "nginx:1.25"},
+                "web2": {"image": "nginx:1.25"},
+            }
+        }
+        specs = generate_service_specs(compose, {"hosts": ["web1", "web2"]})
+        assert len(specs) == 2
+        assert {spec.host for spec in specs} == {"web1", "web2"}
+        assert all(spec.daemon == "nginx" for spec in specs)
 
 
 # ---------------------------------------------------------------------------

--- a/tests/test_validator.py
+++ b/tests/test_validator.py
@@ -668,6 +668,59 @@ async def test_reward_grounding_skips_db_sql_path(mock_containers):
     assert result.passed is True
 
 
+@pytest.mark.asyncio
+async def test_reward_grounding_quotes_filesystem_path():
+    """Filesystem flag paths with shell metacharacters must be quoted."""
+    from open_range.validator.reward_grounding import RewardGroundingCheck
+
+    class RecordingContainers:
+        def __init__(self):
+            self.calls: list[tuple[str, str]] = []
+
+        async def exec(self, container: str, cmd: str, **kwargs) -> str:
+            self.calls.append((container, cmd))
+            return "FLAG{abc}"
+
+    containers = RecordingContainers()
+    spec = SnapshotSpec(
+        flags=[FlagSpec(id="f1", value="FLAG{abc}", path="/tmp/f; echo PWNED", host="web")]
+    )
+    result = await RewardGroundingCheck().check(spec, containers)  # type: ignore[arg-type]
+    assert result.passed is True
+    assert containers.calls
+    assert containers.calls[0][1] == "cat -- '/tmp/f; echo PWNED'"
+
+
+@pytest.mark.asyncio
+async def test_reward_grounding_rejects_invalid_db_identifier_path():
+    """Malformed DB paths must fail rather than altering SQL semantics."""
+    from open_range.validator.reward_grounding import RewardGroundingCheck
+
+    class RecordingContainers:
+        def __init__(self):
+            self.calls: list[tuple[str, str]] = []
+
+        async def exec(self, container: str, cmd: str, **kwargs) -> str:
+            self.calls.append((container, cmd))
+            return "FLAG{abc}"
+
+    containers = RecordingContainers()
+    spec = SnapshotSpec(
+        flags=[
+            FlagSpec(
+                id="f1",
+                value="FLAG{abc}",
+                path="db:flags.secrets.flag FROM secrets; SELECT 'x' --",
+                host="db",
+            )
+        ]
+    )
+    result = await RewardGroundingCheck().check(spec, containers)  # type: ignore[arg-type]
+    assert result.passed is False
+    assert "invalid db flag path format" in result.details["results"][0]["error"]
+    assert containers.calls == []
+
+
 # ---------------------------------------------------------------------------
 # Check 6: Isolation
 # ---------------------------------------------------------------------------

--- a/tests/test_validator.py
+++ b/tests/test_validator.py
@@ -721,6 +721,37 @@ async def test_reward_grounding_rejects_invalid_db_identifier_path():
     assert containers.calls == []
 
 
+@pytest.mark.asyncio
+async def test_reward_grounding_quotes_mysql_password_from_snapshot():
+    """DB checks must not rely on unquoted shell expansion for credentials."""
+    import shlex
+
+    from open_range.validator.reward_grounding import RewardGroundingCheck
+
+    class RecordingContainers:
+        def __init__(self):
+            self.calls: list[tuple[str, str]] = []
+
+        async def exec(self, container: str, cmd: str, **kwargs) -> str:
+            self.calls.append((container, cmd))
+            return "FLAG{abc}"
+
+    containers = RecordingContainers()
+    password = "pa ss;$(id)"
+    spec = SnapshotSpec(
+        topology={"mysql_root_password": password},
+        flags=[FlagSpec(id="f1", value="FLAG{abc}", path="db:flags.secrets.flag", host="db")],
+    )
+    result = await RewardGroundingCheck().check(spec, containers)  # type: ignore[arg-type]
+    assert result.passed is True
+    assert containers.calls
+    cmd = containers.calls[0][1]
+    assert cmd.startswith(
+        f"MYSQL_PWD={shlex.quote(password)} mysql -u root -N -e "
+    )
+    assert "-p$MYSQL_ROOT_PASSWORD" not in cmd
+
+
 # ---------------------------------------------------------------------------
 # Check 6: Isolation
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
Summary: fixes issue set #43, #63, #62, #58, and #39 with isolated commits and regression tests.\n\nChanges:\n- Package manifests.schema under src and include manifests in packaging so lint works when running outside repo root.\n- Preserve per-host service specs by deduping on host+daemon identity.\n- Extend target resolution to use host_catalog and zones before positional fallback.\n- Harden reward grounding with DB identifier validation, malformed DB path rejection, and shell-safe command quoting.\n- Ground curriculum runner manifest axis by passing manifest_path and manifest-built snapshot into reset() when manifest files exist.\n\nVerification:\n- env PYTHONPATH=src /home/talian/priv/open-range/.venv/bin/pytest -q tests/test_lint.py tests/test_service_spec.py tests/test_environment.py tests/test_validator.py tests/test_runner.py\n- 214 passed\n\nNotes:\n- #42 was investigated but intentionally excluded from this PR due an existing app test-client hang path unrelated to this issue set.