### PR TITLE
Refactor Dockerfiles to proper staged builds on official uv image

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,22 +1,35 @@
+# syntax=docker/dockerfile:1.7
+
 # =============================================================================
 # OpenRange — Production All-in-One Dockerfile
 # =============================================================================
-# Python 3.11 base image with system packages available for procedural
-# service provisioning.  The OpenEnv server (uvicorn) is the only process
-# started at boot — individual services (mysql, nginx, slapd, …) are
-# started/stopped dynamically by RangeEnvironment.reset() based on the
-# active snapshot manifest.  No services are hardcoded.
+# Multi-stage build:
+#   1) deps: resolve third-party Python dependencies with official uv image
+#   2) runtime: install system services/tools, then copy app source as last step
 # =============================================================================
 
-FROM python:3.11-slim-bookworm
+ARG UV_IMAGE=ghcr.io/astral-sh/uv:python3.11-bookworm-slim
+
+FROM ${UV_IMAGE} AS deps
+
+WORKDIR /app/env
+
+# Install git only for potential git+ dependencies during uv sync.
+RUN apt-get update && apt-get install -y --no-install-recommends git \
+    && rm -rf /var/lib/apt/lists/*
+
+COPY pyproject.toml uv.lock ./
+
+RUN --mount=type=cache,target=/root/.cache/uv \
+    uv sync --frozen --no-install-project --no-editable \
+    && uv pip install --python .venv/bin/python sqlmap
+
+FROM ${UV_IMAGE} AS runtime
 
 ENV DEBIAN_FRONTEND=noninteractive
 
-# ── 1. System packages ───────────────────────────────────────────────────────
-# Install base packages that all tiers need.  Higher tiers add extras via
-# the TIER_PACKAGES build arg (tier1, tier2, tier3).
-# The Builder/manifest decides which ones actually run per episode.
-
+# Install base packages that all tiers need. Higher tiers add extras via the
+# TIER_PACKAGES build arg (tier1, tier2, tier3).
 ARG TIER_PACKAGES="tier1"
 
 # --- Tier 1 (base) ---
@@ -42,7 +55,7 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
     netcat-openbsd dnsutils tcpdump curl wget sshpass \
     iputils-ping whois \
     # Utilities
-    jq procps iproute2 git ca-certificates bash \
+    jq procps iproute2 ca-certificates bash \
     && rm -rf /var/lib/apt/lists/*
 
 # --- Tier 2 (+ VPN, cron) ---
@@ -59,38 +72,17 @@ RUN if echo "${TIER_PACKAGES}" | grep -qE "tier[3-9]"; then \
         && rm -rf /var/lib/apt/lists/*; \
     fi
 
-# Python-based security tools (not in Debian repos)
-RUN pip install --no-cache-dir sqlmap
-
-# ── 2. Install uv for dependency management ──────────────────────────────────
-
-RUN pip install --no-cache-dir uv
-
-# ── 3. Create base directories ───────────────────────────────────────────────
-
 RUN mkdir -p /var/log/siem/consolidated /run/sshd \
     /var/run/mysqld /var/log/mysql /var/log/nginx \
     && chown mysql:mysql /var/run/mysqld /var/log/mysql 2>/dev/null || true \
     && chmod 755 /var/log/siem
 
-# ── 4. Copy application code and install Python deps ─────────────────────────
-
-WORKDIR /app
-COPY . /app/env
 WORKDIR /app/env
+COPY --from=deps /app/env/.venv /app/env/.venv
+COPY . /app/env
 
-ENV UV_PROJECT_ENVIRONMENT=/app/.venv
-RUN uv venv --python python3.11 /app/.venv \
-    && if [ -f uv.lock ]; then \
-        uv sync --frozen --no-editable; \
-    else \
-        uv sync --no-editable; \
-    fi
-
-# ── 5. Environment ───────────────────────────────────────────────────────────
-
-ENV PATH="/app/.venv/bin:$PATH"
-ENV PYTHONPATH="/app/env/src:/app/env:$PYTHONPATH"
+ENV PATH="/app/env/.venv/bin:$PATH"
+ENV PYTHONPATH="/app/env/src:/app/env"
 ENV OPENRANGE_EXECUTION_MODE=subprocess
 # Enable the managed runtime so reset() boots real services from the manifest
 ENV OPENRANGE_RUNTIME_MANIFEST=manifests/tier1_basic.yaml
@@ -99,13 +91,10 @@ ENV OPENRANGE_SNAPSHOT_POOL_SIZE=1
 # Enable the OpenEnv Gradio web interface at /web
 ENV ENABLE_WEB_INTERFACE=true
 
-# ── 6. Health check ──────────────────────────────────────────────────────────
-
 HEALTHCHECK --interval=30s --timeout=5s --start-period=60s --retries=3 \
-    CMD python3 -c "import urllib.request; urllib.request.urlopen('http://localhost:8000/health')" || exit 1
+    CMD python -c "import urllib.request; urllib.request.urlopen('http://localhost:8000/health')" || exit 1
 
 EXPOSE 8000
 
-# ── 7. Start only the OpenEnv server — services are snapshot-driven ──────────
-
-CMD ["python3", "-m", "uvicorn", "open_range.server.app:app", "--host", "0.0.0.0", "--port", "8000"]
+# Start only the OpenEnv server; services are snapshot-driven.
+CMD ["python", "-m", "uvicorn", "open_range.server.app:app", "--host", "0.0.0.0", "--port", "8000"]

--- a/server/Dockerfile
+++ b/server/Dockerfile
@@ -1,42 +1,31 @@
-ARG BASE_IMAGE=ghcr.io/meta-pytorch/openenv-base:latest
-FROM ${BASE_IMAGE} AS builder
+# syntax=docker/dockerfile:1.7
 
-WORKDIR /app
+ARG UV_IMAGE=ghcr.io/astral-sh/uv:python3.11-bookworm-slim
 
-COPY . /app/env
+FROM ${UV_IMAGE} AS deps
+
 WORKDIR /app/env
 
-# Install git for git+ dependencies
+# Install git for optional git+ dependencies.
 RUN apt-get update && apt-get install -y --no-install-recommends git \
     && rm -rf /var/lib/apt/lists/*
 
-# Two-pass install for better layer caching
-RUN --mount=type=cache,target=/root/.cache/uv \
-    if [ -f uv.lock ]; then \
-        uv sync --frozen --no-install-project --no-editable; \
-    else \
-        uv sync --no-install-project --no-editable; \
-    fi
+COPY pyproject.toml uv.lock ./
 
 RUN --mount=type=cache,target=/root/.cache/uv \
-    if [ -f uv.lock ]; then \
-        uv sync --frozen --no-editable; \
-    else \
-        uv sync --no-editable; \
-    fi
+    uv sync --frozen --no-install-project --no-editable
 
-# Runtime stage
-FROM ${BASE_IMAGE}
+FROM ${UV_IMAGE} AS runtime
 
-WORKDIR /app
+WORKDIR /app/env
 
-COPY --from=builder /app/env/.venv /app/.venv
-COPY --from=builder /app/env /app/env
+COPY --from=deps /app/env/.venv /app/env/.venv
+COPY . /app/env
 
-ENV PATH="/app/.venv/bin:$PATH"
-ENV PYTHONPATH="/app/env/src:/app/env:$PYTHONPATH"
+ENV PATH="/app/env/.venv/bin:$PATH"
+ENV PYTHONPATH="/app/env/src:/app/env"
 
 HEALTHCHECK --interval=30s --timeout=3s --start-period=5s --retries=3 \
     CMD python -c "import urllib.request; urllib.request.urlopen('http://localhost:8000/health')" || exit 1
 
-CMD ["sh", "-c", "cd /app/env && uvicorn server.app:app --host 0.0.0.0 --port 8000"]
+CMD ["uvicorn", "server.app:app", "--host", "0.0.0.0", "--port", "8000"]


### PR DESCRIPTION
## Summary
- switch both runtime Dockerfiles to the official uv image tag `ghcr.io/astral-sh/uv:python3.11-bookworm-slim`
- use explicit deps + runtime stages
- install Python dependencies in deps from pyproject.toml + uv.lock only
- copy source in runtime as the final layer
- preserve runtime env vars, healthchecks, and entrypoints

## Validation
- docker buildx build --check -f Dockerfile .
- docker buildx build --check -f server/Dockerfile .
- docker buildx build -f server/Dockerfile . --load -t open-range-server:staged-uv
- docker buildx build -f Dockerfile . --load -t open-range-allinone:staged-uv
- docker run --rm open-range-server:staged-uv python -c "import open_range, server.app; print('server-image-ok')"
- docker run --rm open-range-allinone:staged-uv python -c "import open_range.server.app; print('allinone-image-ok')"
