### PR TITLE
validator: make patchability fail on inconclusive remediation/retest

### DIFF
--- a/src/open_range/validator/patchability.py
+++ b/src/open_range/validator/patchability.py
@@ -21,6 +21,7 @@ _CMD_PREFIXES = (
     "patch", "iptables", "mysql", "docker",
 )
 _CMD_OPERATORS_RE = re.compile(r"[|>&]|&&")
+_EXIT_STATUS_SENTINEL = "__OPENRANGE_EXIT_STATUS__="
 
 
 def _looks_executable(remediation: str) -> bool:
@@ -80,6 +81,39 @@ def _longest_common_substring(a: str, b: str) -> int:
     return max_len
 
 
+def _wrap_with_exit_status(command: str) -> str:
+    """Wrap *command* so stdout includes an explicit exit status sentinel."""
+    return (
+        f"set +e; {command}; "
+        "__openrange_rc=$?; "
+        f"printf '\\n{_EXIT_STATUS_SENTINEL}%s\\n' \"$__openrange_rc\""
+    )
+
+
+def _split_output_and_exit_status(output: str) -> tuple[str, int | None]:
+    """Return ``(stdout_without_sentinel, exit_code_or_none)``."""
+    marker = output.rfind(_EXIT_STATUS_SENTINEL)
+    if marker == -1:
+        return output, None
+
+    body = output[:marker].rstrip()
+    raw_code = output[marker + len(_EXIT_STATUS_SENTINEL):].strip().splitlines()[0]
+    try:
+        return body, int(raw_code)
+    except ValueError:
+        return body, None
+
+
+async def _exec_with_exit_status(
+    containers: ContainerSet,
+    host: str,
+    command: str,
+) -> tuple[str, int | None]:
+    """Execute *command* and parse explicit status from command output."""
+    raw_output = await containers.exec(host, _wrap_with_exit_status(command))
+    return _split_output_and_exit_status(raw_output)
+
+
 class PatchabilityCheck:
     """Inverse mutation: patching a vuln must break the corresponding golden-path step."""
 
@@ -126,7 +160,11 @@ class PatchabilityCheck:
 
             # --- Apply remediation -------------------------------------------------
             try:
-                await containers.exec(host, vuln.remediation)
+                remediation_output, remediation_code = await _exec_with_exit_status(
+                    containers,
+                    host,
+                    vuln.remediation,
+                )
             except Exception as exc:  # noqa: BLE001
                 results.append({"vuln": vuln.id, "error": f"remediation failed: {exc}"})
                 all_ok = False
@@ -137,25 +175,85 @@ class PatchabilityCheck:
                     pass
                 continue
 
+            if remediation_code is None:
+                results.append({
+                    "vuln": vuln.id,
+                    "passed": False,
+                    "reason": "remediation inconclusive (missing exit status signal)",
+                    "got_snippet": remediation_output[:200],
+                })
+                all_ok = False
+                try:
+                    await containers.restart(host)
+                except Exception:  # noqa: BLE001
+                    pass
+                continue
+
+            if remediation_code != 0:
+                results.append({
+                    "vuln": vuln.id,
+                    "passed": False,
+                    "reason": f"remediation failed (exit {remediation_code})",
+                    "got_snippet": remediation_output[:200],
+                })
+                all_ok = False
+                try:
+                    await containers.restart(host)
+                except Exception:  # noqa: BLE001
+                    pass
+                continue
+
             # --- Re-run linked golden-path step — must now fail --------------------
             step_still_works = False
             matched_any = False
+            inconclusive_retests: list[dict[str, str]] = []
             for chain_step in linked_steps:
                 gp_step = _find_golden_step(snapshot, chain_step)
                 if gp_step is None:
                     continue
                 matched_any = True
+                if not gp_step.expect_in_stdout:
+                    inconclusive_retests.append({
+                        "step": str(gp_step.step),
+                        "reason": "missing expect_in_stdout",
+                    })
+                    continue
                 try:
-                    output = await execute_step(
-                        snapshot,
-                        containers,
-                        gp_step.command,
-                        host=getattr(gp_step, "host", None) or "attacker",
-                    )
-                except Exception:  # noqa: BLE001
-                    continue  # exec failure counts as "step failed" — good
+                    cmd_name = gp_step.command.strip().split()[0] if gp_step.command.strip() else ""
+                    if cmd_name in {"submit_flag", "submit_evidence", "submit_finding", "auth", "logout"}:
+                        output = await execute_step(
+                            snapshot,
+                            containers,
+                            gp_step.command,
+                            host=getattr(gp_step, "host", None) or "attacker",
+                        )
+                        retest_code = 0
+                    else:
+                        output, retest_code = await _exec_with_exit_status(
+                            containers,
+                            getattr(gp_step, "host", None) or "attacker",
+                            gp_step.command,
+                        )
+                        if retest_code is None:
+                            inconclusive_retests.append({
+                                "step": str(gp_step.step),
+                                "reason": "missing exit status signal",
+                            })
+                            continue
+                        if retest_code != 0:
+                            inconclusive_retests.append({
+                                "step": str(gp_step.step),
+                                "reason": f"non-zero exit ({retest_code})",
+                            })
+                            continue
+                except Exception as exc:  # noqa: BLE001
+                    inconclusive_retests.append({
+                        "step": str(gp_step.step),
+                        "reason": f"execution error: {exc}",
+                    })
+                    continue
 
-                if gp_step.expect_in_stdout and gp_step.expect_in_stdout in output:
+                if gp_step.expect_in_stdout in output:
                     step_still_works = True
 
             if not matched_any:
@@ -172,7 +270,15 @@ class PatchabilityCheck:
 
             tested_count += 1
 
-            if step_still_works:
+            if inconclusive_retests:
+                results.append({
+                    "vuln": vuln.id,
+                    "passed": False,
+                    "reason": "retest inconclusive",
+                    "retest_issues": inconclusive_retests,
+                })
+                all_ok = False
+            elif step_still_works:
                 results.append({
                     "vuln": vuln.id,
                     "passed": False,

--- a/tests/test_validator.py
+++ b/tests/test_validator.py
@@ -377,6 +377,11 @@ async def test_exploitability_allows_missing_expectation_in_lenient_mode(mock_co
 # ---------------------------------------------------------------------------
 
 
+def _with_exit_status(stdout: str = "", code: int = 0) -> str:
+    """Mock wrapped command output returned by PatchabilityCheck shell wrapper."""
+    return f"{stdout}\n__OPENRANGE_EXIT_STATUS__={code}\n"
+
+
 @pytest.mark.asyncio
 async def test_patchability_fails_when_no_vulns(mock_containers):
     from open_range.validator.patchability import PatchabilityCheck
@@ -415,10 +420,10 @@ async def test_patchability_passes_when_patch_breaks_exploit(mock_containers):
         ],
     )
 
-    # Remediation exec succeeds (returns empty)
-    mock_containers.exec_results[("web", "sed")] = ""
+    # Remediation exec succeeds (returns empty, exit 0)
+    mock_containers.exec_results[("web", "sed")] = _with_exit_status("")
     # After patch, golden path step returns DIFFERENT output (no SECRET_DATA)
-    mock_containers.exec_results[("attacker", "curl http://web/search?q=exploit")] = "no results"
+    mock_containers.exec_results[("attacker", "curl http://web/search?q=exploit")] = _with_exit_status("no results")
 
     result = await PatchabilityCheck().check(spec, mock_containers)
     assert result.passed is True
@@ -455,13 +460,98 @@ async def test_patchability_fails_when_exploit_still_works(mock_containers):
     )
 
     # Remediation exec succeeds
-    mock_containers.exec_results[("web", "sed")] = ""
+    mock_containers.exec_results[("web", "sed")] = _with_exit_status("")
     # After patch, golden path step STILL returns the expected output (patch didn't work)
-    mock_containers.exec_results[("attacker", "curl http://web/search?q=exploit")] = "SECRET_DATA"
+    mock_containers.exec_results[("attacker", "curl http://web/search?q=exploit")] = _with_exit_status("SECRET_DATA")
 
     result = await PatchabilityCheck().check(spec, mock_containers)
     assert result.passed is False
     assert "exploitable after remediation" in result.error
+
+
+@pytest.mark.asyncio
+async def test_patchability_fails_when_remediation_exits_nonzero(mock_containers):
+    """Non-zero remediation exit must fail instead of counting as patched."""
+    from open_range.protocols import ExploitStep
+    from open_range.validator.patchability import PatchabilityCheck
+
+    spec = SnapshotSpec(
+        truth_graph=TruthGraph(
+            vulns=[
+                Vulnerability(
+                    id="v1",
+                    type="sqli",
+                    host="web",
+                    remediation="sed -i 's/unsafe/safe/' /var/www/app.php",
+                ),
+            ],
+            exploit_chain=[
+                ExploitStep(vuln_id="v1", command="curl http://web/search?q=exploit"),
+            ],
+        ),
+        golden_path=[
+            GoldenPathStep(
+                step=1,
+                command="curl http://web/search?q=exploit",
+                expect_in_stdout="SECRET_DATA",
+            ),
+        ],
+    )
+
+    mock_containers.exec_results[("web", "sed")] = _with_exit_status("sed: no such file", 1)
+
+    result = await PatchabilityCheck().check(spec, mock_containers)
+    assert result.passed is False
+    vuln_result = result.details["vuln_results"][0]
+    assert vuln_result["passed"] is False
+    assert "remediation failed (exit 1)" in vuln_result["reason"]
+    assert mock_containers.restarted == ["web"]
+
+
+@pytest.mark.asyncio
+async def test_patchability_fails_when_retest_execution_is_inconclusive(mock_containers):
+    """Retest execution errors are inconclusive and must fail the check."""
+    from open_range.protocols import ExploitStep
+    from open_range.validator.patchability import PatchabilityCheck
+
+    spec = SnapshotSpec(
+        truth_graph=TruthGraph(
+            vulns=[
+                Vulnerability(
+                    id="v1",
+                    type="sqli",
+                    host="web",
+                    remediation="sed -i 's/unsafe/safe/' /var/www/app.php",
+                ),
+            ],
+            exploit_chain=[
+                ExploitStep(vuln_id="v1", command="curl http://web/search?q=exploit"),
+            ],
+        ),
+        golden_path=[
+            GoldenPathStep(
+                step=1,
+                command="curl http://web/search?q=exploit",
+                expect_in_stdout="SECRET_DATA",
+            ),
+        ],
+    )
+
+    async def exec_side_effect(container: str, cmd: str, **kwargs) -> str:
+        if container == "web" and "sed -i 's/unsafe/safe/' /var/www/app.php" in cmd:
+            return _with_exit_status("")
+        if container == "attacker" and "curl http://web/search?q=exploit" in cmd:
+            raise RuntimeError("timeout")
+        return ""
+
+    mock_containers.exec = exec_side_effect
+    result = await PatchabilityCheck().check(spec, mock_containers)
+    assert result.passed is False
+    vuln_result = result.details["vuln_results"][0]
+    assert vuln_result["passed"] is False
+    assert vuln_result["reason"] == "retest inconclusive"
+    assert vuln_result["retest_issues"][0]["reason"] == "execution error: timeout"
+    assert mock_containers.restarted == ["web"]
 
 
 @pytest.mark.asyncio
@@ -582,11 +672,11 @@ async def test_patchability_restarts_container_after_patch(mock_containers):
     )
 
     # Remediation succeeds for both
-    mock_containers.exec_results[("web", "sed")] = ""
-    mock_containers.exec_results[("web", "rm")] = ""
+    mock_containers.exec_results[("web", "sed")] = _with_exit_status("")
+    mock_containers.exec_results[("web", "rm")] = _with_exit_status("")
     # After patch, exploits fail (return empty)
-    mock_containers.exec_results[("attacker", "curl http://web/search")] = "blocked"
-    mock_containers.exec_results[("attacker", "curl http://web/read")] = "forbidden"
+    mock_containers.exec_results[("attacker", "curl http://web/search")] = _with_exit_status("blocked")
+    mock_containers.exec_results[("attacker", "curl http://web/read")] = _with_exit_status("forbidden")
 
     result = await PatchabilityCheck().check(spec, mock_containers)
     assert result.passed is True


### PR DESCRIPTION
## Summary
- enforce explicit exit-status capture for remediation and retest shell commands in `PatchabilityCheck`
- fail when remediation is inconclusive or exits non-zero
- fail when retest execution is inconclusive (missing expectation, missing exit signal, non-zero exit, or execution error)
- add targeted regression tests for non-zero remediation and inconclusive retest execution
- update existing patchability tests for wrapped command output semantics

## Validation
- `PYTHONPATH=src PYTEST_DISABLE_PLUGIN_AUTOLOAD=1 /home/talian/priv/open-range/.venv/bin/python -m pytest -p pytest_asyncio.plugin tests/test_validator.py -q`

Closes #80