### PR TITLE
Enforce strict managed live-admission defaults

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -86,7 +86,8 @@ ENV PYTHONPATH="/app/env/src:/app/env"
 ENV OPENRANGE_EXECUTION_MODE=subprocess
 # Enable the managed runtime so reset() boots real services from the manifest
 ENV OPENRANGE_RUNTIME_MANIFEST=manifests/tier1_basic.yaml
-ENV OPENRANGE_RUNTIME_VALIDATOR_PROFILE=offline
+ENV OPENRANGE_RUNTIME_VALIDATOR_PROFILE=training
+ENV OPENRANGE_ENABLE_LIVE_ADMISSION=1
 ENV OPENRANGE_SNAPSHOT_POOL_SIZE=1
 # Enable the OpenEnv Gradio web interface at /web
 ENV ENABLE_WEB_INTERFACE=true

--- a/README.md
+++ b/README.md
@@ -100,7 +100,19 @@ uv run pytest tests/ -v --tb=short
 
 The deployed package exposes the standard OpenEnv `reset()`, `step()`, and `state()` contract through `server.app:app`, which is the entrypoint referenced by `openenv.yaml`.
 
-**Validator** — Admission gate for candidate snapshots. The shipped runtime first enforces manifest compliance plus graph-native checks such as graph consistency, path solvability, evidence sufficiency, and reward grounding before structural/task checks. When `OPENRANGE_ENABLE_LIVE_ADMISSION=1`, the runtime also boots the rendered child bundle, applies rendered payload files, constructs a real `ContainerSet`, and runs live build/exploit/evidence/reward checks before admission. Public/HF mode can still rely on a prebuilt admitted pool with live admission disabled.
+**Validator** — Admission gate for candidate snapshots. The shipped runtime enforces manifest compliance plus graph-native checks such as graph consistency, path solvability, evidence sufficiency, and reward grounding before structural/task checks. With the `training` profile, the runtime boots rendered bundles, applies payload files, constructs a real `ContainerSet`, and runs live build/exploit/patch/evidence/reward/isolation/difficulty/NPC/realism checks before admission.
+
+Validator profile matrix:
+
+| Profile | Checks | Guarantees |
+|---------|--------|------------|
+| `offline` | Graph + structural/task checks only (no live containers) | Fast static admission only; no live exploitability/patchability guarantee |
+| `training` | `offline` checks + live/container-backed checks | Full admission guarantees for managed training/runtime use |
+
+Managed runtime defaults and safety behavior:
+- `OPENRANGE_RUNTIME_VALIDATOR_PROFILE` defaults to `training`.
+- `OPENRANGE_ENABLE_LIVE_ADMISSION` defaults to `1`.
+- If managed runtime is configured non-live (`offline` profile and/or live admission disabled), startup raises an error unless you explicitly opt out with `OPENRANGE_ALLOW_NON_LIVE_ADMISSION=1`, in which case a warning is emitted.
 
 **Environment** — `RangeEnvironment(Environment)` following the OpenEnv contract. `reset()` asks the shared runtime for a frozen admitted snapshot. `step(action)` routes commands to the appropriate container — Red runs on the attacker box, Blue runs on the SIEM. No artificial command allowlists; the container's installed tools are the constraint.
 

--- a/src/open_range/server/runtime.py
+++ b/src/open_range/server/runtime.py
@@ -59,6 +59,9 @@ from open_range.validator.validator import ValidationResult, ValidatorGate
 logger = logging.getLogger(__name__)
 
 _DEFAULT_MANIFEST = ("manifests", "tier1_basic.yaml")
+_DEFAULT_MANAGED_VALIDATOR_PROFILE = "training"
+_DEFAULT_MANAGED_LIVE_ADMISSION = True
+_ALLOW_NON_LIVE_ADMISSION_ENV = "OPENRANGE_ALLOW_NON_LIVE_ADMISSION"
 _VALIDATOR_PROFILE_ALIASES = {
     "light": "offline",
     "static": "offline",
@@ -357,6 +360,19 @@ def _build_validator(profile: str, manifest: dict[str, Any]) -> ValidatorGate:
     )
 
 
+def _strict_admission_enabled(profile: str, live_admission_enabled: bool) -> bool:
+    return profile in _LIVE_VALIDATOR_PROFILES and live_admission_enabled
+
+
+def _managed_admission_failure_message(profile: str, live_admission_enabled: bool) -> str:
+    return (
+        "Managed runtime requires strict live admission "
+        f"(validator_profile='training', live_admission_enabled=1). "
+        f"Current configuration: validator_profile={profile!r}, "
+        f"live_admission_enabled={live_admission_enabled!r}."
+    )
+
+
 def _default_live_validator(*, include_patchability: bool = False) -> ValidatorGate:
     checks = [
         BuildBootCheck(),
@@ -436,20 +452,40 @@ class ManagedSnapshotRuntime:
 
     @classmethod
     def from_env(cls) -> "ManagedSnapshotRuntime":
+        profile = _normalize_validator_profile(
+            os.getenv(
+                "OPENRANGE_RUNTIME_VALIDATOR_PROFILE",
+                _DEFAULT_MANAGED_VALIDATOR_PROFILE,
+            )
+        )
+        live_admission_enabled = _env_flag(
+            "OPENRANGE_ENABLE_LIVE_ADMISSION",
+            default=_DEFAULT_MANAGED_LIVE_ADMISSION,
+        )
+        if not _strict_admission_enabled(profile, live_admission_enabled):
+            message = _managed_admission_failure_message(profile, live_admission_enabled)
+            if _env_flag(_ALLOW_NON_LIVE_ADMISSION_ENV, default=False):
+                logger.warning(
+                    "%s Explicit opt-out enabled via %s=1.",
+                    message,
+                    _ALLOW_NON_LIVE_ADMISSION_ENV,
+                )
+            else:
+                raise RuntimeError(
+                    f"{message} Set {_ALLOW_NON_LIVE_ADMISSION_ENV}=1 to explicitly opt out."
+                )
+
         return cls(
             manifest_path=os.getenv("OPENRANGE_RUNTIME_MANIFEST"),
             store_dir=os.getenv("OPENRANGE_SNAPSHOT_DIR"),
-            validator_profile=os.getenv("OPENRANGE_RUNTIME_VALIDATOR_PROFILE", "offline"),
+            validator_profile=profile,
             pool_size=_env_int("OPENRANGE_SNAPSHOT_POOL_SIZE", 3),
             selection_strategy=os.getenv("OPENRANGE_SNAPSHOT_SELECTION", "random"),
             parent_selection_strategy=os.getenv("OPENRANGE_PARENT_SELECTION", "policy"),
             refill_enabled=_env_flag("OPENRANGE_ENABLE_MANAGED_REFILL", default=False),
             refill_interval_s=float(os.getenv("OPENRANGE_REFILL_INTERVAL_S", "2.0")),
             generation_retries=_env_int("OPENRANGE_GENERATION_RETRIES", 3),
-            live_admission_enabled=_env_flag(
-                "OPENRANGE_ENABLE_LIVE_ADMISSION",
-                default=False,
-            ),
+            live_admission_enabled=live_admission_enabled,
             teardown_booted_projects=not _env_flag(
                 "OPENRANGE_KEEP_BOOTED_VALIDATION_STACKS",
                 default=False,

--- a/tests/test_runtime.py
+++ b/tests/test_runtime.py
@@ -2,9 +2,11 @@
 
 from __future__ import annotations
 
+import logging
 from pathlib import Path
 
 import pytest
+import yaml
 
 from open_range.protocols import CheckResult, ContainerSet, SnapshotSpec
 from open_range.server.compose_runner import BootedSnapshotProject
@@ -14,6 +16,62 @@ from open_range.validator.validator import ValidationResult
 
 
 class TestManagedSnapshotRuntime:
+    def test_from_env_defaults_to_training_and_live(self, tier1_manifest, tmp_path, monkeypatch):
+        manifest_path = tmp_path / "manifest.yaml"
+        manifest_path.write_text(yaml.safe_dump(tier1_manifest), encoding="utf-8")
+
+        monkeypatch.setenv("OPENRANGE_RUNTIME_MANIFEST", str(manifest_path))
+        monkeypatch.setenv("OPENRANGE_SNAPSHOT_DIR", str(tmp_path / "snapshots"))
+        monkeypatch.delenv("OPENRANGE_RUNTIME_VALIDATOR_PROFILE", raising=False)
+        monkeypatch.delenv("OPENRANGE_ENABLE_LIVE_ADMISSION", raising=False)
+        monkeypatch.delenv("OPENRANGE_ALLOW_NON_LIVE_ADMISSION", raising=False)
+
+        runtime = ManagedSnapshotRuntime.from_env()
+        assert runtime.validator_profile == "training"
+        assert runtime.live_admission_enabled is True
+
+    def test_from_env_rejects_non_live_without_explicit_opt_out(
+        self,
+        tier1_manifest,
+        tmp_path,
+        monkeypatch,
+    ):
+        manifest_path = tmp_path / "manifest.yaml"
+        manifest_path.write_text(yaml.safe_dump(tier1_manifest), encoding="utf-8")
+
+        monkeypatch.setenv("OPENRANGE_RUNTIME_MANIFEST", str(manifest_path))
+        monkeypatch.setenv("OPENRANGE_SNAPSHOT_DIR", str(tmp_path / "snapshots"))
+        monkeypatch.setenv("OPENRANGE_RUNTIME_VALIDATOR_PROFILE", "offline")
+        monkeypatch.setenv("OPENRANGE_ENABLE_LIVE_ADMISSION", "0")
+        monkeypatch.delenv("OPENRANGE_ALLOW_NON_LIVE_ADMISSION", raising=False)
+
+        with pytest.raises(RuntimeError, match="OPENRANGE_ALLOW_NON_LIVE_ADMISSION=1"):
+            ManagedSnapshotRuntime.from_env()
+
+    def test_from_env_allows_non_live_with_explicit_opt_out_warning(
+        self,
+        tier1_manifest,
+        tmp_path,
+        monkeypatch,
+        caplog,
+    ):
+        manifest_path = tmp_path / "manifest.yaml"
+        manifest_path.write_text(yaml.safe_dump(tier1_manifest), encoding="utf-8")
+
+        monkeypatch.setenv("OPENRANGE_RUNTIME_MANIFEST", str(manifest_path))
+        monkeypatch.setenv("OPENRANGE_SNAPSHOT_DIR", str(tmp_path / "snapshots"))
+        monkeypatch.setenv("OPENRANGE_RUNTIME_VALIDATOR_PROFILE", "offline")
+        monkeypatch.setenv("OPENRANGE_ENABLE_LIVE_ADMISSION", "0")
+        monkeypatch.setenv("OPENRANGE_ALLOW_NON_LIVE_ADMISSION", "1")
+
+        with caplog.at_level(logging.WARNING):
+            runtime = ManagedSnapshotRuntime.from_env()
+
+        assert runtime.validator_profile == "offline"
+        assert runtime.live_admission_enabled is False
+        assert "strict live admission" in caplog.text
+        assert "OPENRANGE_ALLOW_NON_LIVE_ADMISSION=1" in caplog.text
+
     def test_offline_validator_profile_includes_static_checks(self, tier1_manifest, tmp_path):
         runtime = ManagedSnapshotRuntime(
             manifest=tier1_manifest,


### PR DESCRIPTION
## Summary
- make managed runtime (`ManagedSnapshotRuntime.from_env`) default to strict admission (`training` profile + live admission enabled)
- fail fast at startup when managed runtime is configured non-live unless `OPENRANGE_ALLOW_NON_LIVE_ADMISSION=1` is set
- update shipped Docker image defaults to `OPENRANGE_RUNTIME_VALIDATOR_PROFILE=training` and `OPENRANGE_ENABLE_LIVE_ADMISSION=1`
- document the offline/training profile matrix and operational guarantees in README
- add runtime tests covering strict defaults, explicit opt-out failure path, and opt-out warning path

## Validation
- `UV_CACHE_DIR=/tmp/uv-cache PYTEST_DISABLE_PLUGIN_AUTOLOAD=1 uv run pytest -p pytest_asyncio.plugin tests/test_runtime.py -q`
- `UV_CACHE_DIR=/tmp/uv-cache PYTEST_DISABLE_PLUGIN_AUTOLOAD=1 uv run pytest -p pytest_asyncio.plugin tests/test_validator.py tests/test_environment.py -q`

Closes #77