### PR TITLE
Harden managed runtime defaults for strict live admission

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -86,7 +86,10 @@ ENV PYTHONPATH="/app/env/src:/app/env"
 ENV OPENRANGE_EXECUTION_MODE=subprocess
 # Enable the managed runtime so reset() boots real services from the manifest
 ENV OPENRANGE_RUNTIME_MANIFEST=manifests/tier1_basic.yaml
+# This all-in-one image runs in subprocess mode (no nested Docker daemon), so
+# it opts out of strict live admission explicitly.
 ENV OPENRANGE_RUNTIME_VALIDATOR_PROFILE=offline
+ENV OPENRANGE_ALLOW_OFFLINE_ADMISSION=1
 ENV OPENRANGE_SNAPSHOT_POOL_SIZE=1
 # Enable the OpenEnv Gradio web interface at /web
 ENV ENABLE_WEB_INTERFACE=true

--- a/README.md
+++ b/README.md
@@ -100,7 +100,14 @@ uv run pytest tests/ -v --tb=short
 
 The deployed package exposes the standard OpenEnv `reset()`, `step()`, and `state()` contract through `server.app:app`, which is the entrypoint referenced by `openenv.yaml`.
 
-**Validator** — Admission gate for candidate snapshots. The shipped runtime first enforces manifest compliance plus graph-native checks such as graph consistency, path solvability, evidence sufficiency, and reward grounding before structural/task checks. When `OPENRANGE_ENABLE_LIVE_ADMISSION=1`, the runtime also boots the rendered child bundle, applies rendered payload files, constructs a real `ContainerSet`, and runs live build/exploit/evidence/reward checks before admission. Public/HF mode can still rely on a prebuilt admitted pool with live admission disabled.
+**Validator** — Admission gate for candidate snapshots. Managed runtime defaults to strict live admission (`OPENRANGE_RUNTIME_VALIDATOR_PROFILE=training`), which runs graph checks plus container-backed build/exploit/patch/evidence/reward/isolation/difficulty/NPC/realism checks before storing a snapshot. Non-live admission (`offline`) is allowed only as an explicit opt-out via `OPENRANGE_ALLOW_OFFLINE_ADMISSION=1`, and the runtime logs a startup warning when this mode is used.
+
+| Validator Profile | Included Checks | Operational Guarantee | Intended Use |
+|-------------------|-----------------|-----------------------|--------------|
+| `training` (default) | Graph + structural + task + build/boot + exploitability + patchability + evidence + reward grounding + isolation + difficulty + NPC consistency + realism review | Strict live/container-backed admission | Managed/production runtime |
+| `offline` | Graph + structural + task feasibility only | No live exploit/patch/evidence/reward validation | Local fallback only (must set `OPENRANGE_ALLOW_OFFLINE_ADMISSION=1`) |
+
+`OPENRANGE_ENABLE_LIVE_ADMISSION=1` is an additional artifact-level boot validation pass after a candidate snapshot is admitted.
 
 **Environment** — `RangeEnvironment(Environment)` following the OpenEnv contract. `reset()` asks the shared runtime for a frozen admitted snapshot. `step(action)` routes commands to the appropriate container — Red runs on the attacker box, Blue runs on the SIEM. No artificial command allowlists; the container's installed tools are the constraint.
 

--- a/src/open_range/server/runtime.py
+++ b/src/open_range/server/runtime.py
@@ -59,6 +59,7 @@ from open_range.validator.validator import ValidationResult, ValidatorGate
 logger = logging.getLogger(__name__)
 
 _DEFAULT_MANIFEST = ("manifests", "tier1_basic.yaml")
+_DEFAULT_VALIDATOR_PROFILE = "training"
 _VALIDATOR_PROFILE_ALIASES = {
     "light": "offline",
     "static": "offline",
@@ -66,6 +67,7 @@ _VALIDATOR_PROFILE_ALIASES = {
     "strict": "training",
 }
 _LIVE_VALIDATOR_PROFILES = {"training"}
+_ALLOW_OFFLINE_ADMISSION_ENV = "OPENRANGE_ALLOW_OFFLINE_ADMISSION"
 
 
 def _env_flag(name: str, default: bool = False) -> bool:
@@ -308,7 +310,7 @@ def _default_builder() -> SnapshotBuilder:
 
 
 def _normalize_validator_profile(profile: str | None) -> str:
-    normalized = (profile or "offline").strip().lower()
+    normalized = (profile or _DEFAULT_VALIDATOR_PROFILE).strip().lower()
     normalized = _VALIDATOR_PROFILE_ALIASES.get(normalized, normalized)
     if normalized not in {"offline", "training"}:
         raise ValueError(
@@ -381,6 +383,7 @@ class ManagedSnapshotRuntime:
         builder: SnapshotBuilder | None = None,
         validator: ValidatorGate | None = None,
         validator_profile: str | None = None,
+        allow_insecure_offline_profile: bool | None = None,
         pool_size: int = 3,
         selection_strategy: str = "random",
         parent_selection_strategy: str = "policy",
@@ -405,9 +408,16 @@ class ManagedSnapshotRuntime:
         self.builder = builder or _default_builder()
         self.mutation_policy = mutation_policy or PopulationMutationPolicy()
         self.mutator = Mutator(self.builder, policy=self.mutation_policy)
-        self.validator_profile = _normalize_validator_profile(
-            validator_profile or os.getenv("OPENRANGE_RUNTIME_VALIDATOR_PROFILE", "offline")
+        self.allow_insecure_offline_profile = (
+            _env_flag(_ALLOW_OFFLINE_ADMISSION_ENV, default=False)
+            if allow_insecure_offline_profile is None
+            else bool(allow_insecure_offline_profile)
         )
+        self.validator_profile = _normalize_validator_profile(
+            validator_profile
+            or os.getenv("OPENRANGE_RUNTIME_VALIDATOR_PROFILE", _DEFAULT_VALIDATOR_PROFILE)
+        )
+        self._enforce_validator_profile_policy()
         self.validator = validator or _build_validator(self.validator_profile, self.manifest)
         self.renderer = SnapshotRenderer()
         self.curriculum = CurriculumTracker()
@@ -439,7 +449,14 @@ class ManagedSnapshotRuntime:
         return cls(
             manifest_path=os.getenv("OPENRANGE_RUNTIME_MANIFEST"),
             store_dir=os.getenv("OPENRANGE_SNAPSHOT_DIR"),
-            validator_profile=os.getenv("OPENRANGE_RUNTIME_VALIDATOR_PROFILE", "offline"),
+            validator_profile=os.getenv(
+                "OPENRANGE_RUNTIME_VALIDATOR_PROFILE",
+                _DEFAULT_VALIDATOR_PROFILE,
+            ),
+            allow_insecure_offline_profile=_env_flag(
+                _ALLOW_OFFLINE_ADMISSION_ENV,
+                default=False,
+            ),
             pool_size=_env_int("OPENRANGE_SNAPSHOT_POOL_SIZE", 3),
             selection_strategy=os.getenv("OPENRANGE_SNAPSHOT_SELECTION", "random"),
             parent_selection_strategy=os.getenv("OPENRANGE_PARENT_SELECTION", "policy"),
@@ -458,6 +475,28 @@ class ManagedSnapshotRuntime:
                 "OPENRANGE_ENABLE_PATCH_VALIDATION",
                 default=False,
             ),
+        )
+
+    def _enforce_validator_profile_policy(self) -> None:
+        if self.validator_profile in _LIVE_VALIDATOR_PROFILES:
+            return
+
+        warning = (
+            "ManagedSnapshotRuntime validator profile is set to "
+            f"{self.validator_profile!r}; container-backed admission checks are disabled "
+            "(build_boot, exploitability, patchability, evidence, reward_grounding, "
+            "isolation, difficulty, npc_consistency, realism_review)."
+        )
+        if not self.allow_insecure_offline_profile:
+            raise RuntimeError(
+                warning
+                + " Set OPENRANGE_RUNTIME_VALIDATOR_PROFILE=training for strict admission, "
+                + f"or set {_ALLOW_OFFLINE_ADMISSION_ENV}=1 to explicitly opt out."
+            )
+        logger.warning(
+            "%s Running with explicit opt-out (%s=1).",
+            warning,
+            _ALLOW_OFFLINE_ADMISSION_ENV,
         )
 
     @staticmethod
@@ -604,6 +643,7 @@ class ManagedSnapshotRuntime:
             "selection_strategy": self.selection_strategy,
             "parent_selection_strategy": self.parent_selection_strategy,
             "validator_profile": self.validator_profile,
+            "allow_insecure_offline_profile": self.allow_insecure_offline_profile,
             "refill_enabled": self.refill_enabled,
             "live_admission_enabled": self.live_admission_enabled,
             "snapshot_count": self.snapshot_count(),

--- a/tests/test_runtime.py
+++ b/tests/test_runtime.py
@@ -19,6 +19,7 @@ class TestManagedSnapshotRuntime:
             manifest=tier1_manifest,
             store_dir=tmp_path / "snapshots",
             validator_profile="offline",
+            allow_insecure_offline_profile=True,
             refill_enabled=False,
         )
         names = [type(check).__name__ for check in runtime.validator.checks]
@@ -54,10 +55,59 @@ class TestManagedSnapshotRuntime:
         assert "RewardGroundingCheck" in names
         assert "DifficultyCheck" in names
 
+    def test_offline_validator_profile_requires_explicit_opt_out(
+        self,
+        tier1_manifest,
+        tmp_path,
+        monkeypatch,
+    ):
+        monkeypatch.delenv("OPENRANGE_ALLOW_OFFLINE_ADMISSION", raising=False)
+        with pytest.raises(RuntimeError, match="OPENRANGE_ALLOW_OFFLINE_ADMISSION=1"):
+            ManagedSnapshotRuntime(
+                manifest=tier1_manifest,
+                store_dir=tmp_path / "snapshots",
+                validator_profile="offline",
+                refill_enabled=False,
+            )
+
+    def test_offline_validator_profile_logs_warning_when_opted_out(
+        self,
+        tier1_manifest,
+        tmp_path,
+        caplog,
+    ):
+        caplog.set_level("WARNING")
+        ManagedSnapshotRuntime(
+            manifest=tier1_manifest,
+            store_dir=tmp_path / "snapshots",
+            validator_profile="offline",
+            allow_insecure_offline_profile=True,
+            refill_enabled=False,
+        )
+        assert any(
+            "container-backed admission checks are disabled" in record.message
+            for record in caplog.records
+        )
+
+    def test_from_env_defaults_to_training_validator_profile(self, tmp_path, monkeypatch):
+        repo_root = Path(__file__).resolve().parent.parent
+        monkeypatch.setenv(
+            "OPENRANGE_RUNTIME_MANIFEST",
+            str(repo_root / "manifests" / "tier1_basic.yaml"),
+        )
+        monkeypatch.setenv("OPENRANGE_SNAPSHOT_DIR", str(tmp_path / "snapshots"))
+        monkeypatch.delenv("OPENRANGE_RUNTIME_VALIDATOR_PROFILE", raising=False)
+        monkeypatch.delenv("OPENRANGE_ALLOW_OFFLINE_ADMISSION", raising=False)
+
+        runtime = ManagedSnapshotRuntime.from_env()
+        assert runtime.validator_profile == "training"
+
     def test_start_preloads_snapshot_pool(self, tier1_manifest, tmp_path):
         runtime = ManagedSnapshotRuntime(
             manifest=tier1_manifest,
             store_dir=tmp_path / "snapshots",
+            validator_profile="offline",
+            allow_insecure_offline_profile=True,
             pool_size=2,
             refill_enabled=False,
         )
@@ -74,6 +124,8 @@ class TestManagedSnapshotRuntime:
         runtime = ManagedSnapshotRuntime(
             manifest=tier1_manifest,
             store_dir=tmp_path / "snapshots",
+            validator_profile="offline",
+            allow_insecure_offline_profile=True,
             pool_size=1,
             refill_enabled=False,
         )
@@ -93,6 +145,8 @@ class TestManagedSnapshotRuntime:
         runtime = ManagedSnapshotRuntime(
             manifest=tier1_manifest,
             store_dir=tmp_path / "snapshots",
+            validator_profile="offline",
+            allow_insecure_offline_profile=True,
             pool_size=1,
             selection_strategy="latest",
             refill_enabled=False,
@@ -111,6 +165,8 @@ class TestManagedSnapshotRuntime:
         runtime = ManagedSnapshotRuntime(
             manifest=tier1_manifest,
             store_dir=tmp_path / "snapshots",
+            validator_profile="offline",
+            allow_insecure_offline_profile=True,
             pool_size=1,
             refill_enabled=False,
         )
@@ -129,6 +185,8 @@ class TestManagedSnapshotRuntime:
         runtime = ManagedSnapshotRuntime(
             manifest=tier1_manifest,
             store_dir=tmp_path / "snapshots",
+            validator_profile="offline",
+            allow_insecure_offline_profile=True,
             pool_size=2,
             selection_strategy="latest",
             parent_selection_strategy="policy",
@@ -150,6 +208,8 @@ class TestManagedSnapshotRuntime:
         runtime = ManagedSnapshotRuntime(
             manifest=tier1_manifest,
             store_dir=tmp_path / "snapshots",
+            validator_profile="offline",
+            allow_insecure_offline_profile=True,
             pool_size=1,
             parent_selection_strategy="policy",
             refill_enabled=False,
@@ -161,6 +221,8 @@ class TestManagedSnapshotRuntime:
         runtime = ManagedSnapshotRuntime(
             manifest=tier1_manifest,
             store_dir=tmp_path / "snapshots",
+            validator_profile="offline",
+            allow_insecure_offline_profile=True,
             pool_size=2,
             refill_enabled=False,
         )
@@ -225,6 +287,8 @@ class TestManagedSnapshotRuntime:
         runtime = ManagedSnapshotRuntime(
             manifest=tier1_manifest,
             store_dir=tmp_path / "snapshots",
+            validator_profile="offline",
+            allow_insecure_offline_profile=True,
             pool_size=1,
             refill_enabled=False,
             live_admission_enabled=True,
@@ -290,6 +354,8 @@ class TestManagedSnapshotRuntime:
         runtime = ManagedSnapshotRuntime(
             manifest=tier1_manifest,
             store_dir=tmp_path / "snapshots",
+            validator_profile="offline",
+            allow_insecure_offline_profile=True,
             pool_size=1,
             refill_enabled=False,
             compose_runner=compose_runner,  # type: ignore[arg-type]
@@ -318,6 +384,8 @@ class TestEnvironmentRuntimeIntegration:
         runtime = ManagedSnapshotRuntime(
             manifest=tier1_manifest,
             store_dir=tmp_path / "snapshots",
+            validator_profile="offline",
+            allow_insecure_offline_profile=True,
             pool_size=1,
             refill_enabled=False,
         )
@@ -337,6 +405,8 @@ class TestEnvironmentRuntimeIntegration:
         runtime = ManagedSnapshotRuntime(
             manifest=tier1_manifest,
             store_dir=tmp_path / "snapshots",
+            validator_profile="offline",
+            allow_insecure_offline_profile=True,
             pool_size=1,
             refill_enabled=False,
         )
@@ -356,6 +426,8 @@ class TestEnvironmentRuntimeIntegration:
         runtime = ManagedSnapshotRuntime(
             manifest=tier1_manifest,
             store_dir=tmp_path / "snapshots",
+            validator_profile="offline",
+            allow_insecure_offline_profile=True,
             pool_size=1,
             refill_enabled=False,
         )


### PR DESCRIPTION
## Summary
- default managed runtime validator profile to training (strict live admission)
- require explicit opt-out for non-live offline profile via OPENRANGE_ALLOW_OFFLINE_ADMISSION=1
- add startup/runtime warning/error behavior for offline profile policy
- document validator profile matrix and guarantees in README
- keep all-in-one Docker image on explicit offline opt-out mode

## Validation
- env PYTHONPATH=src /home/talian/priv/open-range/.venv/bin/pytest -q tests/test_runtime.py
- env PYTHONPATH=src /home/talian/priv/open-range/.venv/bin/pytest -q tests/test_builder.py tests/test_lint.py tests/test_service_spec.py tests/test_environment.py tests/test_validator.py tests/test_runner.py tests/test_runtime.py

Closes #77