### PR TITLE
fix(runtime): stabilize live admission boot path

### DIFF
--- a/src/open_range/builder/builder.py
+++ b/src/open_range/builder/builder.py
@@ -618,10 +618,10 @@ _DEFAULT_VULN_POOL: list[dict[str, Any]] = [
         ),
         "root_cause": "Unsanitized user input in SQL query",
         "blast_radius": "Full database read access",
-        "remediation": "Use parameterized queries",
-        "flag_id": "flag1",
+        "remediation": "mv /var/www/portal/search.php /var/www/portal/search.php.disabled",
+        "flag_id": "flag_sqli",
         "flag_value": "FLAG{sql1_t3st_f1ag}",
-        "flag_path": "/var/flags/flag1.txt",
+        "flag_path": "/var/flags/sqli_flag.txt",
         "golden_path_steps": [
             {
                 "step": 1,
@@ -723,10 +723,10 @@ _DEFAULT_VULN_POOL: list[dict[str, Any]] = [
         ),
         "root_cause": "No path sanitization on file parameter",
         "blast_radius": "Arbitrary file read on web server",
-        "remediation": "Validate and sanitize file path, use basename()",
-        "flag_id": "flag1",
+        "remediation": "mv /var/www/portal/download.php /var/www/portal/download.php.disabled",
+        "flag_id": "flag_path_traversal",
         "flag_value": "FLAG{p4th_tr4v3rs4l_fl4g}",
-        "flag_path": "/var/flags/flag1.txt",
+        "flag_path": "/var/flags/path_traversal_flag.txt",
         "golden_path_steps": [
             {
                 "step": 1,
@@ -754,7 +754,7 @@ _DEFAULT_VULN_POOL: list[dict[str, Any]] = [
             },
             {
                 "step": 5,
-                "cmd": "curl 'http://web/download?file=../../../var/flags/flag1.txt'",
+                "cmd": "curl 'http://web/download?file=../../../var/flags/path_traversal_flag.txt'",
                 "expect_stdout": "FLAG{p4th_tr4v3rs4l_fl4g}",
                 "host": "attacker",
             },
@@ -956,7 +956,9 @@ class TemplateOnlyBuilder:
             )
 
         if "prefer_live_admission_compatible_vulns" in context.narrative_hints:
-            live_supported = {"sqli", "idor", "path_traversal", "weak_creds"}
+            # Keep strict live admission on task paths the current zone policy
+            # can actually reach from the attacker host.
+            live_supported = {"sqli", "path_traversal"}
             supported = [v for v in candidates if v["type"] in live_supported]
             if supported:
                 candidates = supported

--- a/src/open_range/builder/mutator.py
+++ b/src/open_range/builder/mutator.py
@@ -57,7 +57,7 @@ _GENERIC_SERVICES = {
     "nikto",
     "sqlmap",
 }
-_LIVE_MUTATION_SUPPORTED_VULNS = {"sqli", "idor", "path_traversal", "weak_creds"}
+_LIVE_MUTATION_SUPPORTED_VULNS = {"sqli", "path_traversal"}
 
 
 class Mutator:

--- a/src/open_range/builder/templates/docker-compose.yml.j2
+++ b/src/open_range/builder/templates/docker-compose.yml.j2
@@ -39,7 +39,7 @@ services:
       - -c
       - |
         apt-get update -qq && apt-get install -y -qq \
-          nmap sqlmap hydra nikto smbclient curl wget netcat-openbsd \
+          libblas3 nmap sqlmap hydra nikto smbclient curl wget netcat-openbsd \
           ssh dnsutils tcpdump python3 python3-pip iproute2 sshpass \
           default-mysql-client ldap-utils \
           > /dev/null 2>&1
@@ -47,9 +47,24 @@ services:
         ip route add 10.0.2.0/24 via 10.0.0.2 2>/dev/null || true
         ip route add 10.0.3.0/24 via 10.0.0.2 2>/dev/null || true
         tail -f /dev/null
+    extra_hosts:
+      - "firewall:10.0.0.2"
+      - "web:10.0.1.10"
+      - "mail:10.0.1.11"
+      - "db:10.0.2.20"
+      - "files:10.0.2.21"
+      - "ldap:10.0.3.20"
+      - "siem:10.0.3.21"
     networks:
       external:
         ipv4_address: 10.0.0.10
+    healthcheck:
+      test:
+        - "CMD-SHELL"
+        - "nmap --version >/dev/null 2>&1 && ip route | grep -q '10.0.1.0/24 via 10.0.0.2' && getent hosts web db files ldap siem >/dev/null 2>&1"
+      interval: 10s
+      timeout: 5s
+      retries: 12
     restart: unless-stopped
 
   firewall:
@@ -62,9 +77,10 @@ services:
       - |
         apt-get update -qq && apt-get install -y -qq iptables iproute2 > /dev/null 2>&1
         echo 1 > /proc/sys/net/ipv4/ip_forward
-        iptables -t nat -A POSTROUTING -o eth1 -j MASQUERADE
-        iptables -t nat -A POSTROUTING -o eth2 -j MASQUERADE
-        iptables -t nat -A POSTROUTING -o eth3 -j MASQUERADE
+        iptables -t nat -A POSTROUTING -s 10.0.0.0/24 -d 10.0.1.0/24 -j MASQUERADE
+        iptables -t nat -A POSTROUTING -s 10.0.1.0/24 -d 10.0.2.0/24 -j MASQUERADE
+        iptables -t nat -A POSTROUTING -s 10.0.1.0/24 -d 10.0.3.0/24 -j MASQUERADE
+        iptables -t nat -A POSTROUTING -s 10.0.2.0/24 -d 10.0.3.0/24 -j MASQUERADE
         iptables -A FORWARD -m state --state RELATED,ESTABLISHED -j ACCEPT
         iptables -A FORWARD -s 10.0.0.0/24 -d 10.0.1.0/24 -j ACCEPT
         iptables -A FORWARD -s 10.0.1.0/24 -d 10.0.2.0/24 -j ACCEPT
@@ -81,6 +97,13 @@ services:
         ipv4_address: 10.0.2.2
       management:
         ipv4_address: 10.0.3.2
+    healthcheck:
+      test:
+        - "CMD-SHELL"
+        - "grep -qx '1' /proc/sys/net/ipv4/ip_forward && iptables -C FORWARD -s 10.0.0.0/24 -d 10.0.1.0/24 -j ACCEPT >/dev/null 2>&1 && iptables -t nat -C POSTROUTING -s 10.0.0.0/24 -d 10.0.1.0/24 -j MASQUERADE >/dev/null 2>&1"
+      interval: 10s
+      timeout: 5s
+      retries: 12
     restart: unless-stopped
 
   web:
@@ -101,7 +124,9 @@ services:
       management:
         ipv4_address: 10.0.3.10
     healthcheck:
-      test: ["CMD", "curl", "-sf", "http://localhost/"]
+      test:
+        - "CMD-SHELL"
+        - "status=$(curl -s -o /dev/null -w '%{http_code}' http://localhost/ || true); case \"$$status\" in 2*|3*|4*) exit 0;; *) exit 1;; esac"
       interval: 10s
       timeout: 5s
       retries: 3

--- a/src/open_range/server/runtime.py
+++ b/src/open_range/server/runtime.py
@@ -896,16 +896,36 @@ class ManagedSnapshotRuntime:
             topology["snapshot_id"] = snapshot_id
             rendered.topology = topology
             self.renderer.render(rendered, snapshot_dir)
+            compose_path = snapshot_dir / "docker-compose.yml"
+            rendered.compose = yaml.safe_load(compose_path.read_text(encoding="utf-8")) or {}
 
-            compose_file = snapshot_dir / "docker-compose.yml"
-            up_result = self._compose_up(snapshot_dir, compose_file, project_name)
-            if up_result is not None:
-                return up_result
+            project: BootedSnapshotProject | None = None
+            try:
+                project = self.compose_runner.boot(
+                    snapshot_id=snapshot_id,
+                    artifacts_dir=snapshot_dir,
+                    compose=rendered.compose,
+                    project_name=project_name,
+                )
+            except Exception as exc:  # noqa: BLE001
+                self._best_effort_teardown_validation_project(
+                    snapshot_dir=snapshot_dir,
+                    project_name=project_name,
+                )
+                return ValidationResult(
+                    passed=False,
+                    checks=[
+                        CheckResult(
+                            name="build_boot",
+                            passed=False,
+                            error=str(exc),
+                        )
+                    ],
+                )
 
             try:
-                containers = self._discover_containers(project_name)
-                self._deploy_snapshot_artifacts(rendered, containers, snapshot_dir)
-                return _run_coro_sync(self.validator.validate(rendered, containers))
+                self._deploy_snapshot_artifacts(rendered, project.containers, snapshot_dir)
+                return _run_coro_sync(self.validator.validate(rendered, project.containers))
             except Exception as exc:  # noqa: BLE001
                 return ValidationResult(
                     passed=False,
@@ -918,7 +938,37 @@ class ManagedSnapshotRuntime:
                     ],
                 )
             finally:
-                self._compose_down(snapshot_dir, compose_file, project_name)
+                if project is not None:
+                    try:
+                        self.compose_runner.teardown(project)
+                    except Exception:  # noqa: BLE001
+                        logger.warning(
+                            "Failed to tear down validation project %s",
+                            project.project_name,
+                        )
+
+    def _best_effort_teardown_validation_project(
+        self,
+        *,
+        snapshot_dir: Path,
+        project_name: str,
+    ) -> None:
+        """Tear down a failed validation project when boot aborts mid-flight."""
+        compose_file = snapshot_dir / "docker-compose.yml"
+        try:
+            self.compose_runner.teardown(
+                BootedSnapshotProject(
+                    project_name=project_name,
+                    compose_file=compose_file,
+                    artifacts_dir=snapshot_dir,
+                    containers=ContainerSet(project_name=project_name),
+                )
+            )
+        except Exception:  # noqa: BLE001
+            logger.warning(
+                "Failed to tear down validation project %s after boot failure",
+                project_name,
+            )
 
     def _project_name(self, snapshot_id: str) -> str:
         safe = "".join(ch if ch.isalnum() else "-" for ch in snapshot_id.lower()).strip("-")

--- a/src/open_range/validator/exploitability.py
+++ b/src/open_range/validator/exploitability.py
@@ -12,6 +12,10 @@ logger = logging.getLogger(__name__)
 _META_COMMANDS = {"submit_flag", "submit_evidence", "submit_finding", "auth", "logout"}
 
 
+def _collapse_whitespace(value: str) -> str:
+    return " ".join(value.split())
+
+
 class ExploitabilityCheck:
     """Execute every golden-path step and verify ``expect_in_stdout`` appears."""
 
@@ -75,7 +79,7 @@ class ExploitabilityCheck:
                         message,
                     )
                     unvalidated_steps.append(step.step)
-            elif expected not in output:
+            elif expected not in output and _collapse_whitespace(expected) not in _collapse_whitespace(output):
                 failed_steps.append({
                     "step": step.step,
                     "expected": expected,

--- a/tests/test_builder.py
+++ b/tests/test_builder.py
@@ -125,6 +125,49 @@ async def test_template_builder_avoids_previous_vulns(tier1_manifest):
 
 
 @pytest.mark.asyncio
+async def test_template_builder_live_admission_hints_skip_unreachable_weak_creds(tier1_manifest):
+    from open_range.builder.builder import TemplateOnlyBuilder
+
+    builder = TemplateOnlyBuilder()
+    manifest = {
+        **tier1_manifest,
+        "bug_families": ["weak_creds", "sqli"],
+        "difficulty": {**tier1_manifest.get("difficulty", {}), "min_vulns": 1, "max_vulns": 1},
+    }
+    ctx = BuildContext(
+        seed=3,
+        tier=1,
+        narrative_hints=["prefer_live_admission_compatible_vulns"],
+    )
+    spec = await builder.build(manifest, ctx)
+    assert [v.type for v in spec.truth_graph.vulns] == ["sqli"]
+
+
+@pytest.mark.asyncio
+async def test_template_builder_live_admission_vulns_have_executable_remediations(tier1_manifest):
+    from open_range.builder.builder import TemplateOnlyBuilder
+    from open_range.validator.patchability import _looks_executable
+
+    builder = TemplateOnlyBuilder()
+    manifest = {
+        **tier1_manifest,
+        "bug_families": ["path_traversal", "sqli"],
+        "difficulty": {**tier1_manifest.get("difficulty", {}), "min_vulns": 2, "max_vulns": 2},
+    }
+    spec = await builder.build(
+        manifest,
+        BuildContext(
+            seed=4,
+            tier=1,
+            narrative_hints=["prefer_live_admission_compatible_vulns"],
+        ),
+    )
+    assert {v.type for v in spec.truth_graph.vulns} == {"path_traversal", "sqli"}
+    assert all(_looks_executable(v.remediation) for v in spec.truth_graph.vulns)
+    assert len({flag.path for flag in spec.flags}) == len(spec.flags)
+
+
+@pytest.mark.asyncio
 async def test_template_builder_deterministic_with_seed(tier1_manifest):
     from open_range.builder.builder import TemplateOnlyBuilder
 
@@ -520,6 +563,30 @@ async def test_mutator_fails_fast_on_illegal_add_service_target(tier1_manifest):
             parent_snapshot=parent,
             parent_snapshot_id="root_snap",
         )
+
+
+@pytest.mark.asyncio
+async def test_mutator_live_only_templates_exclude_weak_creds(tier1_manifest):
+    from open_range.builder.builder import TemplateOnlyBuilder
+    from open_range.builder.mutator import Mutator
+
+    mutator = Mutator(TemplateOnlyBuilder())
+    root = await mutator.mutate(
+        tier1_manifest,
+        context=BuildContext(seed=1, tier=1),
+    )
+    templates = mutator._compatible_vuln_templates(  # type: ignore[attr-defined]
+        root,
+        BuildContext(
+            seed=2,
+            tier=1,
+            narrative_hints=["prefer_live_admission_compatible_vulns"],
+        ),
+    )
+    assert templates
+    assert {template["type"] for template in templates}.issubset(
+        {"sqli", "path_traversal"}
+    )
 
 
 # ---------------------------------------------------------------------------

--- a/tests/test_renderer.py
+++ b/tests/test_renderer.py
@@ -270,6 +270,32 @@ def test_compose_web_depends_on_db(renderer, sqli_spec):
         assert "depends_on:" in compose
 
 
+def test_compose_web_healthcheck_accepts_pre_overlay_http_statuses(renderer, sqli_spec):
+    with tempfile.TemporaryDirectory() as tmpdir:
+        out = Path(tmpdir) / "out"
+        renderer.render(sqli_spec, out)
+        compose = (out / "docker-compose.yml").read_text()
+        assert "CMD-SHELL" in compose
+        assert "http://localhost/ || true" in compose
+        assert '$$status' in compose
+        assert '2*|3*|4*) exit 0' in compose
+        assert 'curl", "-sf", "http://localhost/"' not in compose
+
+
+def test_compose_attacker_has_routed_host_aliases_and_nmap_runtime_lib(renderer, sqli_spec):
+    with tempfile.TemporaryDirectory() as tmpdir:
+        out = Path(tmpdir) / "out"
+        renderer.render(sqli_spec, out)
+        compose = (out / "docker-compose.yml").read_text()
+        assert "libblas3 nmap" in compose
+        assert 'extra_hosts:' in compose
+        assert '"web:10.0.1.10"' in compose
+        assert '"db:10.0.2.20"' in compose
+        assert '"files:10.0.2.21"' in compose
+        assert "nmap --version" in compose
+        assert "iptables -C FORWARD" in compose
+
+
 # ---------------------------------------------------------------------------
 # Dockerfile.web content checks
 # ---------------------------------------------------------------------------
@@ -333,6 +359,16 @@ def test_nginx_no_download_for_sqli(renderer, sqli_spec):
         nginx = (out / "nginx.conf").read_text()
         # The download location block should not be rendered
         assert "download.php" not in nginx
+
+
+def test_compose_firewall_nat_is_subnet_based(renderer, sqli_spec):
+    with tempfile.TemporaryDirectory() as tmpdir:
+        out = Path(tmpdir) / "out"
+        renderer.render(sqli_spec, out)
+        compose = (out / "docker-compose.yml").read_text()
+        assert "-s 10.0.0.0/24 -d 10.0.1.0/24 -j MASQUERADE" in compose
+        assert "-s 10.0.1.0/24 -d 10.0.2.0/24 -j MASQUERADE" in compose
+        assert "-o eth1 -j MASQUERADE" not in compose
 
 
 # ---------------------------------------------------------------------------

--- a/tests/test_renderer_integration.py
+++ b/tests/test_renderer_integration.py
@@ -203,6 +203,14 @@ class TestDockerCompose:
         compose = (rendered_dir / "docker-compose.yml").read_text()
         assert "healthcheck:" in compose
 
+    def test_web_healthcheck_does_not_require_pre_overlay_2xx(self, rendered_dir):
+        compose = (rendered_dir / "docker-compose.yml").read_text()
+        assert "CMD-SHELL" in compose
+        assert "http://localhost/ || true" in compose
+        assert "$$status" in compose
+        assert '2*|3*|4*) exit 0' in compose
+        assert 'curl", "-sf", "http://localhost/"' not in compose
+
     def test_attacker_has_net_admin(self, rendered_dir):
         compose = (rendered_dir / "docker-compose.yml").read_text()
         assert "NET_ADMIN" in compose

--- a/tests/test_runtime.py
+++ b/tests/test_runtime.py
@@ -412,6 +412,89 @@ class TestManagedSnapshotRuntime:
         finally:
             runtime.stop()
 
+    def test_training_live_validation_uses_compose_runner_boot(
+        self,
+        tier1_manifest,
+        tmp_path,
+    ):
+        class FakeContainers:
+            def __init__(self) -> None:
+                self.exec_calls: list[tuple[str, str]] = []
+                self.cp_calls: list[tuple[str, str, str]] = []
+
+            async def exec(self, container: str, cmd: str, **kwargs) -> str:
+                self.exec_calls.append((container, cmd))
+                return "ok"
+
+            async def cp(self, container: str, src: str, dest: str) -> None:
+                self.cp_calls.append((container, src, dest))
+
+            async def is_healthy(self, container: str) -> bool:
+                return True
+
+        class FakeComposeRunner:
+            def __init__(self) -> None:
+                self.boot_calls: list[tuple[str, str, str | None]] = []
+                self.compose_payloads: list[dict[str, object]] = []
+                self.teardown_calls: list[str] = []
+                self.containers = FakeContainers()
+
+            def boot(self, *, snapshot_id, artifacts_dir, compose, project_name=None):
+                self.boot_calls.append((snapshot_id, str(artifacts_dir), project_name))
+                self.compose_payloads.append(compose)
+                return BootedSnapshotProject(
+                    project_name=project_name or f"openrange-{snapshot_id}",
+                    compose_file=artifacts_dir / "docker-compose.yml",
+                    artifacts_dir=artifacts_dir,
+                    containers=self.containers,  # type: ignore[arg-type]
+                )
+
+            def teardown(self, project):
+                self.teardown_calls.append(project.project_name)
+
+        class FakeTrainingValidator:
+            def __init__(self) -> None:
+                self.calls: list[tuple[SnapshotSpec, object]] = []
+
+            async def validate(self, snapshot, containers):
+                self.calls.append((snapshot, containers))
+                return ValidationResult(
+                    passed=True,
+                    checks=[CheckResult(name="build_boot", passed=True)],
+                    total_time_s=0.0,
+                )
+
+        compose_runner = FakeComposeRunner()
+        validator = FakeTrainingValidator()
+        runtime = ManagedSnapshotRuntime(
+            manifest=tier1_manifest,
+            store_dir=tmp_path / "snapshots",
+            validator_profile="training",
+            pool_size=1,
+            refill_enabled=False,
+            compose_runner=compose_runner,  # type: ignore[arg-type]
+            validator=validator,  # type: ignore[arg-type]
+        )
+
+        runtime.start()
+        try:
+            listing = runtime.list_snapshots()
+            assert listing
+            assert compose_runner.boot_calls
+            snapshot_id, artifacts_dir, project_name = compose_runner.boot_calls[0]
+            assert Path(artifacts_dir).name.startswith(f"openrange-validate-{snapshot_id}")
+            expected_project_name = runtime._project_name(snapshot_id)
+            assert project_name == expected_project_name
+            assert compose_runner.compose_payloads[0]["services"]
+            assert compose_runner.teardown_calls == [expected_project_name]
+            assert validator.calls
+            assert any(
+                dest.endswith("/var/www/portal/index.php")
+                for _, _, dest in compose_runner.containers.cp_calls
+            )
+        finally:
+            runtime.stop()
+
     def test_activate_snapshot_project_uses_unique_episode_project_name(
         self,
         tier1_manifest,

--- a/tests/test_validator.py
+++ b/tests/test_validator.py
@@ -290,6 +290,27 @@ async def test_exploitability_passes_when_golden_path_succeeds(mock_containers):
 
 
 @pytest.mark.asyncio
+async def test_exploitability_normalizes_whitespace_for_tool_output(mock_containers):
+    from open_range.validator.exploitability import ExploitabilityCheck
+
+    spec = SnapshotSpec(
+        golden_path=[
+            GoldenPathStep(
+                step=1,
+                command="nmap -sV 10.0.1.0/24",
+                expect_in_stdout="80/tcp open http",
+            ),
+        ],
+    )
+    mock_containers.exec_results[("attacker", "nmap -sV 10.0.1.0/24")] = (
+        "80/tcp   open  http   nginx"
+    )
+
+    result = await ExploitabilityCheck().check(spec, mock_containers)
+    assert result.passed is True
+
+
+@pytest.mark.asyncio
 async def test_exploitability_fails_when_step_output_missing(
     sample_snapshot_spec, mock_containers
 ):


### PR DESCRIPTION
Closes #96

## Summary
- validate live snapshots against the rendered compose bundle and compose-runner boot path
- relax the web healthcheck and harden runtime networking/readiness for live admission
- constrain live-admission templates to reachable scenarios and make validator matching/remediation checks reliable

## Tests
- targeted pytest sweep for builder/renderer/runtime/validator coverage