### PR TITLE
fix(npc): normalize compiled topology hosts

### DIFF
--- a/src/open_range/builder/npc/npc_manager.py
+++ b/src/open_range/builder/npc/npc_manager.py
@@ -52,8 +52,59 @@ _ROLE_SERVICE_KEYWORDS: dict[str, list[str]] = {
 
 
 def _hosts_from_topology(topology: dict[str, Any]) -> list[dict[str, Any]]:
-    """Extract the list of host dicts from *topology*, tolerating missing keys."""
-    return topology.get("hosts") or []
+    """Return normalized host dicts for compiled or manifest-style topology.
+
+    ``compile_manifest_topology()`` canonicalizes ``topology["hosts"]`` to a
+    list of host names and keeps the richer metadata in ``host_catalog`` /
+    ``host_details``. NPC helpers need the richer dict shape, so normalize the
+    compiled form back into ``{"name": ..., "services": ...}`` records here.
+    """
+    raw_hosts = topology.get("hosts") or []
+    host_catalog = topology.get("host_catalog")
+    if not isinstance(host_catalog, dict):
+        host_catalog = {}
+    host_details = topology.get("host_details")
+    if not isinstance(host_details, dict):
+        host_details = {}
+
+    hosts: list[dict[str, Any]] = []
+    seen: set[str] = set()
+
+    def _append_host(raw_host: Any) -> None:
+        if isinstance(raw_host, dict):
+            name = str(raw_host.get("name", "")).strip()
+        else:
+            name = str(raw_host).strip()
+        if not name or name in seen:
+            return
+
+        merged: dict[str, Any] = {}
+        catalog_detail = host_catalog.get(name)
+        if isinstance(catalog_detail, dict):
+            merged.update(catalog_detail)
+        detailed_detail = host_details.get(name)
+        if isinstance(detailed_detail, dict):
+            merged.update(detailed_detail)
+        if isinstance(raw_host, dict):
+            merged.update(raw_host)
+
+        merged["name"] = name
+        services = merged.get("services")
+        merged["services"] = list(services) if isinstance(services, list) else []
+        seen.add(name)
+        hosts.append(merged)
+
+    if isinstance(raw_hosts, list):
+        for raw_host in raw_hosts:
+            _append_host(raw_host)
+
+    for name in host_catalog:
+        _append_host(name)
+
+    for name in host_details:
+        _append_host(name)
+
+    return hosts
 
 
 def _host_matches_keywords(host: dict[str, Any], keywords: list[str]) -> bool:

--- a/tests/test_npc_channels.py
+++ b/tests/test_npc_channels.py
@@ -18,7 +18,12 @@ from open_range.builder.npc.channels import (
     VoiceTranscript,
 )
 from open_range.builder.npc.chat_traffic import generate_chat_traffic
-from open_range.builder.npc.npc_manager import NPCManager
+from open_range.builder.npc.npc_manager import (
+    NPCManager,
+    _derive_scripts_from_topology,
+    _hosts_from_topology,
+    _resolve_env_vars,
+)
 from open_range.protocols import NPCPersona, NPCTrafficSpec, SnapshotSpec, TaskSpec
 
 
@@ -331,3 +336,58 @@ class TestChannelSIEM:
         assert "chat" in mgr.channels
         assert "voice" in mgr.channels
         assert "document" in mgr.channels
+
+
+class TestTopologyNormalization:
+    def test_hosts_from_topology_normalizes_compiled_host_names(self):
+        topology = {
+            "hosts": ["web", "db"],
+            "host_catalog": {
+                "web": {"zone": "dmz", "services": ["nginx", "php-fpm"]},
+                "db": {"zone": "internal", "services": ["mysql"]},
+            },
+        }
+
+        hosts = _hosts_from_topology(topology)
+
+        assert [host["name"] for host in hosts] == ["web", "db"]
+        assert hosts[0]["services"] == ["nginx", "php-fpm"]
+        assert hosts[1]["services"] == ["mysql"]
+
+    def test_helpers_accept_compiled_topology_host_names(self):
+        topology = {
+            "hosts": ["web", "db", "mail", "siem"],
+            "host_catalog": {
+                "web": {"services": ["nginx", "php-fpm"]},
+                "db": {"services": ["mysql"]},
+                "mail": {"services": ["postfix"]},
+                "siem": {"services": ["rsyslog"]},
+            },
+            "users": [
+                {
+                    "username": "svc_db",
+                    "password": "SvcDb!401",
+                    "hosts": ["db"],
+                    "role": "service",
+                },
+                {
+                    "username": "admin",
+                    "password": "Adm1n!2024",
+                    "hosts": ["web", "siem"],
+                    "role": "admin",
+                },
+            ],
+        }
+
+        scripts = _derive_scripts_from_topology(topology)
+        env = _resolve_env_vars(topology, rate_lambda=10.0)
+
+        assert "http_traffic.sh" in scripts
+        assert "db_traffic.sh" in scripts
+        assert "smtp_traffic.sh" in scripts
+        assert env["WEB_HOST"] == "web"
+        assert env["DB_HOST"] == "db"
+        assert env["MAIL_HOST"] == "mail"
+        assert env["SIEM_HOST"] == "siem"
+        assert env["DB_USER"] == "svc_db"
+        assert env["SSH_USER"] == "admin"


### PR DESCRIPTION
Closes #101

## Summary
- normalize compiled topology host entries before NPC helpers inspect them
- make NPC script/env resolution tolerate topology["hosts"] as plain host names
- add focused coverage for compiled-topology NPC helper behavior