### PR TITLE
Fix live runtime crashers before merge

### DIFF
--- a/scripts/eval_model_rollouts.py
+++ b/scripts/eval_model_rollouts.py
@@ -29,6 +29,7 @@ from open_range.runtime import ReferenceDrivenRuntime
 from open_range.snapshot import RuntimeSnapshot
 from open_range.store import FileSnapshotStore
 from open_range.training_data import (
+    TraceCandidate,
     TraceLineage,
     build_decision_prompt,
     render_candidate_completion,

--- a/src/open_range/cluster.py
+++ b/src/open_range/cluster.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import asyncio
 import logging
 import shutil
 import subprocess
@@ -38,7 +39,7 @@ class ExecResult:
         return not self.timed_out and self.exit_code == 0
 
 
-@dataclass(frozen=True, slots=True)
+@dataclass(slots=True)
 class PodSet:
     """Handle to live pods for one admitted release."""
 

--- a/src/open_range/execution.py
+++ b/src/open_range/execution.py
@@ -276,7 +276,9 @@ class PodActionBackend:
             ".\n"
             "QUIT\n"
         )
-        return f"printf %s {shlex.quote(payload)} | nc -w 3 {shlex.quote(target)} {port}"
+        return (
+            f"printf %s {shlex.quote(payload)} | nc -w 3 {shlex.quote(target)} {port}"
+        )
 
     def _is_contained(self, target: str) -> bool:
         release = self._require_release()
@@ -328,7 +330,9 @@ class PodActionBackend:
 
     def _weakness_for(self, target: str) -> WeaknessSpec | None:
         snapshot = self._require_snapshot()
-        return next((weak for weak in snapshot.world.weaknesses if weak.target == target), None)
+        return next(
+            (weak for weak in snapshot.world.weaknesses if weak.target == target), None
+        )
 
     def _require_release(self) -> BootedRelease:
         if self._release is None:
@@ -339,6 +343,7 @@ class PodActionBackend:
         if self._snapshot is None:
             raise RuntimeError("no active snapshot is bound")
         return self._snapshot
+
 
 def _green_sandbox_name(persona_id: str) -> str:
     safe = "".join(ch.lower() if ch.isalnum() else "-" for ch in persona_id).strip("-")

--- a/src/open_range/execution.py
+++ b/src/open_range/execution.py
@@ -110,7 +110,7 @@ class PodActionBackend:
         }
 
     def _execute_control(self, action: Action) -> ActionExecution:
-        assert self._release is not None
+        release = self._require_release()
         target = action_target(action)
         directive = str(action.payload.get("action", "contain")).lower()
         if target not in self._service_by_id:
@@ -125,7 +125,7 @@ class PodActionBackend:
             command = self._patch_command_for(target)
         else:
             command = "touch /tmp/openrange-contained"
-        result = run_async(self._release.pods.exec(target, command, timeout=action.timeout_s))
+        result = run_async(release.pods.exec(target, command, timeout=action.timeout_s))
         return ActionExecution(
             stdout=result.stdout.strip(),
             stderr=result.stderr.strip(),
@@ -137,7 +137,7 @@ class PodActionBackend:
         )
 
     def _run_in_runner(self, action: Action, command: str) -> ActionExecution:
-        assert self._release is not None
+        release = self._require_release()
         if not command:
             return ActionExecution(
                 stderr="no command provided",
@@ -159,7 +159,7 @@ class PodActionBackend:
                     service_health=self.service_health(),
                 )
         runner = self._runner_for(action)
-        result = run_async(self._release.pods.exec(runner, command, timeout=action.timeout_s))
+        result = run_async(release.pods.exec(runner, command, timeout=action.timeout_s))
         return ActionExecution(
             stdout=result.stdout.strip(),
             stderr=result.stderr.strip(),
@@ -168,7 +168,7 @@ class PodActionBackend:
         )
 
     def _run_on_target_service(self, action: Action, command: str) -> ActionExecution:
-        assert self._release is not None
+        release = self._require_release()
         target = action_target(action)
         if not target or target not in self._service_by_id:
             return ActionExecution(
@@ -188,7 +188,7 @@ class PodActionBackend:
                 ok=False,
                 service_health=self.service_health(),
             )
-        result = run_async(self._release.pods.exec(target, command, timeout=action.timeout_s))
+        result = run_async(release.pods.exec(target, command, timeout=action.timeout_s))
         return ActionExecution(
             stdout=result.stdout.strip(),
             stderr=result.stderr.strip(),
@@ -254,34 +254,34 @@ class PodActionBackend:
         if service is None:
             return f"echo unknown mail target {target}; exit 1"
         port = service.ports[0] if service.ports else 25
-        sender = action.payload.get("from", action.actor_id)
-        recipient = action.payload.get("to", "noreply@corp.local")
-        subject = action.payload.get("subject", "routine update")
-        return (
-            "printf 'HELO corp.local\\nMAIL FROM:<{sender}>\\nRCPT TO:<{recipient}>\\nDATA\\n"
-            "Subject: {subject}\\n\\nOpenRange test mail.\\n.\\nQUIT\\n' | "
-            "nc -w 3 {target} {port}"
-        ).format(
-            sender=sender,
-            recipient=recipient,
-            subject=subject,
-            target=target,
-            port=port,
+        sender = str(action.payload.get("from", action.actor_id))
+        recipient = str(action.payload.get("to", "noreply@corp.local"))
+        subject = str(action.payload.get("subject", "routine update"))
+        payload = (
+            "HELO corp.local\n"
+            f"MAIL FROM:<{sender}>\n"
+            f"RCPT TO:<{recipient}>\n"
+            "DATA\n"
+            f"Subject: {subject}\n\n"
+            "OpenRange test mail.\n"
+            ".\n"
+            "QUIT\n"
         )
+        return f"printf %s {shlex.quote(payload)} | nc -w 3 {shlex.quote(target)} {port}"
 
     def _is_contained(self, target: str) -> bool:
-        assert self._release is not None
+        release = self._require_release()
         result = run_async(
-            self._release.pods.exec(target, "test ! -f /tmp/openrange-contained", timeout=5.0)
+            release.pods.exec(target, "test ! -f /tmp/openrange-contained", timeout=5.0)
         )
         return not result.ok
 
     def _is_patched(self, target: str) -> bool:
-        assert self._release is not None
+        release = self._require_release()
         weakness = self._weakness_for(target)
         if weakness is not None and weakness.family == "code_web":
             result = run_async(
-                self._release.pods.exec(
+                release.pods.exec(
                     target,
                     f"test ! -f {shlex.quote(code_web_guard_path(weakness))}",
                     timeout=5.0,
@@ -289,7 +289,7 @@ class PodActionBackend:
             )
             return not result.ok
         result = run_async(
-            self._release.pods.exec(target, "test ! -f /tmp/openrange-patched", timeout=5.0)
+            release.pods.exec(target, "test ! -f /tmp/openrange-patched", timeout=5.0)
         )
         return not result.ok
 
@@ -314,8 +314,18 @@ class PodActionBackend:
         return " && ".join(cleanup)
 
     def _weakness_for(self, target: str) -> WeaknessSpec | None:
-        assert self._snapshot is not None
-        return next((weak for weak in self._snapshot.world.weaknesses if weak.target == target), None)
+        snapshot = self._require_snapshot()
+        return next((weak for weak in snapshot.world.weaknesses if weak.target == target), None)
+
+    def _require_release(self) -> BootedRelease:
+        if self._release is None:
+            raise RuntimeError("no live release is bound")
+        return self._release
+
+    def _require_snapshot(self) -> RuntimeSnapshot:
+        if self._snapshot is None:
+            raise RuntimeError("no active snapshot is bound")
+        return self._snapshot
 
 def _green_sandbox_name(persona_id: str) -> str:
     safe = "".join(ch.lower() if ch.isalnum() else "-" for ch in persona_id).strip("-")

--- a/src/open_range/runtime.py
+++ b/src/open_range/runtime.py
@@ -845,8 +845,7 @@ class ReferenceDrivenRuntime:
         return f"{self._briefing_text(actor)}\n{base}"
 
     def _briefing_text(self, actor: ExternalRole) -> str:
-        assert self._snapshot is not None
-        world = self._snapshot.world
+        world = self._require_snapshot().world
         objectives = world.red_objectives if actor == "red" else world.blue_objectives
         public_services = ",".join(service.id for service in world.services if self._predicates and self._predicates.is_public_service(service))
         lines = [
@@ -976,14 +975,17 @@ class ReferenceDrivenRuntime:
         return next((weakness for weakness in self._predicates.active_weaknesses() if weakness.id == weakness_id), None)
 
     def _reference_attack_trace(self):
-        assert self._snapshot is not None
-        traces = self._snapshot.reference_bundle.reference_attack_traces
+        traces = self._require_snapshot().reference_bundle.reference_attack_traces
         return traces[self._reference_attack_index % len(traces)]
 
     def _reference_defense_trace(self):
-        assert self._snapshot is not None
-        traces = self._snapshot.reference_bundle.reference_defense_traces
+        traces = self._require_snapshot().reference_bundle.reference_defense_traces
         return traces[self._reference_defense_index % len(traces)]
+
+    def _require_snapshot(self) -> RuntimeSnapshot:
+        if self._snapshot is None:
+            raise RuntimeError("runtime has no active snapshot")
+        return self._snapshot
 
     def _resolve_reference_index(
         self,

--- a/tests/test_cluster.py
+++ b/tests/test_cluster.py
@@ -1,0 +1,35 @@
+from __future__ import annotations
+
+from open_range.async_utils import run_async
+from open_range.cluster import PodSet
+import open_range.cluster as cluster_mod
+
+
+class _FakeProc:
+    def __init__(self, stdout: bytes = b"True", stderr: bytes = b"") -> None:
+        self.returncode = 0
+        self._stdout = stdout
+        self._stderr = stderr
+
+    async def communicate(self):
+        return self._stdout, self._stderr
+
+
+def test_podset_is_healthy_uses_async_kubectl(monkeypatch) -> None:
+    async def fake_create_subprocess_exec(*args, **kwargs):
+        del args, kwargs
+        return _FakeProc()
+
+    podset = PodSet(project_name="or-demo", pod_ids={"svc-web": "ns/svc-web-pod"})
+    monkeypatch.setattr(PodSet, "_discover_current_ref", lambda self, service: "")
+    monkeypatch.setattr(cluster_mod.asyncio, "create_subprocess_exec", fake_create_subprocess_exec)
+
+    assert run_async(podset.is_healthy("svc-web")) is True
+
+
+def test_podset_resolve_caches_discovered_refs(monkeypatch) -> None:
+    podset = PodSet(project_name="or-demo")
+    monkeypatch.setattr(PodSet, "_discover_current_ref", lambda self, service: "ns/svc-web-pod")
+
+    assert podset._resolve("svc-web") == ("ns", "svc-web-pod")
+    assert podset.pod_ids["svc-web"] == "ns/svc-web-pod"

--- a/tests/test_cluster.py
+++ b/tests/test_cluster.py
@@ -22,14 +22,18 @@ def test_podset_is_healthy_uses_async_kubectl(monkeypatch) -> None:
 
     podset = PodSet(project_name="or-demo", pod_ids={"svc-web": "ns/svc-web-pod"})
     monkeypatch.setattr(PodSet, "_discover_current_ref", lambda self, service: "")
-    monkeypatch.setattr(cluster_mod.asyncio, "create_subprocess_exec", fake_create_subprocess_exec)
+    monkeypatch.setattr(
+        cluster_mod.asyncio, "create_subprocess_exec", fake_create_subprocess_exec
+    )
 
     assert run_async(podset.is_healthy("svc-web")) is True
 
 
 def test_podset_resolve_caches_discovered_refs(monkeypatch) -> None:
     podset = PodSet(project_name="or-demo")
-    monkeypatch.setattr(PodSet, "_discover_current_ref", lambda self, service: "ns/svc-web-pod")
+    monkeypatch.setattr(
+        PodSet, "_discover_current_ref", lambda self, service: "ns/svc-web-pod"
+    )
 
     assert podset._resolve("svc-web") == ("ns", "svc-web-pod")
     assert podset.pod_ids["svc-web"] == "ns/svc-web-pod"

--- a/tests/test_execution.py
+++ b/tests/test_execution.py
@@ -46,7 +46,10 @@ def test_mail_command_quotes_smtp_payload_and_target() -> None:
 
     command = backend._mail_command(action)
 
-    assert command == f"printf %s {shlex.quote(payload)} | nc -w 3 {shlex.quote('svc-email')} 25"
+    assert (
+        command
+        == f"printf %s {shlex.quote(payload)} | nc -w 3 {shlex.quote('svc-email')} 25"
+    )
 
 
 def test_execution_helpers_raise_clear_errors_when_unbound() -> None:

--- a/tests/test_execution.py
+++ b/tests/test_execution.py
@@ -1,0 +1,58 @@
+from __future__ import annotations
+
+import shlex
+
+import pytest
+
+from open_range.execution import PodActionBackend
+from open_range.runtime_types import Action
+from open_range.world_ir import ServiceSpec
+
+
+def test_mail_command_quotes_smtp_payload_and_target() -> None:
+    backend = PodActionBackend()
+    backend._service_by_id = {
+        "svc-email": ServiceSpec(
+            id="svc-email",
+            kind="email",
+            host="mail-1",
+            ports=(25,),
+            dependencies=(),
+            telemetry_surfaces=(),
+        )
+    }
+    action = Action(
+        actor_id="red",
+        role="red",
+        kind="mail",
+        payload={
+            "target": "svc-email",
+            "from": "attacker\n; rm -rf /",
+            "to": "victim@corp.local",
+            "subject": "hi'; touch /tmp/pwned #",
+        },
+    )
+
+    payload = (
+        "HELO corp.local\n"
+        "MAIL FROM:<attacker\n; rm -rf />\n"
+        "RCPT TO:<victim@corp.local>\n"
+        "DATA\n"
+        "Subject: hi'; touch /tmp/pwned #\n\n"
+        "OpenRange test mail.\n"
+        ".\n"
+        "QUIT\n"
+    )
+
+    command = backend._mail_command(action)
+
+    assert command == f"printf %s {shlex.quote(payload)} | nc -w 3 {shlex.quote('svc-email')} 25"
+
+
+def test_execution_helpers_raise_clear_errors_when_unbound() -> None:
+    backend = PodActionBackend()
+
+    with pytest.raises(RuntimeError, match="no live release is bound"):
+        backend._is_contained("svc-web")
+    with pytest.raises(RuntimeError, match="no active snapshot is bound"):
+        backend._weakness_for("svc-web")

--- a/tests/test_model_rollouts.py
+++ b/tests/test_model_rollouts.py
@@ -3,6 +3,7 @@ from __future__ import annotations
 import importlib.util
 import sys
 from pathlib import Path
+from typing import get_type_hints
 
 from open_range._runtime_store import hydrate_runtime_snapshot
 from open_range.admit import LocalAdmissionController
@@ -79,3 +80,11 @@ def test_teacher_pick_rate_counts_teacher_labels() -> None:
     )
 
     assert rate == 2 / 3
+
+
+def test_model_rollout_score_candidates_type_hints_resolve() -> None:
+    mod = _load_module("eval_model_rollouts_hints", "scripts/eval_model_rollouts.py")
+
+    hints = get_type_hints(mod.score_candidates, globalns=vars(mod), localns=vars(mod))
+
+    assert "return" in hints

--- a/tests/test_runtime.py
+++ b/tests/test_runtime.py
@@ -228,6 +228,17 @@ def test_runtime_matching_rejects_extra_api_path_when_reference_has_no_path() ->
     assert ReferenceDrivenRuntime._matches_step(action, expected, "ok") is False
 
 
+def test_runtime_internal_snapshot_helpers_raise_clear_errors_without_reset() -> None:
+    runtime = ReferenceDrivenRuntime()
+
+    with pytest.raises(RuntimeError, match="runtime has no active snapshot"):
+        runtime._briefing_text("red")
+    with pytest.raises(RuntimeError, match="runtime has no active snapshot"):
+        runtime._reference_attack_trace()
+    with pytest.raises(RuntimeError, match="runtime has no active snapshot"):
+        runtime._reference_defense_trace()
+
+
 def test_runtime_live_containment_blocks_future_red_step(tmp_path: Path):
     snapshot = _snapshot(tmp_path)
 


### PR DESCRIPTION
Closes #115

## Summary
- import `asyncio` for live pod execution and make `PodSet` explicitly mutable as a cache
- replace assert-based live/runtime guards with explicit runtime errors
- shell-quote SMTP payload delivery and import `TraceCandidate` in rollout eval
- add focused regressions for pod health, mail quoting, and missing-snapshot behavior