### PR TITLE
Document uv workflow in AGENTS

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -139,6 +139,20 @@ contract, especially around:
 - hydrated runtime snapshots
 - multi-reference support
 
+## Local Dev Workflow
+
+Prefer `uv run` for Python commands in this repo.
+
+- use `uv run -m pytest`, `uv run -m open_range.cli`, and similar module entrypoints
+- do not use `source .venv/bin/activate` for normal development flows
+- do not fall back to raw `python -m ...` when `uv run -m ...` is available
+- if Codex does not see `uv` on `PATH`, resolve the machine's local `uv` path first instead of falling back to venv activation
+- run `docker` and `kind` directly, without wrapping them in Python env activation
+
+## PR Targeting
+
+Default pull requests for this repo should target `v1`, not `main`, unless the user explicitly asks otherwise.
+
 ## Review Priorities
 
 When reviewing or changing code, prioritize:


### PR DESCRIPTION
## Summary
- add local guidance to prefer `uv run -m ...` for Python commands
- discourage manual venv activation for normal workflows
- document that PRs should target `v1` by default

## Testing
- docs only