### PR TITLE
Add PR template and contributing guide

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,0 +1,29 @@
+<!--
+Inspired by lightweight templates used in projects like uv and Zed.
+Keep this PR body concise and review-friendly.
+-->
+
+Closes #
+
+## Summary
+
+<!-- What changed, and why? -->
+
+## Testing
+
+<!--
+Keep verification terse:
+- list the command(s) you ran
+- mark each as pass/fail
+- if something was not run, say why
+- do not paste long terminal transcripts
+-->
+
+- Not run
+
+## Review Notes
+
+<!--
+Optional. Call out non-obvious tradeoffs, follow-up work, or reviewer focus areas.
+Delete this section if there is nothing special to flag.
+-->

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -139,27 +139,28 @@ contract, especially around:
 - hydrated runtime snapshots
 - multi-reference support
 
-## Local Dev Workflow
+## Build, Test, and Dev Commands
 
-Prefer `uv run` for Python commands in this repo.
+Prefer `uv run -m ...` for Python commands in this repo.
 
-- use `uv run -m pytest`, `uv run -m open_range.cli`, and similar module entrypoints
+- create or refresh the local environment with `uv sync --extra dev`
+- run the main test suite with `uv run -m pytest tests -q`
+- run focused tests with `uv run -m pytest tests/test_runtime.py -q`
+- inspect the CLI with `uv run -m open_range.cli --help`
+- run demos with `uv run -m open_range.examples.demo` and `uv run -m open_range.examples.bootstrap`
 - do not use `source .venv/bin/activate` for normal development flows
 - do not fall back to raw `python -m ...` when `uv run -m ...` is available
 - if Codex does not see `uv` on `PATH`, resolve the machine's local `uv` path first instead of falling back to venv activation
 - run `docker` and `kind` directly, without wrapping them in Python env activation
 
-## PR Targeting
+## PR Guidelines
 
-Default pull requests for this repo should target `v1`, not `main`, unless the user explicitly asks otherwise.
-
-## Pull Requests
-
-When Codex opens or updates a pull request:
-
+- default pull requests for this repo should target `v1`, not `main`, unless the user explicitly asks otherwise
+- keep each PR focused on one theme
 - follow `.github/PULL_REQUEST_TEMPLATE.md`
 - keep the `Testing` section terse and factual: commands plus pass/fail or an explicit `Not run`
 - do not paste long verification logs or terminal transcripts into the PR body
+- include the exact verification commands used in the PR description, especially for admission, runtime, or Kind-backed changes
 - use `Review Notes` only for reviewer-relevant context such as risks, tradeoffs, or follow-up work
 
 ## Review Priorities

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -153,6 +153,15 @@ Prefer `uv run` for Python commands in this repo.
 
 Default pull requests for this repo should target `v1`, not `main`, unless the user explicitly asks otherwise.
 
+## Pull Requests
+
+When Codex opens or updates a pull request:
+
+- follow `.github/PULL_REQUEST_TEMPLATE.md`
+- keep the `Testing` section terse and factual: commands plus pass/fail or an explicit `Not run`
+- do not paste long verification logs or terminal transcripts into the PR body
+- use `Review Notes` only for reviewer-relevant context such as risks, tradeoffs, or follow-up work
+
 ## Review Priorities
 
 When reviewing or changing code, prioritize:

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,76 @@
+# Contributing to OpenRange
+
+Thanks for contributing.
+
+## What To Work On
+
+Small bug fixes, tests, docs improvements, and scoped quality-of-life changes are
+great candidates for pull requests.
+
+For larger features, behavioral changes, or broad refactors, please start with
+an issue or discussion before investing heavily in implementation. That helps us
+align on scope early and avoids wasted work.
+
+## Local Setup
+
+OpenRange uses [`uv`](https://github.com/astral-sh/uv) for local development.
+
+```bash
+uv sync --group dev
+```
+
+Useful smoke checks:
+
+```bash
+uv run openrange --help
+uv run openrange-demo
+```
+
+Training dependencies are optional:
+
+```bash
+uv sync --extra training
+```
+
+## Checks
+
+Before opening a pull request, run the checks relevant to your change.
+
+```bash
+uv run ruff format --check .
+uv run ruff check .
+uv run pytest tests/ -v --tb=short
+```
+
+Optional Docker parse check:
+
+```bash
+docker buildx build --check -f Dockerfile .
+```
+
+## Pull Requests
+
+Good pull requests are usually:
+
+- scoped to one clear change
+- explicit about what changed and why
+- backed by tests when behavior changes
+- accompanied by doc updates when public behavior or workflows change
+
+Use the repository PR template in
+[.github/PULL_REQUEST_TEMPLATE.md](.github/PULL_REQUEST_TEMPLATE.md).
+
+Keep the `Testing` section short and factual:
+
+- list the command(s) you ran
+- mark them pass/fail
+- if something was not run, say so plainly
+- do not paste long terminal transcripts into the PR body
+
+## Project Context
+
+If you need more background before changing core behavior, start with:
+
+- [`docs/architecture.md`](docs/architecture.md)
+- [`docs/training-data-spec.md`](docs/training-data-spec.md)
+- [`AGENTS.md`](AGENTS.md) for repo-specific Codex guidance


### PR DESCRIPTION
Closes #

## Summary

- add a lightweight pull request template for concise summaries, testing notes, and reviewer context
- add a contributor guide focused on setup, checks, and pull request expectations
- update `AGENTS.md` so Codex follows the template and keeps PR verification terse

## Testing

- Not run (docs and workflow changes only)
