### PR TITLE
Add Ruff formatting and pre-commit checks

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -2,64 +2,69 @@ name: CI
 
 on:
   push:
-    branches: [main]
+    branches: [main, v1]
   pull_request:
-    branches: [main]
+    branches: [main, v1]
+
+permissions:
+  contents: read
 
 jobs:
+  ruff:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v6
+
+      - name: Install uv
+        uses: astral-sh/setup-uv@v7
+        with:
+          version: "0.10.11"
+          python-version: "3.11"
+          enable-cache: true
+
+      - name: Install lint dependencies
+        run: uv sync --locked --no-default-groups --group lint
+
+      - name: Check formatting
+        run: uv run ruff format --check .
+
+      - name: Run lint
+        run: uv run ruff check .
+
+      - name: Validate manifests
+        run: |
+          uv run python - <<'PY'
+          from pathlib import Path
+          import yaml
+
+          for path in sorted(Path("manifests").glob("*.yaml")):
+              with path.open("r", encoding="utf-8") as handle:
+                  yaml.safe_load(handle)
+          PY
+
   test:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
 
       - name: Install uv
-        uses: astral-sh/setup-uv@v4
+        uses: astral-sh/setup-uv@v7
         with:
-          version: "latest"
+          version: "0.10.11"
+          python-version: "3.11"
+          enable-cache: true
 
-      - name: Set up Python 3.11
-        run: uv python install 3.11
-
-      - name: Install dependencies
-        run: uv sync --all-extras
+      - name: Install test dependencies
+        run: uv sync --locked --no-default-groups --group test
 
       - name: Run tests
         run: uv run pytest tests/ -v --tb=short
-
-  lint:
-    runs-on: ubuntu-latest
-    steps:
-      - uses: actions/checkout@v4
-
-      - name: Install uv
-        uses: astral-sh/setup-uv@v4
-        with:
-          version: "latest"
-
-      - name: Set up Python 3.11
-        run: uv python install 3.11
-
-      - name: Install dependencies
-        run: uv sync --all-extras
-
-      - name: Check Python syntax
-        run: uv run python -m py_compile src/open_range/server/app.py
-
-      - name: Validate YAML manifests
-        run: uv run python -c "import yaml; yaml.safe_load(open('manifests/tier1_basic.yaml'))"
 
   docker-build:
     runs-on: ubuntu-latest
     continue-on-error: true
     steps:
-      - uses: actions/checkout@v4
-
-      - name: Validate docker-compose.yml
-        run: docker compose config --quiet
+      - uses: actions/checkout@v6
 
       - name: Verify Dockerfiles parse correctly
-        run: |
-          for f in docker/*.Dockerfile src/open_range/server/Dockerfile; do
-            echo "Checking $f ..."
-            docker buildx build --check -f "$f" "${f%/*}" 2>/dev/null || echo "  (buildx --check not supported, skipping)"
-          done
+        run: docker buildx build --check -f Dockerfile .

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,0 +1,23 @@
+minimum_pre_commit_version: "4.5.0"
+
+repos:
+  - repo: https://github.com/pre-commit/pre-commit-hooks
+    rev: v5.0.0
+    hooks:
+      - id: check-yaml
+        exclude: ^(deploy/openrange/templates/|src/open_range/chart/templates/)
+      - id: end-of-file-fixer
+      - id: trailing-whitespace
+
+  - repo: https://github.com/astral-sh/ruff-pre-commit
+    rev: v0.15.6
+    hooks:
+      - id: ruff-check
+        args: [--fix]
+      - id: ruff-format
+
+  - repo: https://github.com/astral-sh/uv-pre-commit
+    rev: 0.10.11
+    hooks:
+      - id: uv-lock
+        files: ^(pyproject\.toml|uv\.lock)$

--- a/Dockerfile
+++ b/Dockerfile
@@ -18,7 +18,7 @@ RUN uv venv --python python3.11 /app/.venv \
     fi
 
 ENV PATH="/app/.venv/bin:$PATH"
-ENV PYTHONPATH="/app/src:$PYTHONPATH"
+ENV PYTHONPATH="/app/src"
 
 ENTRYPOINT ["openrange"]
 CMD ["--help"]

--- a/README.md
+++ b/README.md
@@ -343,3 +343,14 @@ docker run --rm openrange --help
 ```bash
 PYTHONPATH=src .venv/bin/python -m pytest tests -q
 ```
+
+## Development checks
+
+```bash
+uv sync
+uv run ruff format .
+uv run ruff check .
+uv run pytest
+uv run pre-commit install
+uv run pre-commit run --all-files
+```

--- a/manifests/schema.py
+++ b/manifests/schema.py
@@ -6,7 +6,11 @@ from pathlib import Path
 
 import yaml
 
-from open_range.manifest import EnterpriseSaaSManifest, manifest_schema, validate_manifest
+from open_range.manifest import (
+    EnterpriseSaaSManifest,
+    manifest_schema,
+    validate_manifest,
+)
 
 
 def load_manifest(path: str | Path) -> EnterpriseSaaSManifest:
@@ -18,4 +22,9 @@ def load_manifest(path: str | Path) -> EnterpriseSaaSManifest:
     return validate_manifest(payload)
 
 
-__all__ = ["EnterpriseSaaSManifest", "load_manifest", "manifest_schema", "validate_manifest"]
+__all__ = [
+    "EnterpriseSaaSManifest",
+    "load_manifest",
+    "manifest_schema",
+    "validate_manifest",
+]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -15,7 +15,6 @@ dependencies = [
 ]
 
 [project.optional-dependencies]
-dev = ["pytest>=8.0"]
 training = [
     "torch>=2.10",
     "transformers>=5.2",
@@ -24,6 +23,16 @@ training = [
     "peft>=0.18",
     "trl>=0.24",
 ]
+
+[dependency-groups]
+dev = [
+    { include-group = "hooks" },
+    { include-group = "lint" },
+    { include-group = "test" },
+]
+hooks = ["pre-commit>=4.5"]
+lint = ["ruff>=0.15.6"]
+test = ["pytest>=8.0"]
 
 [project.scripts]
 openrange = "open_range.cli:cli"
@@ -43,3 +52,10 @@ include = ["open_range*"]
 markers = [
     "live_model: runs live LiteLLM model smoke tests",
 ]
+
+[tool.ruff]
+line-length = 88
+target-version = "py311"
+
+[tool.ruff.lint]
+select = ["E4", "E7", "E9", "F"]

--- a/scripts/eval_model_rollouts.py
+++ b/scripts/eval_model_rollouts.py
@@ -29,6 +29,7 @@ from open_range.runtime import ReferenceDrivenRuntime
 from open_range.snapshot import RuntimeSnapshot
 from open_range.store import FileSnapshotStore
 from open_range.training_data import (
+    TraceCandidate,
     TraceLineage,
     build_decision_prompt,
     render_candidate_completion,
@@ -60,10 +61,14 @@ def _load_manifest(source: str | Path | None) -> dict[str, Any]:
 def teacher_pick_rate(picks: list[dict[str, Any]]) -> float:
     if not picks:
         return 0.0
-    return sum(1 for pick in picks if pick.get("chosen_label") == "teacher") / len(picks)
+    return sum(1 for pick in picks if pick.get("chosen_label") == "teacher") / len(
+        picks
+    )
 
 
-def build_prompt(snapshot: RuntimeSnapshot, observation, candidates, decision_index: int) -> str:
+def build_prompt(
+    snapshot: RuntimeSnapshot, observation, candidates, decision_index: int
+) -> str:
     return (
         "<system>\n"
         "You are the red operator in OpenRange. "
@@ -97,7 +102,9 @@ def build_prompt(snapshot: RuntimeSnapshot, observation, candidates, decision_in
     )
 
 
-def red_candidates(runtime: ReferenceDrivenRuntime, snapshot: RuntimeSnapshot, observation):
+def red_candidates(
+    runtime: ReferenceDrivenRuntime, snapshot: RuntimeSnapshot, observation
+):
     expected = runtime.reference_step("red")
     return candidate_actions(
         snapshot,
@@ -108,14 +115,18 @@ def red_candidates(runtime: ReferenceDrivenRuntime, snapshot: RuntimeSnapshot, o
     )
 
 
-def score_candidates(model: Any, tokenizer: Any, prompt: str, candidates) -> list[tuple[object, float]]:
+def score_candidates(
+    model: Any, tokenizer: Any, prompt: str, candidates
+) -> list[tuple[TraceCandidate, float]]:
     import torch
 
     prompt_ids = tokenizer(prompt, return_tensors="pt").input_ids.to(model.device)
     scored: list[tuple[TraceCandidate, float]] = []
     for candidate in candidates:
         completion = render_candidate_completion(candidate)
-        full_ids = tokenizer(prompt + completion, return_tensors="pt").input_ids.to(model.device)
+        full_ids = tokenizer(prompt + completion, return_tensors="pt").input_ids.to(
+            model.device
+        )
         labels = full_ids.clone()
         labels[:, : prompt_ids.shape[1]] = -100
         with torch.no_grad():
@@ -142,8 +153,10 @@ def evaluate_model_rollouts(
     tokenizer = AutoTokenizer.from_pretrained(str(adapter), use_fast=True)
     if tokenizer.pad_token is None:
         tokenizer.pad_token = tokenizer.eos_token
-    dtype = torch.bfloat16 if torch.cuda.is_available() and torch.cuda.is_bf16_supported() else (
-        torch.float16 if torch.cuda.is_available() else torch.float32
+    dtype = (
+        torch.bfloat16
+        if torch.cuda.is_available() and torch.cuda.is_bf16_supported()
+        else (torch.float16 if torch.cuda.is_available() else torch.float32)
     )
     base = AutoModelForCausalLM.from_pretrained(
         base_model,
@@ -165,7 +178,7 @@ def evaluate_model_rollouts(
             pipeline.admit(
                 pipeline.build(payload, root / "rendered-base", OFFLINE_BUILD_CONFIG),
                 split="train",
-            )
+            ),
         )
         snapshots.append(current)
         for idx in range(1, mutations + 1):
@@ -181,7 +194,9 @@ def evaluate_model_rollouts(
                 novelty=min(0.5 + idx * 0.1, 1.0),
                 blue_signal_points=current.validator_report.blue_signal_points,
             )
-            child_world = mutation_policy.mutate(current.world, parent_stats=parent_stats)
+            child_world = mutation_policy.mutate(
+                current.world, parent_stats=parent_stats
+            )
             current = hydrate_runtime_snapshot(
                 store,
                 pipeline.admit_child(
@@ -189,7 +204,7 @@ def evaluate_model_rollouts(
                     root / f"rendered-child-{idx}",
                     split="eval",
                     build_config=OFFLINE_BUILD_CONFIG,
-                )
+                ),
             )
             snapshots.append(current)
 
@@ -201,12 +216,18 @@ def evaluate_model_rollouts(
 
         for snapshot in snapshots:
             pair_reports: list[dict[str, Any]] = []
-            for attack_trace_index in range(max(1, len(snapshot.reference_bundle.reference_attack_traces))):
+            for attack_trace_index in range(
+                max(1, len(snapshot.reference_bundle.reference_attack_traces))
+            ):
                 total_pairs += 1
                 runtime = ReferenceDrivenRuntime()
                 runtime.reset(
                     snapshot,
-                    EpisodeConfig(mode="red_only", scheduler_mode="strict_turns", opponent_blue="scripted"),
+                    EpisodeConfig(
+                        mode="red_only",
+                        scheduler_mode="strict_turns",
+                        opponent_blue="scripted",
+                    ),
                     reference_attack_index=attack_trace_index,
                 )
                 picks: list[dict[str, Any]] = []
@@ -239,7 +260,10 @@ def evaluate_model_rollouts(
                             "chosen_label": chosen.label,
                             "chosen_text": chosen.text,
                             "chosen_loss": loss,
-                            "candidates": [{"label": cand.label, "loss": cand_loss} for cand, cand_loss in ranked],
+                            "candidates": [
+                                {"label": cand.label, "loss": cand_loss}
+                                for cand, cand_loss in ranked
+                            ],
                         }
                     )
 
@@ -253,7 +277,8 @@ def evaluate_model_rollouts(
                         "done": score.done,
                         "truncated": truncated,
                         "winner": score.winner,
-                        "terminal_reason": score.terminal_reason or ("max_turns_reached" if truncated else ""),
+                        "terminal_reason": score.terminal_reason
+                        or ("max_turns_reached" if truncated else ""),
                         "red_reward": score.red_reward,
                         "blue_reward": score.blue_reward,
                         "turns": turns,
@@ -265,15 +290,30 @@ def evaluate_model_rollouts(
                 {
                     "snapshot_id": snapshot.snapshot_id,
                     "world_id": snapshot.world.world_id,
-                    "red_win_rate": sum(1 for report in pair_reports if report["winner"] == "red") / len(pair_reports) if pair_reports else 0.0,
-                    "exact_pick_rate": sum(report["exact_pick_rate"] for report in pair_reports) / len(pair_reports) if pair_reports else 0.0,
+                    "red_win_rate": sum(
+                        1 for report in pair_reports if report["winner"] == "red"
+                    )
+                    / len(pair_reports)
+                    if pair_reports
+                    else 0.0,
+                    "exact_pick_rate": sum(
+                        report["exact_pick_rate"] for report in pair_reports
+                    )
+                    / len(pair_reports)
+                    if pair_reports
+                    else 0.0,
                     "pairs": pair_reports,
-                    "weaknesses": [f"{weak.family}:{weak.kind}@{weak.target}" for weak in snapshot.world.weaknesses],
+                    "weaknesses": [
+                        f"{weak.family}:{weak.kind}@{weak.target}"
+                        for weak in snapshot.world.weaknesses
+                    ],
                 }
             )
 
         result = {
-            "manifest_source": str(manifest) if manifest is not None else _default_manifest_name(),
+            "manifest_source": str(manifest)
+            if manifest is not None
+            else _default_manifest_name(),
             "adapter": str(adapter),
             "base_model": base_model,
             "snapshot_count": len(reports),
@@ -290,10 +330,20 @@ def evaluate_model_rollouts(
 
 
 def parse_args() -> argparse.Namespace:
-    parser = argparse.ArgumentParser(description="Run a bounded model-in-the-loop OpenRange rollout probe.")
-    parser.add_argument("--adapter", default=DEFAULT_ADAPTER, help="Path to a saved LoRA adapter.")
-    parser.add_argument("--base-model", default=DEFAULT_BASE_MODEL, help="Base model id or local path.")
-    parser.add_argument("--manifest", default=None, help="Bundled manifest name or path to strict manifest YAML.")
+    parser = argparse.ArgumentParser(
+        description="Run a bounded model-in-the-loop OpenRange rollout probe."
+    )
+    parser.add_argument(
+        "--adapter", default=DEFAULT_ADAPTER, help="Path to a saved LoRA adapter."
+    )
+    parser.add_argument(
+        "--base-model", default=DEFAULT_BASE_MODEL, help="Base model id or local path."
+    )
+    parser.add_argument(
+        "--manifest",
+        default=None,
+        help="Bundled manifest name or path to strict manifest YAML.",
+    )
     parser.add_argument("--mutations", type=int, default=3)
     parser.add_argument("--max-turns", type=int, default=8)
     parser.add_argument("--out", default="/tmp/openrange-model-rollout.json")

--- a/scripts/eval_rollouts.py
+++ b/scripts/eval_rollouts.py
@@ -42,11 +42,15 @@ def _load_manifest(source: str | Path | None) -> dict[str, Any]:
     return load_bundled_manifest(str(source))
 
 
-def _scripted_agent(snapshot: RuntimeSnapshot, actor: str, *, trace_index: int) -> ScriptedRuntimeAgent:
+def _scripted_agent(
+    snapshot: RuntimeSnapshot, actor: str, *, trace_index: int
+) -> ScriptedRuntimeAgent:
     return ScriptedRuntimeAgent(trace_actions(snapshot, actor, trace_index=trace_index))
 
 
-def _run_mode(snapshot: RuntimeSnapshot, episode_config: EpisodeConfig) -> dict[str, Any]:
+def _run_mode(
+    snapshot: RuntimeSnapshot, episode_config: EpisodeConfig
+) -> dict[str, Any]:
     pair_reports: list[dict[str, Any]] = []
     for attack_idx, defense_idx in reference_trace_pairs(snapshot, episode_config.mode):
         runtime = ReferenceDrivenRuntime()
@@ -116,27 +120,70 @@ def _score_payload(
     }
 
 
-def _aggregate_pair_reports(pair_reports: list[dict[str, Any]], *, mode: str) -> dict[str, Any]:
+def _aggregate_pair_reports(
+    pair_reports: list[dict[str, Any]], *, mode: str
+) -> dict[str, Any]:
     total = len(pair_reports)
     return {
         "mode": mode,
         "pairs_evaluated": total,
-        "winner": "mixed" if len({entry["winner"] for entry in pair_reports}) > 1 else (pair_reports[0]["winner"] if pair_reports else ""),
+        "winner": "mixed"
+        if len({entry["winner"] for entry in pair_reports}) > 1
+        else (pair_reports[0]["winner"] if pair_reports else ""),
         "done": all(entry["done"] for entry in pair_reports),
-        "terminal_reason": "mixed" if len({entry["terminal_reason"] for entry in pair_reports}) > 1 else (pair_reports[0]["terminal_reason"] if pair_reports else ""),
-        "sim_time": sum(entry["sim_time"] for entry in pair_reports) / total if total else 0.0,
-        "turns": sum(entry["turns"] for entry in pair_reports) / total if total else 0.0,
-        "continuity": sum(entry["continuity"] for entry in pair_reports) / total if total else 0.0,
-        "red_reward": sum(entry["red_reward"] for entry in pair_reports) / total if total else 0.0,
-        "blue_reward": sum(entry["blue_reward"] for entry in pair_reports) / total if total else 0.0,
-        "red_objectives": sorted({objective for entry in pair_reports for objective in entry["red_objectives"]}),
-        "blue_objectives": sorted({objective for entry in pair_reports for objective in entry["blue_objectives"]}),
-        "event_count": sum(entry["event_count"] for entry in pair_reports) / total if total else 0.0,
-        "red_win_rate": sum(1 for entry in pair_reports if entry["winner"] == "red") / total if total else 0.0,
-        "blue_win_rate": sum(1 for entry in pair_reports if entry["winner"] == "blue") / total if total else 0.0,
+        "terminal_reason": "mixed"
+        if len({entry["terminal_reason"] for entry in pair_reports}) > 1
+        else (pair_reports[0]["terminal_reason"] if pair_reports else ""),
+        "sim_time": sum(entry["sim_time"] for entry in pair_reports) / total
+        if total
+        else 0.0,
+        "turns": sum(entry["turns"] for entry in pair_reports) / total
+        if total
+        else 0.0,
+        "continuity": sum(entry["continuity"] for entry in pair_reports) / total
+        if total
+        else 0.0,
+        "red_reward": sum(entry["red_reward"] for entry in pair_reports) / total
+        if total
+        else 0.0,
+        "blue_reward": sum(entry["blue_reward"] for entry in pair_reports) / total
+        if total
+        else 0.0,
+        "red_objectives": sorted(
+            {
+                objective
+                for entry in pair_reports
+                for objective in entry["red_objectives"]
+            }
+        ),
+        "blue_objectives": sorted(
+            {
+                objective
+                for entry in pair_reports
+                for objective in entry["blue_objectives"]
+            }
+        ),
+        "event_count": sum(entry["event_count"] for entry in pair_reports) / total
+        if total
+        else 0.0,
+        "red_win_rate": sum(1 for entry in pair_reports if entry["winner"] == "red")
+        / total
+        if total
+        else 0.0,
+        "blue_win_rate": sum(1 for entry in pair_reports if entry["winner"] == "blue")
+        / total
+        if total
+        else 0.0,
     }
 
-def _population_stats(snapshot: RuntimeSnapshot, episodes: list[dict[str, Any]], *, split: str, novelty: float) -> PopulationStats:
+
+def _population_stats(
+    snapshot: RuntimeSnapshot,
+    episodes: list[dict[str, Any]],
+    *,
+    split: str,
+    novelty: float,
+) -> PopulationStats:
     total = len(episodes)
     red_wins = sum(1 for episode in episodes if episode["winner"] == "red")
     blue_wins = sum(1 for episode in episodes if episode["winner"] == "blue")
@@ -168,8 +215,14 @@ def evaluate_rollouts(
 
     mode_plan = (
         EpisodeConfig(mode="joint_pool", scheduler_mode="strict_turns"),
-        EpisodeConfig(mode="red_only", scheduler_mode="strict_turns", opponent_blue="reference"),
-        EpisodeConfig(mode="blue_only_live", scheduler_mode="strict_turns", opponent_red="reference"),
+        EpisodeConfig(
+            mode="red_only", scheduler_mode="strict_turns", opponent_blue="reference"
+        ),
+        EpisodeConfig(
+            mode="blue_only_live",
+            scheduler_mode="strict_turns",
+            opponent_red="reference",
+        ),
         EpisodeConfig(
             mode="blue_only_from_prefix",
             scheduler_mode="strict_turns",
@@ -189,7 +242,7 @@ def evaluate_rollouts(
             pipeline.admit(
                 pipeline.build(payload, root / "rendered-base", OFFLINE_BUILD_CONFIG),
                 split="train",
-            )
+            ),
         )
         snapshots.append(base)
 
@@ -225,7 +278,7 @@ def evaluate_rollouts(
                         root / f"rendered-child-{attempts}",
                         split="eval",
                         build_config=OFFLINE_BUILD_CONFIG,
-                    )
+                    ),
                 )
             except ValueError:
                 continue
@@ -234,12 +287,16 @@ def evaluate_rollouts(
             accepted += 1
 
         if accepted < mutations:
-            raise ValueError(f"unable to admit {mutations} mutated children after {attempts} attempts")
+            raise ValueError(
+                f"unable to admit {mutations} mutated children after {attempts} attempts"
+            )
 
         snapshot_reports: list[dict[str, Any]] = []
         population: list[PopulationStats] = []
         for idx, snapshot in enumerate(snapshots):
-            bootstrap = sim_plane.generate_bootstrap_trace(snapshot, episode_seed=idx + 7)
+            bootstrap = sim_plane.generate_bootstrap_trace(
+                snapshot, episode_seed=idx + 7
+            )
             episodes = [_run_mode(snapshot, config) for config in mode_plan]
             split = "train" if idx == 0 else "eval"
             report = {
@@ -273,24 +330,60 @@ def evaluate_rollouts(
                 "episodes": episodes,
             }
             snapshot_reports.append(report)
-            population.append(_population_stats(snapshot, episodes, split=split, novelty=min(0.5 + idx * 0.1, 1.0)))
+            population.append(
+                _population_stats(
+                    snapshot, episodes, split=split, novelty=min(0.5 + idx * 0.1, 1.0)
+                )
+            )
 
         aggregate: dict[str, dict[str, Any]] = {}
-        for mode in {episode["mode"] for report in snapshot_reports for episode in report["episodes"]}:
-            matching = [episode for report in snapshot_reports for episode in report["episodes"] if episode["mode"] == mode]
+        for mode in {
+            episode["mode"]
+            for report in snapshot_reports
+            for episode in report["episodes"]
+        }:
+            matching = [
+                episode
+                for report in snapshot_reports
+                for episode in report["episodes"]
+                if episode["mode"] == mode
+            ]
             total = len(matching)
             aggregate[mode] = {
                 "episodes": total,
-                "red_win_rate": sum(1 for episode in matching if episode["winner"] == "red") / total if total else 0.0,
-                "blue_win_rate": sum(1 for episode in matching if episode["winner"] == "blue") / total if total else 0.0,
-                "avg_red_reward": sum(episode["red_reward"] for episode in matching) / total if total else 0.0,
-                "avg_blue_reward": sum(episode["blue_reward"] for episode in matching) / total if total else 0.0,
-                "avg_continuity": sum(episode["continuity"] for episode in matching) / total if total else 0.0,
-                "avg_turns": sum(episode["turns"] for episode in matching) / total if total else 0.0,
+                "red_win_rate": sum(
+                    1 for episode in matching if episode["winner"] == "red"
+                )
+                / total
+                if total
+                else 0.0,
+                "blue_win_rate": sum(
+                    1 for episode in matching if episode["winner"] == "blue"
+                )
+                / total
+                if total
+                else 0.0,
+                "avg_red_reward": sum(episode["red_reward"] for episode in matching)
+                / total
+                if total
+                else 0.0,
+                "avg_blue_reward": sum(episode["blue_reward"] for episode in matching)
+                / total
+                if total
+                else 0.0,
+                "avg_continuity": sum(episode["continuity"] for episode in matching)
+                / total
+                if total
+                else 0.0,
+                "avg_turns": sum(episode["turns"] for episode in matching) / total
+                if total
+                else 0.0,
             }
 
         result = {
-            "manifest_source": str(manifest) if manifest is not None else _default_manifest_name(),
+            "manifest_source": str(manifest)
+            if manifest is not None
+            else _default_manifest_name(),
             "snapshot_count": len(snapshot_reports),
             "population": [entry.model_dump(mode="json") for entry in population],
             "snapshots": snapshot_reports,
@@ -309,16 +402,33 @@ def evaluate_rollouts(
 
 
 def parse_args() -> argparse.Namespace:
-    parser = argparse.ArgumentParser(description="Run held-out OpenRange rollout evaluation.")
-    parser.add_argument("--manifest", default=None, help="Bundled manifest name or path to strict manifest YAML.")
-    parser.add_argument("--mutations", type=int, default=3, help="How many sequential admitted mutations to evaluate.")
-    parser.add_argument("--out", default="/tmp/openrange-rollout-eval.json", help="Where to write the JSON report.")
+    parser = argparse.ArgumentParser(
+        description="Run held-out OpenRange rollout evaluation."
+    )
+    parser.add_argument(
+        "--manifest",
+        default=None,
+        help="Bundled manifest name or path to strict manifest YAML.",
+    )
+    parser.add_argument(
+        "--mutations",
+        type=int,
+        default=3,
+        help="How many sequential admitted mutations to evaluate.",
+    )
+    parser.add_argument(
+        "--out",
+        default="/tmp/openrange-rollout-eval.json",
+        help="Where to write the JSON report.",
+    )
     return parser.parse_args()
 
 
 def main() -> None:
     args = parse_args()
-    result = evaluate_rollouts(manifest=args.manifest, mutations=args.mutations, quiet=False)
+    result = evaluate_rollouts(
+        manifest=args.manifest, mutations=args.mutations, quiet=False
+    )
     out_path = Path(args.out)
     out_path.write_text(json.dumps(result, indent=2), encoding="utf-8")
     print(f"report={out_path}")

--- a/scripts/eval_tiny_sft.py
+++ b/scripts/eval_tiny_sft.py
@@ -40,33 +40,64 @@ def _assistant_prefix(example: dict[str, Any]) -> str:
 
 
 def parse_args() -> argparse.Namespace:
-    parser = argparse.ArgumentParser(description="Evaluate a tiny OpenRange LoRA adapter.")
-    parser.add_argument("--data", default=None, help="Path to JSONL chat data. If omitted, generate branch-native decision traces.")
-    parser.add_argument("--base-model", default=DEFAULT_MODEL, help="Base model id or local path.")
-    parser.add_argument("--adapter", required=True, help="Path to a saved LoRA adapter directory.")
+    parser = argparse.ArgumentParser(
+        description="Evaluate a tiny OpenRange LoRA adapter."
+    )
+    parser.add_argument(
+        "--data",
+        default=None,
+        help="Path to JSONL chat data. If omitted, generate branch-native decision traces.",
+    )
+    parser.add_argument(
+        "--base-model", default=DEFAULT_MODEL, help="Base model id or local path."
+    )
+    parser.add_argument(
+        "--adapter", required=True, help="Path to a saved LoRA adapter directory."
+    )
     parser.add_argument("--seed", type=int, default=7)
     parser.add_argument("--max-samples", type=int, default=96)
     parser.add_argument("--eval-ratio", type=float, default=0.2)
     parser.add_argument("--min-eval-samples", type=int, default=8)
-    parser.add_argument("--roles", default="red", help="Comma-separated role filter for branch-native datasets.")
-    parser.add_argument("--modes", default="", help="Optional comma-separated runtime-mode filter.")
-    parser.add_argument("--trace-sources", default="runtime", help="Comma-separated trace-source filter.")
+    parser.add_argument(
+        "--roles",
+        default="red",
+        help="Comma-separated role filter for branch-native datasets.",
+    )
+    parser.add_argument(
+        "--modes", default="", help="Optional comma-separated runtime-mode filter."
+    )
+    parser.add_argument(
+        "--trace-sources",
+        default="runtime",
+        help="Comma-separated trace-source filter.",
+    )
     parser.add_argument("--max-length", type=int, default=2048)
     parser.add_argument("--max-new-tokens", type=int, default=96)
-    parser.add_argument("--out", default="/tmp/openrange-sft-eval.json", help="Where to write eval metrics.")
+    parser.add_argument(
+        "--out",
+        default="/tmp/openrange-sft-eval.json",
+        help="Where to write eval metrics.",
+    )
     return parser.parse_args()
 
 
 def main() -> None:
     import torch
     from peft import PeftModel
-    from transformers import AutoModelForCausalLM, AutoTokenizer, Trainer, TrainingArguments
+    from transformers import (
+        AutoModelForCausalLM,
+        AutoTokenizer,
+        Trainer,
+        TrainingArguments,
+    )
 
     args = parse_args()
     random.seed(args.seed)
     torch.manual_seed(args.seed)
 
-    rows = load_examples(resolve_data_path(args.data, seed=args.seed), limit=None, seed=args.seed)
+    rows = load_examples(
+        resolve_data_path(args.data, seed=args.seed), limit=None, seed=args.seed
+    )
     rows = filter_examples(
         rows,
         roles=parse_filter(args.roles),
@@ -135,7 +166,9 @@ def main() -> None:
             do_sample=False,
             pad_token_id=tokenizer.pad_token_id,
         )
-        generated = tokenizer.decode(output[0][inputs["input_ids"].shape[1] :], skip_special_tokens=True)
+        generated = tokenizer.decode(
+            output[0][inputs["input_ids"].shape[1] :], skip_special_tokens=True
+        )
         if "<tool_call>" in generated or generated.strip():
             formatted += 1
         previews.append(

--- a/scripts/generate_schemas.py
+++ b/scripts/generate_schemas.py
@@ -11,7 +11,9 @@ from open_range.manifest import EnterpriseSaaSManifest
 
 def _write_schema(path: Path, payload: dict) -> None:
     path.parent.mkdir(parents=True, exist_ok=True)
-    path.write_text(json.dumps(payload, indent=2, sort_keys=True) + "\n", encoding="utf-8")
+    path.write_text(
+        json.dumps(payload, indent=2, sort_keys=True) + "\n", encoding="utf-8"
+    )
 
 
 def main() -> None:

--- a/scripts/generate_traces.py
+++ b/scripts/generate_traces.py
@@ -31,14 +31,40 @@ def _load_manifest(source: str | Path | None) -> tuple[dict[str, Any], str]:
 
 
 def parse_args() -> argparse.Namespace:
-    parser = argparse.ArgumentParser(description="Generate branch-native OpenRange trace datasets.")
-    parser.add_argument("--manifest", default=None, help="Bundled manifest name or path to strict manifest YAML.")
-    parser.add_argument("--roots", type=int, default=1, help="How many independent root lineages to generate.")
-    parser.add_argument("--mutations", type=int, default=3, help="How many sequential admitted mutations per lineage.")
-    parser.add_argument("--outdir", default="/tmp/openrange-traces", help="Dataset output directory.")
-    parser.add_argument("--include-joint-pool", action="store_true", help="Also export runtime joint_pool traces.")
-    parser.add_argument("--no-sim", action="store_true", help="Skip sim-plane bootstrap traces.")
-    parser.add_argument("--report", default=None, help="Optional explicit JSON report path.")
+    parser = argparse.ArgumentParser(
+        description="Generate branch-native OpenRange trace datasets."
+    )
+    parser.add_argument(
+        "--manifest",
+        default=None,
+        help="Bundled manifest name or path to strict manifest YAML.",
+    )
+    parser.add_argument(
+        "--roots",
+        type=int,
+        default=1,
+        help="How many independent root lineages to generate.",
+    )
+    parser.add_argument(
+        "--mutations",
+        type=int,
+        default=3,
+        help="How many sequential admitted mutations per lineage.",
+    )
+    parser.add_argument(
+        "--outdir", default="/tmp/openrange-traces", help="Dataset output directory."
+    )
+    parser.add_argument(
+        "--include-joint-pool",
+        action="store_true",
+        help="Also export runtime joint_pool traces.",
+    )
+    parser.add_argument(
+        "--no-sim", action="store_true", help="Skip sim-plane bootstrap traces."
+    )
+    parser.add_argument(
+        "--report", default=None, help="Optional explicit JSON report path."
+    )
     return parser.parse_args()
 
 
@@ -56,7 +82,9 @@ def main() -> None:
         include_joint_pool=args.include_joint_pool,
     )
     report_path = Path(args.report) if args.report else outdir / "report.json"
-    report_path.write_text(json.dumps(report.model_dump(mode="json"), indent=2), encoding="utf-8")
+    report_path.write_text(
+        json.dumps(report.model_dump(mode="json"), indent=2), encoding="utf-8"
+    )
 
     print(f"manifest={report.manifest_source}")
     print(f"roots={report.roots}")

--- a/scripts/run_grpo.py
+++ b/scripts/run_grpo.py
@@ -64,60 +64,208 @@ _FLAG_RE = re.compile(r"flag\{[^}]+\}", re.IGNORECASE)
 # Known tools & classification (from open-trajectory-gym v9)
 # ---------------------------------------------------------------------------
 
-_FLAG_PLACEHOLDERS = frozenset({
-    "content_of_flag_here", "FLAG{...}", "", "CHECK",
-    "gctf{DUMMY_FLAG}", "flag{this_is_fake_flag}",
-})
+_FLAG_PLACEHOLDERS = frozenset(
+    {
+        "content_of_flag_here",
+        "FLAG{...}",
+        "",
+        "CHECK",
+        "gctf{DUMMY_FLAG}",
+        "flag{this_is_fake_flag}",
+    }
+)
 
-_KNOWN_TOOL_NAMES = frozenset({
-    "shell_command", "exec_command", "execute_command",
-    "python_code", "read_file", "grep", "file_search",
-    "submit_flag", "flag_found", "submit_finding",
-    "get_challenge", "get_progress", "check_services",
-    "write_stdin", "apply_patch", "web_search",
-    "list_sessions", "close_session",
-})
+_KNOWN_TOOL_NAMES = frozenset(
+    {
+        "shell_command",
+        "exec_command",
+        "execute_command",
+        "python_code",
+        "read_file",
+        "grep",
+        "file_search",
+        "submit_flag",
+        "flag_found",
+        "submit_finding",
+        "get_challenge",
+        "get_progress",
+        "check_services",
+        "write_stdin",
+        "apply_patch",
+        "web_search",
+        "list_sessions",
+        "close_session",
+    }
+)
 
-_SHELL_WRAPPERS = frozenset({
-    "shell_command", "exec_command", "execute_command",
-})
+_SHELL_WRAPPERS = frozenset(
+    {
+        "shell_command",
+        "exec_command",
+        "execute_command",
+    }
+)
 
 _FLAG_TOOLS = frozenset({"submit_flag", "flag_found"})
 
-_RECON_BINARIES = frozenset({
-    "nmap", "masscan", "ping", "traceroute", "whois", "dig",
-    "nslookup", "host", "smbclient", "smbmap", "enum4linux",
-})
-_ENUM_BINARIES = frozenset({
-    "curl", "wget", "gobuster", "ffuf", "dirb", "nikto",
-    "ls", "cat", "head", "tail", "find", "grep", "strings",
-    "file", "id", "whoami", "ps", "env", "uname", "hostname",
-    "ip", "ifconfig", "netstat", "ss", "xxd", "hexdump",
-})
-_EXPLOIT_BINARIES = frozenset({
-    "sqlmap", "hydra", "john", "hashcat", "python", "python3",
-    "ruby", "perl", "gcc", "nc", "ncat", "netcat", "ssh",
-    "msfconsole", "msfvenom", "chmod", "gdb", "bash", "php",
-})
+_RECON_BINARIES = frozenset(
+    {
+        "nmap",
+        "masscan",
+        "ping",
+        "traceroute",
+        "whois",
+        "dig",
+        "nslookup",
+        "host",
+        "smbclient",
+        "smbmap",
+        "enum4linux",
+    }
+)
+_ENUM_BINARIES = frozenset(
+    {
+        "curl",
+        "wget",
+        "gobuster",
+        "ffuf",
+        "dirb",
+        "nikto",
+        "ls",
+        "cat",
+        "head",
+        "tail",
+        "find",
+        "grep",
+        "strings",
+        "file",
+        "id",
+        "whoami",
+        "ps",
+        "env",
+        "uname",
+        "hostname",
+        "ip",
+        "ifconfig",
+        "netstat",
+        "ss",
+        "xxd",
+        "hexdump",
+    }
+)
+_EXPLOIT_BINARIES = frozenset(
+    {
+        "sqlmap",
+        "hydra",
+        "john",
+        "hashcat",
+        "python",
+        "python3",
+        "ruby",
+        "perl",
+        "gcc",
+        "nc",
+        "ncat",
+        "netcat",
+        "ssh",
+        "msfconsole",
+        "msfvenom",
+        "chmod",
+        "gdb",
+        "bash",
+        "php",
+    }
+)
 
 # OpenEnv tool definitions (activates qwen3_coder format in chat template)
 OPENENV_TOOLS = [
-    {"type": "function", "function": {"name": "shell_command", "description": "Execute a shell command",
-        "parameters": {"type": "object", "properties": {"command": {"type": "string"}}, "required": ["command"]}}},
-    {"type": "function", "function": {"name": "python_code", "description": "Execute Python code",
-        "parameters": {"type": "object", "properties": {"code": {"type": "string"}}, "required": ["code"]}}},
-    {"type": "function", "function": {"name": "submit_flag", "description": "Submit a captured flag",
-        "parameters": {"type": "object", "properties": {"flag": {"type": "string"}}, "required": ["flag"]}}},
-    {"type": "function", "function": {"name": "submit_finding", "description": "Submit a security finding",
-        "parameters": {"type": "object", "properties": {"description": {"type": "string"}}, "required": ["description"]}}},
-    {"type": "function", "function": {"name": "read_file", "description": "Read a file",
-        "parameters": {"type": "object", "properties": {"path": {"type": "string"}}, "required": ["path"]}}},
-    {"type": "function", "function": {"name": "get_challenge", "description": "Get challenge briefing",
-        "parameters": {"type": "object", "properties": {"role": {"type": "string", "default": "red"}}}}},
-    {"type": "function", "function": {"name": "get_progress", "description": "Get current progress",
-        "parameters": {"type": "object", "properties": {}}}},
-    {"type": "function", "function": {"name": "check_services", "description": "Check service health",
-        "parameters": {"type": "object", "properties": {}}}},
+    {
+        "type": "function",
+        "function": {
+            "name": "shell_command",
+            "description": "Execute a shell command",
+            "parameters": {
+                "type": "object",
+                "properties": {"command": {"type": "string"}},
+                "required": ["command"],
+            },
+        },
+    },
+    {
+        "type": "function",
+        "function": {
+            "name": "python_code",
+            "description": "Execute Python code",
+            "parameters": {
+                "type": "object",
+                "properties": {"code": {"type": "string"}},
+                "required": ["code"],
+            },
+        },
+    },
+    {
+        "type": "function",
+        "function": {
+            "name": "submit_flag",
+            "description": "Submit a captured flag",
+            "parameters": {
+                "type": "object",
+                "properties": {"flag": {"type": "string"}},
+                "required": ["flag"],
+            },
+        },
+    },
+    {
+        "type": "function",
+        "function": {
+            "name": "submit_finding",
+            "description": "Submit a security finding",
+            "parameters": {
+                "type": "object",
+                "properties": {"description": {"type": "string"}},
+                "required": ["description"],
+            },
+        },
+    },
+    {
+        "type": "function",
+        "function": {
+            "name": "read_file",
+            "description": "Read a file",
+            "parameters": {
+                "type": "object",
+                "properties": {"path": {"type": "string"}},
+                "required": ["path"],
+            },
+        },
+    },
+    {
+        "type": "function",
+        "function": {
+            "name": "get_challenge",
+            "description": "Get challenge briefing",
+            "parameters": {
+                "type": "object",
+                "properties": {"role": {"type": "string", "default": "red"}},
+            },
+        },
+    },
+    {
+        "type": "function",
+        "function": {
+            "name": "get_progress",
+            "description": "Get current progress",
+            "parameters": {"type": "object", "properties": {}},
+        },
+    },
+    {
+        "type": "function",
+        "function": {
+            "name": "check_services",
+            "description": "Check service health",
+            "parameters": {"type": "object", "properties": {}},
+        },
+    },
 ]
 
 _reward_rng = random.Random(3407)
@@ -144,7 +292,9 @@ def completion_to_text(c):
     if isinstance(c, str):
         return c
     if isinstance(c, list):
-        return "\n".join(m.get("content", "") if isinstance(m, dict) else str(m) for m in c)
+        return "\n".join(
+            m.get("content", "") if isinstance(m, dict) else str(m) for m in c
+        )
     return str(c)
 
 
@@ -153,8 +303,13 @@ def is_real_flag(flag):
         return False
     if flag in _FLAG_PLACEHOLDERS:
         return False
-    for poison in ("content_of_flag_here", "dummy_flag", "fake_flag",
-                    "this_is_fake", "placeholder"):
+    for poison in (
+        "content_of_flag_here",
+        "dummy_flag",
+        "fake_flag",
+        "this_is_fake",
+        "placeholder",
+    ):
         if poison in flag.lower():
             return False
     return True
@@ -164,7 +319,9 @@ def action_fingerprint(tc):
     name = tc.get("name", "")
     if name in _SHELL_WRAPPERS:
         args = tc.get("arguments", {})
-        cmd = args.get("command", args.get("code", "")) if isinstance(args, dict) else ""
+        cmd = (
+            args.get("command", args.get("code", "")) if isinstance(args, dict) else ""
+        )
         if cmd:
             binary = cmd.split()[0].rsplit("/", 1)[-1].lower()
             return f"{name}:{binary}"
@@ -195,7 +352,9 @@ def binary_reward_fn(completions, **kwargs):
                     found = True
                     break
         if not found:
-            has_flag_tool = any(tc["name"] in _FLAG_TOOLS for tc in parse_tool_calls(text))
+            has_flag_tool = any(
+                tc["name"] in _FLAG_TOOLS for tc in parse_tool_calls(text)
+            )
             if has_flag_tool:
                 found = any(f.strip() == gt.strip() for f in extract_flags(text))
         rewards.append(1.0 if found else 0.0)
@@ -236,7 +395,6 @@ def online_reward_fn(completions, **kwargs):
             urllib.request.urlopen(req, timeout=10)
 
             episode_reward = 0.0
-            done = False
 
             for tc in tcs:
                 name = tc["name"]
@@ -269,7 +427,9 @@ def online_reward_fn(completions, **kwargs):
 
                 step_req = urllib.request.Request(
                     f"{env_url}/step",
-                    data=json.dumps({"action": {"command": command, "mode": "red"}}).encode(),
+                    data=json.dumps(
+                        {"action": {"command": command, "mode": "red"}}
+                    ).encode(),
                     headers={"Content-Type": "application/json"},
                     method="POST",
                 )
@@ -280,7 +440,6 @@ def online_reward_fn(completions, **kwargs):
                 episode_reward += float(step_reward)
 
                 if data.get("done", False):
-                    done = True
                     break
 
             # Bonus noise for variance
@@ -288,7 +447,9 @@ def online_reward_fn(completions, **kwargs):
             rewards.append(max(episode_reward, -1.0))
 
         except (urllib.error.URLError, TimeoutError, OSError) as e:
-            logger.warning("Online reward failed for sample %d: %s. Falling back.", i, e)
+            logger.warning(
+                "Online reward failed for sample %d: %s. Falling back.", i, e
+            )
             # Fall back to offline progressive scoring
             fallback = progressive_reward_fn([c], ground_truth=[gt])
             rewards.append(fallback[0])
@@ -335,7 +496,9 @@ def progressive_reward_fn(completions, **kwargs):
             opt = opt_steps or 10
             step_ratio = min(opt / n_calls, 1.0)
             fingerprints = [action_fingerprint(tc) for tc in tcs]
-            novelty = len(set(fingerprints)) / len(fingerprints) if fingerprints else 1.0
+            novelty = (
+                len(set(fingerprints)) / len(fingerprints) if fingerprints else 1.0
+            )
             excess = max(0, n_calls - opt) / max(opt, 1)
             time_decay = math.exp(-0.3 * excess)
             eff_sc = step_ratio * novelty * time_decay
@@ -371,9 +534,13 @@ def progressive_reward_fn(completions, **kwargs):
                     premature_mult = 1.0 + max(0.0, 1.0 - n_calls / 5.0)
                     hall_sc *= premature_mult
                     if gt and is_real_flag(gt):
-                        submitted = tc["arguments"].get("flag", tc["arguments"].get("value", ""))
+                        submitted = tc["arguments"].get(
+                            "flag", tc["arguments"].get("value", "")
+                        )
                         if submitted:
-                            sim = difflib.SequenceMatcher(None, submitted.strip(), gt.strip()).ratio()
+                            sim = difflib.SequenceMatcher(
+                                None, submitted.strip(), gt.strip()
+                            ).ratio()
                             if sim >= 0.8:
                                 hall_sc *= 0.1
                     break
@@ -410,13 +577,22 @@ def convert_messages(messages):
                 name = func.get("name", "unknown")
                 args_raw = func.get("arguments", "{}")
                 args = json.loads(args_raw) if isinstance(args_raw, str) else args_raw
-                params = "\n".join(f"<parameter={k}>{v}</parameter>" for k, v in args.items())
-                parts.append(f"<tool_call>\n<function={name}>\n{params}\n</function>\n</tool_call>")
+                params = "\n".join(
+                    f"<parameter={k}>{v}</parameter>" for k, v in args.items()
+                )
+                parts.append(
+                    f"<tool_call>\n<function={name}>\n{params}\n</function>\n</tool_call>"
+                )
             xml = "\n".join(parts)
             full = f"{content}\n\n{xml}" if content else xml
             converted.append({"role": "assistant", "content": full})
         elif role == "tool":
-            converted.append({"role": "user", "content": f"<tool_response>\n{content}\n</tool_response>"})
+            converted.append(
+                {
+                    "role": "user",
+                    "content": f"<tool_response>\n{content}\n</tool_response>",
+                }
+            )
         elif role in ("system", "user", "assistant"):
             converted.append({"role": role, "content": content})
     return converted
@@ -432,8 +608,16 @@ def main():
     parser.add_argument("--model", default=MODEL)
     parser.add_argument("--data", default=DATA)
     parser.add_argument("--output", default=OUTPUT)
-    parser.add_argument("--reward", default="online", choices=["binary", "progressive", "online", "both"])
-    parser.add_argument("--env-url", default="http://localhost:8000", help="OpenEnv server URL for online reward")
+    parser.add_argument(
+        "--reward",
+        default="online",
+        choices=["binary", "progressive", "online", "both"],
+    )
+    parser.add_argument(
+        "--env-url",
+        default="http://localhost:8000",
+        help="OpenEnv server URL for online reward",
+    )
     parser.add_argument("--seq", type=int, default=SEQ)
     parser.add_argument("--comp-len", type=int, default=COMP_LEN)
     parser.add_argument("--num-gen", type=int, default=NUM_GEN)
@@ -540,8 +724,13 @@ def main():
         model,
         r=LORA_R,
         target_modules=[
-            "q_proj", "k_proj", "v_proj", "o_proj",
-            "gate_proj", "up_proj", "down_proj",
+            "q_proj",
+            "k_proj",
+            "v_proj",
+            "o_proj",
+            "gate_proj",
+            "up_proj",
+            "down_proj",
         ],
         lora_alpha=LORA_ALPHA,
         lora_dropout=0,
@@ -554,10 +743,12 @@ def main():
     # Create dataset
     from datasets import Dataset
 
-    ds = Dataset.from_dict({
-        "prompt": prompts,
-        "ground_truth": ground_truths,
-    })
+    ds = Dataset.from_dict(
+        {
+            "prompt": prompts,
+            "ground_truth": ground_truths,
+        }
+    )
 
     # Select reward
     if args.reward == "online":

--- a/scripts/train_tiny_sft.py
+++ b/scripts/train_tiny_sft.py
@@ -84,14 +84,20 @@ def load_examples(path: Path, *, limit: int | None, seed: int) -> list[dict[str,
     return rows
 
 
-def limit_examples(rows: list[dict[str, Any]], *, limit: int | None, seed: int) -> list[dict[str, Any]]:
+def limit_examples(
+    rows: list[dict[str, Any]], *, limit: int | None, seed: int
+) -> list[dict[str, Any]]:
     if limit is None or len(rows) <= limit:
         return list(rows)
     limited = list(rows)
     random.Random(seed).shuffle(limited)
     if len(limited) > limit:
-        split_values = {str(row.get("split", "")).strip() for row in rows if isinstance(row, dict)}
-        explicit_splits = {value for value in split_values if value in {"train", "val", "test"}}
+        split_values = {
+            str(row.get("split", "")).strip() for row in rows if isinstance(row, dict)
+        }
+        explicit_splits = {
+            value for value in split_values if value in {"train", "val", "test"}
+        }
         if "train" in explicit_splits and ({"val", "test"} & explicit_splits):
             train_rows = [row for row in limited if row.get("split") == "train"]
             eval_rows = [row for row in limited if row.get("split") in {"val", "test"}]
@@ -132,8 +138,12 @@ def split_examples(
 ) -> tuple[list[dict[str, Any]], list[dict[str, Any]]]:
     if not rows:
         return [], []
-    split_values = {str(row.get("split", "")).strip() for row in rows if isinstance(row, dict)}
-    explicit_splits = {value for value in split_values if value in {"train", "val", "test"}}
+    split_values = {
+        str(row.get("split", "")).strip() for row in rows if isinstance(row, dict)
+    }
+    explicit_splits = {
+        value for value in split_values if value in {"train", "val", "test"}
+    }
     if "train" in explicit_splits and ({"val", "test"} & explicit_splits):
         train_rows = [row for row in rows if row.get("split") == "train"]
         eval_rows = [row for row in rows if row.get("split") in {"val", "test"}]
@@ -197,17 +207,37 @@ class CausalCollator:
 
 
 def parse_args() -> argparse.Namespace:
-    parser = argparse.ArgumentParser(description="Tiny LoRA SFT for OpenRange chat data.")
-    parser.add_argument("--data", default=None, help="Path to JSONL chat data. If omitted, generate branch-native decision traces.")
-    parser.add_argument("--model", default=DEFAULT_MODEL, help="Hugging Face model id or local path.")
-    parser.add_argument("--outdir", default="/tmp/openrange-sft-tiny", help="Output directory.")
+    parser = argparse.ArgumentParser(
+        description="Tiny LoRA SFT for OpenRange chat data."
+    )
+    parser.add_argument(
+        "--data",
+        default=None,
+        help="Path to JSONL chat data. If omitted, generate branch-native decision traces.",
+    )
+    parser.add_argument(
+        "--model", default=DEFAULT_MODEL, help="Hugging Face model id or local path."
+    )
+    parser.add_argument(
+        "--outdir", default="/tmp/openrange-sft-tiny", help="Output directory."
+    )
     parser.add_argument("--seed", type=int, default=7)
     parser.add_argument("--max-samples", type=int, default=96)
     parser.add_argument("--eval-ratio", type=float, default=0.2)
     parser.add_argument("--min-eval-samples", type=int, default=8)
-    parser.add_argument("--roles", default="red", help="Comma-separated role filter for branch-native datasets.")
-    parser.add_argument("--modes", default="", help="Optional comma-separated runtime-mode filter.")
-    parser.add_argument("--trace-sources", default="runtime", help="Comma-separated trace-source filter.")
+    parser.add_argument(
+        "--roles",
+        default="red",
+        help="Comma-separated role filter for branch-native datasets.",
+    )
+    parser.add_argument(
+        "--modes", default="", help="Optional comma-separated runtime-mode filter."
+    )
+    parser.add_argument(
+        "--trace-sources",
+        default="runtime",
+        help="Comma-separated trace-source filter.",
+    )
     parser.add_argument("--max-length", type=int, default=2048)
     parser.add_argument("--epochs", type=float, default=1.0)
     parser.add_argument("--max-steps", type=int, default=24)
@@ -246,7 +276,12 @@ def parse_filter(value: str) -> set[str] | None:
 def main() -> None:
     import torch
     from peft import LoraConfig, get_peft_model
-    from transformers import AutoModelForCausalLM, AutoTokenizer, Trainer, TrainingArguments
+    from transformers import (
+        AutoModelForCausalLM,
+        AutoTokenizer,
+        Trainer,
+        TrainingArguments,
+    )
 
     args = parse_args()
     random.seed(args.seed)
@@ -357,7 +392,9 @@ def main() -> None:
         "model": args.model,
         "output_dir": str(outdir / "adapter"),
     }
-    (outdir / "metrics.json").write_text(json.dumps(metrics, indent=2), encoding="utf-8")
+    (outdir / "metrics.json").write_text(
+        json.dumps(metrics, indent=2), encoding="utf-8"
+    )
 
     print(f"train_loss={metrics['train_loss']:.4f}")
     print(f"eval_loss={metrics['eval_loss']:.4f}")

--- a/src/open_range/__init__.py
+++ b/src/open_range/__init__.py
@@ -21,7 +21,11 @@ from open_range.compiler import EnterpriseSaaSManifestCompiler
 from open_range.curriculum import FrontierMutationPolicy, PopulationStats
 from open_range.driver import ScriptedRuntimeAgent, TandemEpisodeDriver
 from open_range.episode_config import DEFAULT_EPISODE_CONFIG, EpisodeConfig
-from open_range.manifest import EnterpriseSaaSManifest, manifest_schema, validate_manifest
+from open_range.manifest import (
+    EnterpriseSaaSManifest,
+    manifest_schema,
+    validate_manifest,
+)
 from open_range.objectives import ObjectiveGraderSpec, StandardAttackObjective
 from open_range.pipeline import BuildPipeline, CandidateWorld, admit, admit_child, build
 from open_range.resources import (

--- a/src/open_range/_runtime_store.py
+++ b/src/open_range/_runtime_store.py
@@ -13,10 +13,14 @@ def load_world_ir(store: FileSnapshotStore, snapshot_id: str) -> WorldIR:
     return WorldIR.model_validate_json(world_path.read_text(encoding="utf-8"))
 
 
-def hydrate_runtime_snapshot(store: FileSnapshotStore, snapshot: Snapshot) -> RuntimeSnapshot:
+def hydrate_runtime_snapshot(
+    store: FileSnapshotStore, snapshot: Snapshot
+) -> RuntimeSnapshot:
     world = load_world_ir(store, snapshot.snapshot_id)
     reference_path = store._reference_bundle_path(snapshot.snapshot_id)
-    reference_bundle = ReferenceBundle.model_validate_json(reference_path.read_text(encoding="utf-8"))
+    reference_bundle = ReferenceBundle.model_validate_json(
+        reference_path.read_text(encoding="utf-8")
+    )
     return RuntimeSnapshot.model_validate(
         {
             **snapshot.model_dump(mode="json"),
@@ -26,7 +30,9 @@ def hydrate_runtime_snapshot(store: FileSnapshotStore, snapshot: Snapshot) -> Ru
     )
 
 
-def load_runtime_snapshot(store: FileSnapshotStore, snapshot_id: str) -> RuntimeSnapshot:
+def load_runtime_snapshot(
+    store: FileSnapshotStore, snapshot_id: str
+) -> RuntimeSnapshot:
     return hydrate_runtime_snapshot(store, store.load(snapshot_id))
 
 
@@ -37,4 +43,6 @@ def sample_runtime_snapshot(
     seed: int | None = None,
     strategy: str = "random",
 ) -> RuntimeSnapshot:
-    return hydrate_runtime_snapshot(store, store.sample(split=split, seed=seed, strategy=strategy))
+    return hydrate_runtime_snapshot(
+        store, store.sample(split=split, seed=seed, strategy=strategy)
+    )

--- a/src/open_range/admission_plan.py
+++ b/src/open_range/admission_plan.py
@@ -36,8 +36,12 @@ def admission_stages(build_config: BuildConfig) -> tuple[AdmissionStagePlan, ...
         ),
     )
     reference_stages = (
-        AdmissionStagePlan("red_reference", ("red_reference",), requires_references=True),
-        AdmissionStagePlan("blue_reference", ("blue_reference",), requires_references=True),
+        AdmissionStagePlan(
+            "red_reference", ("red_reference",), requires_references=True
+        ),
+        AdmissionStagePlan(
+            "blue_reference", ("blue_reference",), requires_references=True
+        ),
     )
     advanced_stages = (
         AdmissionStagePlan("necessity", ("necessity",), requires_references=True),
@@ -54,8 +58,12 @@ def admission_stages(build_config: BuildConfig) -> tuple[AdmissionStagePlan, ...
             static_stage,
             live_stage,
             *reference_stages,
-            AdmissionStagePlan("shortcut", ("shortcut_probes",), requires_references=True),
-            AdmissionStagePlan("determinism", ("determinism",), requires_references=True),
+            AdmissionStagePlan(
+                "shortcut", ("shortcut_probes",), requires_references=True
+            ),
+            AdmissionStagePlan(
+                "determinism", ("determinism",), requires_references=True
+            ),
         )
     return (static_stage, live_stage, *reference_stages, *advanced_stages)
 

--- a/src/open_range/admission_scoring.py
+++ b/src/open_range/admission_scoring.py
@@ -2,7 +2,11 @@
 
 from __future__ import annotations
 
-from open_range.admission import ValidatorCheckReport, ValidatorStageReport, ReferenceBundle
+from open_range.admission import (
+    ValidatorCheckReport,
+    ValidatorStageReport,
+    ReferenceBundle,
+)
 from open_range.predicates import PredicateEngine
 from open_range.world_ir import WorldIR
 
@@ -45,7 +49,10 @@ def report_summary(
         shortcut_risk = "medium"
     else:
         shortcut_risk = "high"
-    live_service_count = float(health_info.get("live_service_count", len(world.services)) or len(world.services))
+    live_service_count = float(
+        health_info.get("live_service_count", len(world.services))
+        or len(world.services)
+    )
     continuity = min(1.0, live_service_count / max(1.0, float(len(world.services))))
     return {
         "graph_ok": all(
@@ -60,7 +67,8 @@ def report_summary(
         "boot_ok": all(
             checks.get(name, ValidatorCheckReport(name=name, passed=False)).passed
             for name in ("render_outputs", "service_health")
-        ) and all(
+        )
+        and all(
             checks.get(name, ValidatorCheckReport(name=name, passed=True)).passed
             for name in ("kind_boot", "kind_health")
         ),

--- a/src/open_range/admit.py
+++ b/src/open_range/admit.py
@@ -26,7 +26,7 @@ from open_range.objectives import evaluate_objective_grader_live
 from open_range.predicates import PredicateEngine
 from open_range.probe_planner import build_reference_bundle
 from open_range.probe_runner import run_blue_reference, run_red_reference
-from open_range.snapshot import KindArtifacts, RuntimeSnapshot, Snapshot, world_hash
+from open_range.snapshot import KindArtifacts, RuntimeSnapshot, world_hash
 from open_range.world_ir import ServiceSpec, WorldIR
 
 
@@ -39,7 +39,9 @@ class AdmissionController(Protocol):
     ) -> tuple[ReferenceBundle, ValidatorReport]: ...
 
 
-CheckFunc = Callable[[WorldIR, KindArtifacts, ReferenceBundle | None], ValidatorCheckReport]
+CheckFunc = Callable[
+    [WorldIR, KindArtifacts, ReferenceBundle | None], ValidatorCheckReport
+]
 
 
 class LocalAdmissionController:
@@ -70,7 +72,9 @@ class LocalAdmissionController:
         health_info: dict[str, object] = {"render_dir": artifacts.render_dir}
         live_backend = self.live_backend or self._auto_live_backend(build_config)
         health_info["live_backend_mode"] = (
-            "explicit" if self.live_backend is not None else ("auto" if live_backend is not None else "unavailable")
+            "explicit"
+            if self.live_backend is not None
+            else ("auto" if live_backend is not None else "unavailable")
         )
 
         check_map = self._check_map()
@@ -83,7 +87,11 @@ class LocalAdmissionController:
                     reference_bundle = build_reference_bundle(world, build_config)
                 result = check_map[check_name](world, artifacts, reference_bundle)
                 checks.append(result)
-                if self.mode == "fail_fast" and not result.passed and not result.advisory:
+                if (
+                    self.mode == "fail_fast"
+                    and not result.passed
+                    and not result.advisory
+                ):
                     continue_running = False
             stage_passed = all(result.passed or result.advisory for result in checks)
             stages.append(
@@ -99,7 +107,9 @@ class LocalAdmissionController:
         final_bundle = reference_bundle or build_reference_bundle(world, build_config)
 
         if continue_running and live_backend is not None:
-            live_stage, live_info = self._run_live_backend_checks(world, artifacts, final_bundle, live_backend)
+            live_stage, live_info = self._run_live_backend_checks(
+                world, artifacts, final_bundle, live_backend
+            )
             stages.append(live_stage)
             health_info.update(live_info)
             if self.mode == "fail_fast" and not live_stage.passed:
@@ -189,7 +199,9 @@ class LocalAdmissionController:
                         "expected_services": sorted(expected_services),
                         "discovered_services": sorted(discovered),
                     },
-                    error="" if expected_services <= discovered else "live release missing expected services",
+                    error=""
+                    if expected_services <= discovered
+                    else "live release missing expected services",
                 )
             )
 
@@ -206,7 +218,9 @@ class LocalAdmissionController:
                         "release_name": release.release_name,
                         "unhealthy_services": unhealthy,
                     },
-                    error="" if not unhealthy else "one or more live services failed readiness",
+                    error=""
+                    if not unhealthy
+                    else "one or more live services failed readiness",
                 )
             )
             snapshot = _ephemeral_snapshot(world, artifacts, reference_bundle)
@@ -268,14 +282,20 @@ class LocalAdmissionController:
         )
         if clusters.returncode != 0:
             return None
-        if "openrange" not in {line.strip() for line in clusters.stdout.splitlines() if line.strip()}:
+        if "openrange" not in {
+            line.strip() for line in clusters.stdout.splitlines() if line.strip()
+        }:
             return None
         return KindBackend()
 
 
-def _check_manifest_compliance(world: WorldIR, _artifacts: KindArtifacts, _wb: ReferenceBundle | None) -> ValidatorCheckReport:
+def _check_manifest_compliance(
+    world: WorldIR, _artifacts: KindArtifacts, _wb: ReferenceBundle | None
+) -> ValidatorCheckReport:
     allowed = {"web_app", "email", "idp", "fileshare", "db", "siem"}
-    invalid = sorted(service.kind for service in world.services if service.kind not in allowed)
+    invalid = sorted(
+        service.kind for service in world.services if service.kind not in allowed
+    )
     passed = world.world_family == "enterprise_saas_v1" and not invalid
     return ValidatorCheckReport(
         name="manifest_compliance",
@@ -285,7 +305,9 @@ def _check_manifest_compliance(world: WorldIR, _artifacts: KindArtifacts, _wb: R
     )
 
 
-def _check_graph_consistency(world: WorldIR, _artifacts: KindArtifacts, _wb: ReferenceBundle | None) -> ValidatorCheckReport:
+def _check_graph_consistency(
+    world: WorldIR, _artifacts: KindArtifacts, _wb: ReferenceBundle | None
+) -> ValidatorCheckReport:
     host_ids = {host.id for host in world.hosts}
     service_ids = {service.id for service in world.services}
     asset_ids = {asset.id for asset in world.assets}
@@ -298,14 +320,20 @@ def _check_graph_consistency(world: WorldIR, _artifacts: KindArtifacts, _wb: Ref
 
     for service in world.services:
         if service.host not in host_ids:
-            issues.append(f"service {service.id} references missing host {service.host}")
+            issues.append(
+                f"service {service.id} references missing host {service.host}"
+            )
         for dep in service.dependencies:
             if dep not in service_ids:
-                issues.append(f"service {service.id} references missing dependency {dep}")
+                issues.append(
+                    f"service {service.id} references missing dependency {dep}"
+                )
 
     for asset in world.assets:
         if asset.owner_service not in service_ids:
-            issues.append(f"asset {asset.id} references missing owner service {asset.owner_service}")
+            issues.append(
+                f"asset {asset.id} references missing owner service {asset.owner_service}"
+            )
 
     valid_nodes = (
         host_ids
@@ -330,9 +358,15 @@ def _check_graph_consistency(world: WorldIR, _artifacts: KindArtifacts, _wb: Ref
     )
 
 
-def _check_path_solvability(world: WorldIR, _artifacts: KindArtifacts, _wb: ReferenceBundle | None) -> ValidatorCheckReport:
+def _check_path_solvability(
+    world: WorldIR, _artifacts: KindArtifacts, _wb: ReferenceBundle | None
+) -> ValidatorCheckReport:
     predicates = PredicateEngine(world)
-    starts = {service.id for service in world.services if predicates.is_public_service(service)}
+    starts = {
+        service.id
+        for service in world.services
+        if predicates.is_public_service(service)
+    }
     unreachable = []
     for objective in world.red_objectives:
         target_service = predicates.objective_target_service(objective.predicate)
@@ -342,11 +376,15 @@ def _check_path_solvability(world: WorldIR, _artifacts: KindArtifacts, _wb: Refe
         name="path_solvability",
         passed=not unreachable,
         details={"starts": sorted(starts), "unreachable_targets": unreachable},
-        error="" if not unreachable else f"unreachable objective targets: {sorted(set(unreachable))}",
+        error=""
+        if not unreachable
+        else f"unreachable objective targets: {sorted(set(unreachable))}",
     )
 
 
-def _check_objective_grounding(world: WorldIR, _artifacts: KindArtifacts, _wb: ReferenceBundle | None) -> ValidatorCheckReport:
+def _check_objective_grounding(
+    world: WorldIR, _artifacts: KindArtifacts, _wb: ReferenceBundle | None
+) -> ValidatorCheckReport:
     predicates = PredicateEngine(world)
     issues = []
     graders = {}
@@ -370,16 +408,22 @@ def _check_objective_grounding(world: WorldIR, _artifacts: KindArtifacts, _wb: R
     )
 
 
-def _check_workflow_consistency(world: WorldIR, _artifacts: KindArtifacts, _wb: ReferenceBundle | None) -> ValidatorCheckReport:
+def _check_workflow_consistency(
+    world: WorldIR, _artifacts: KindArtifacts, _wb: ReferenceBundle | None
+) -> ValidatorCheckReport:
     service_ids = {service.id for service in world.services}
     asset_ids = {asset.id for asset in world.assets}
     issues = []
     for workflow in world.workflows:
         for step in workflow.steps:
             if step.service and step.service not in service_ids:
-                issues.append(f"workflow {workflow.id} references missing service {step.service}")
+                issues.append(
+                    f"workflow {workflow.id} references missing service {step.service}"
+                )
             if step.asset and step.asset not in asset_ids:
-                issues.append(f"workflow {workflow.id} references missing asset {step.asset}")
+                issues.append(
+                    f"workflow {workflow.id} references missing asset {step.asset}"
+                )
     return ValidatorCheckReport(
         name="topology_workflow_consistency",
         passed=not issues,
@@ -388,7 +432,9 @@ def _check_workflow_consistency(world: WorldIR, _artifacts: KindArtifacts, _wb: 
     )
 
 
-def _check_render_outputs(_world: WorldIR, artifacts: KindArtifacts, _wb: ReferenceBundle | None) -> ValidatorCheckReport:
+def _check_render_outputs(
+    _world: WorldIR, artifacts: KindArtifacts, _wb: ReferenceBundle | None
+) -> ValidatorCheckReport:
     missing = [path for path in artifacts.rendered_files if not Path(path).exists()]
     return ValidatorCheckReport(
         name="render_outputs",
@@ -398,7 +444,9 @@ def _check_render_outputs(_world: WorldIR, artifacts: KindArtifacts, _wb: Refere
     )
 
 
-def _check_service_health_contract(world: WorldIR, artifacts: KindArtifacts, _wb: ReferenceBundle | None) -> ValidatorCheckReport:
+def _check_service_health_contract(
+    world: WorldIR, artifacts: KindArtifacts, _wb: ReferenceBundle | None
+) -> ValidatorCheckReport:
     rendered = artifacts.chart_values.get("services", {})
     missing = [service.id for service in world.services if service.id not in rendered]
     passed = not missing and len(rendered) == len(world.services)
@@ -406,24 +454,35 @@ def _check_service_health_contract(world: WorldIR, artifacts: KindArtifacts, _wb
         name="service_health",
         passed=passed,
         details={"missing_services": missing, "rendered_service_count": len(rendered)},
-        error="" if passed else f"services missing from rendered chart values: {missing}",
+        error=""
+        if passed
+        else f"services missing from rendered chart values: {missing}",
     )
 
 
-def _check_siem_ingest(world: WorldIR, _artifacts: KindArtifacts, _wb: ReferenceBundle | None) -> ValidatorCheckReport:
+def _check_siem_ingest(
+    world: WorldIR, _artifacts: KindArtifacts, _wb: ReferenceBundle | None
+) -> ValidatorCheckReport:
     telemetry_targets = {edge.target for edge in world.telemetry_edges}
     actual_sources = {edge.source for edge in world.telemetry_edges}
-    expected_sources = {service.id for service in world.services if service.id != "svc-siem"}
+    expected_sources = {
+        service.id for service in world.services if service.id != "svc-siem"
+    }
     passed = "svc-siem" in telemetry_targets and expected_sources <= actual_sources
     return ValidatorCheckReport(
         name="siem_ingest",
         passed=passed,
-        details={"expected_sources": sorted(expected_sources), "actual_sources": sorted(actual_sources)},
+        details={
+            "expected_sources": sorted(expected_sources),
+            "actual_sources": sorted(actual_sources),
+        },
         error="" if passed else "not all services ship telemetry to svc-siem",
     )
 
 
-def _check_isolation(world: WorldIR, _artifacts: KindArtifacts, _wb: ReferenceBundle | None) -> ValidatorCheckReport:
+def _check_isolation(
+    world: WorldIR, _artifacts: KindArtifacts, _wb: ReferenceBundle | None
+) -> ValidatorCheckReport:
     issues = []
     host_by_id = {host.id: host for host in world.hosts}
     for service in world.services:
@@ -438,13 +497,17 @@ def _check_isolation(world: WorldIR, _artifacts: KindArtifacts, _wb: ReferenceBu
     )
 
 
-def _check_difficulty_envelope(world: WorldIR, _artifacts: KindArtifacts, _wb: ReferenceBundle | None) -> ValidatorCheckReport:
+def _check_difficulty_envelope(
+    world: WorldIR, _artifacts: KindArtifacts, _wb: ReferenceBundle | None
+) -> ValidatorCheckReport:
     predicates = PredicateEngine(world)
     red_depth = predicates.red_path_depth()
     lower = max(1, world.target_red_path_depth - 2)
     upper = world.target_red_path_depth + 2
     blue_signal_points = len({edge.source for edge in world.telemetry_edges})
-    passed = lower <= red_depth <= upper and blue_signal_points >= min(world.target_blue_signal_points, len(world.services))
+    passed = lower <= red_depth <= upper and blue_signal_points >= min(
+        world.target_blue_signal_points, len(world.services)
+    )
     return ValidatorCheckReport(
         name="difficulty_envelope",
         passed=passed,
@@ -454,11 +517,15 @@ def _check_difficulty_envelope(world: WorldIR, _artifacts: KindArtifacts, _wb: R
             "blue_signal_points": blue_signal_points,
             "target_blue_signal_points": world.target_blue_signal_points,
         },
-        error="" if passed else "world falls outside the configured difficulty envelope",
+        error=""
+        if passed
+        else "world falls outside the configured difficulty envelope",
     )
 
 
-def _check_red_reference(_world: WorldIR, _artifacts: KindArtifacts, wb: ReferenceBundle | None) -> ValidatorCheckReport:
+def _check_red_reference(
+    _world: WorldIR, _artifacts: KindArtifacts, wb: ReferenceBundle | None
+) -> ValidatorCheckReport:
     if wb is None or not wb.reference_attack_traces:
         return ValidatorCheckReport(
             name="red_reference",
@@ -483,7 +550,11 @@ def _check_red_reference(_world: WorldIR, _artifacts: KindArtifacts, wb: Referen
             events=events,
             service_health=dict(health),
         )
-        trace_passed = score.winner == "red" and score.done and predicates.red_terminal_satisfied(satisfied)
+        trace_passed = (
+            score.winner == "red"
+            and score.done
+            and predicates.red_terminal_satisfied(satisfied)
+        )
         passed = passed and trace_passed
         satisfied_all.update(satisfied)
         per_trace.append(
@@ -505,11 +576,15 @@ def _check_red_reference(_world: WorldIR, _artifacts: KindArtifacts, wb: Referen
             "satisfied_predicates": sorted(satisfied_all),
             "traces": per_trace,
         },
-        error="" if passed else "offline red reference did not satisfy terminal objectives",
+        error=""
+        if passed
+        else "offline red reference did not satisfy terminal objectives",
     )
 
 
-def _check_blue_reference(world: WorldIR, _artifacts: KindArtifacts, wb: ReferenceBundle | None) -> ValidatorCheckReport:
+def _check_blue_reference(
+    world: WorldIR, _artifacts: KindArtifacts, wb: ReferenceBundle | None
+) -> ValidatorCheckReport:
     if wb is None or not wb.reference_defense_traces:
         return ValidatorCheckReport(
             name="blue_reference",
@@ -522,7 +597,11 @@ def _check_blue_reference(world: WorldIR, _artifacts: KindArtifacts, wb: Referen
     passed = True
     for trace_index, trace in enumerate(wb.reference_defense_traces):
         score, outputs = run_blue_reference(snapshot, None, trace_index=trace_index)
-        trace_passed = score.winner == "blue" and score.done and len(trace.objective_ids) <= len(world.blue_objectives)
+        trace_passed = (
+            score.winner == "blue"
+            and score.done
+            and len(trace.objective_ids) <= len(world.blue_objectives)
+        )
         passed = passed and trace_passed
         per_trace.append(
             {
@@ -537,19 +616,27 @@ def _check_blue_reference(world: WorldIR, _artifacts: KindArtifacts, wb: Referen
         name="blue_reference",
         passed=passed,
         details={"trace_count": len(per_trace), "traces": per_trace},
-        error="" if passed else "offline blue reference did not validate detect-and-contain path",
+        error=""
+        if passed
+        else "offline blue reference did not validate detect-and-contain path",
     )
 
 
-def _check_necessity(world: WorldIR, _artifacts: KindArtifacts, wb: ReferenceBundle | None) -> ValidatorCheckReport:
+def _check_necessity(
+    world: WorldIR, _artifacts: KindArtifacts, wb: ReferenceBundle | None
+) -> ValidatorCheckReport:
     weaknesses = PredicateEngine(world).active_weaknesses()
     observability_sources = {edge.source for edge in world.telemetry_edges}
-    executable_targets = {weak.target for weak in weaknesses if remediation_command(weak)}
+    executable_targets = {
+        weak.target for weak in weaknesses if remediation_command(weak)
+    }
     trace_bindings = []
     if wb is not None:
         for trace_index, red_trace in enumerate(wb.reference_attack_traces):
             weakness_id = _reference_weakness_id(red_trace)
-            weakness = next((weak for weak in weaknesses if weak.id == weakness_id), None)
+            weakness = next(
+                (weak for weak in weaknesses if weak.id == weakness_id), None
+            )
             if weakness is not None:
                 trace_bindings.append((trace_index, red_trace, weakness))
     issues = []
@@ -563,13 +650,20 @@ def _check_necessity(world: WorldIR, _artifacts: KindArtifacts, wb: ReferenceBun
         issues.append("one or more weaknesses lack remediation metadata")
     if not executable_targets:
         issues.append("no executable remediation exists for live necessity checks")
-    elif not any(weakness.target in executable_targets for _idx, _trace, weakness in trace_bindings):
+    elif not any(
+        weakness.target in executable_targets
+        for _idx, _trace, weakness in trace_bindings
+    ):
         issues.append("no reference-relevant weakness has executable remediation")
     if not issues and trace_bindings:
         trace_results = []
         for trace_index, _trace, weakness in trace_bindings:
             counterfactual_world = world.model_copy(
-                update={"weaknesses": tuple(weak for weak in world.weaknesses if weak.id != weakness.id)}
+                update={
+                    "weaknesses": tuple(
+                        weak for weak in world.weaknesses if weak.id != weakness.id
+                    )
+                }
             )
             score, _events, _health, outputs = run_red_reference(
                 _ephemeral_snapshot(counterfactual_world, _artifacts, wb),
@@ -602,11 +696,21 @@ def _check_necessity(world: WorldIR, _artifacts: KindArtifacts, wb: ReferenceBun
     )
 
 
-def _check_shortcut_probes(world: WorldIR, _artifacts: KindArtifacts, wb: ReferenceBundle | None) -> ValidatorCheckReport:
+def _check_shortcut_probes(
+    world: WorldIR, _artifacts: KindArtifacts, wb: ReferenceBundle | None
+) -> ValidatorCheckReport:
     probes = wb.shortcut_probes if wb else ()
     predicates = PredicateEngine(world)
-    public_services = {service.id for service in world.services if predicates.is_public_service(service)}
-    critical_assets = {asset.owner_service for asset in world.assets if asset.confidentiality == "critical"}
+    public_services = {
+        service.id
+        for service in world.services
+        if predicates.is_public_service(service)
+    }
+    critical_assets = {
+        asset.owner_service
+        for asset in world.assets
+        if asset.confidentiality == "critical"
+    }
     issues = []
     if public_services & critical_assets:
         issues.append("critical asset exposed directly via public service")
@@ -622,7 +726,9 @@ def _check_shortcut_probes(world: WorldIR, _artifacts: KindArtifacts, wb: Refere
     )
 
 
-def _check_determinism(world: WorldIR, _artifacts: KindArtifacts, wb: ReferenceBundle | None) -> ValidatorCheckReport:
+def _check_determinism(
+    world: WorldIR, _artifacts: KindArtifacts, wb: ReferenceBundle | None
+) -> ValidatorCheckReport:
     regenerated = build_reference_bundle(
         world,
         BuildConfig(
@@ -632,7 +738,9 @@ def _check_determinism(world: WorldIR, _artifacts: KindArtifacts, wb: ReferenceB
     )
     snapshot = _ephemeral_snapshot(world, _artifacts, wb or regenerated)
     trace_results = []
-    passed = wb is not None and regenerated.model_dump(mode="json") == wb.model_dump(mode="json")
+    passed = wb is not None and regenerated.model_dump(mode="json") == wb.model_dump(
+        mode="json"
+    )
     for trace_index, trace in enumerate((wb or regenerated).reference_attack_traces):
         first_score, first_events, first_health, _first_outputs = run_red_reference(
             snapshot,
@@ -684,10 +792,18 @@ def _reference_weakness_id(trace) -> str:
     return ""
 
 
-def _ephemeral_snapshot(world: WorldIR, artifacts: KindArtifacts, reference_bundle: ReferenceBundle) -> RuntimeSnapshot:
+def _ephemeral_snapshot(
+    world: WorldIR, artifacts: KindArtifacts, reference_bundle: ReferenceBundle
+) -> RuntimeSnapshot:
     predicates = PredicateEngine(world)
-    db_seed_state = {"services": [service.id for service in world.services if service.kind == "db"]}
-    mail_state = {"mailboxes": [persona.mailbox for persona in world.green_personas if persona.mailbox]}
+    db_seed_state = {
+        "services": [service.id for service in world.services if service.kind == "db"]
+    }
+    mail_state = {
+        "mailboxes": [
+            persona.mailbox for persona in world.green_personas if persona.mailbox
+        ]
+    }
     file_assets = {asset.id: asset.location for asset in world.assets}
     identity_seed = {"users": [user.id for user in world.users]}
     report = ValidatorReport(
@@ -738,14 +854,19 @@ def _live_service_smoke_check(world: WorldIR, release) -> ValidatorCheckReport:
         "svc-idp": ("sandbox-blue", "nc -z -w 3 svc-idp 389"),
         "svc-fileshare": ("sandbox-blue", "nc -z -w 3 svc-fileshare 445"),
         "svc-db": ("sandbox-blue", "nc -z -w 3 svc-db 3306"),
-        "svc-siem": ("sandbox-blue", "wget -qO- http://svc-siem:9200/all.log >/dev/null"),
+        "svc-siem": (
+            "sandbox-blue",
+            "wget -qO- http://svc-siem:9200/all.log >/dev/null",
+        ),
     }
     failures: list[str] = []
     for service in world.services:
         runner, cmd = commands.get(service.id, ("sandbox-blue", "true"))
         result = run_async(release.pods.exec(runner, cmd, timeout=10.0))
         if not result.ok:
-            failures.append(f"{service.id}:{result.stderr or result.stdout or 'smoke failed'}")
+            failures.append(
+                f"{service.id}:{result.stderr or result.stdout or 'smoke failed'}"
+            )
     return ValidatorCheckReport(
         name="live_service_smoke",
         passed=not failures,
@@ -754,11 +875,15 @@ def _live_service_smoke_check(world: WorldIR, release) -> ValidatorCheckReport:
     )
 
 
-def _live_red_reference_check(snapshot: RuntimeSnapshot, release, backend: PodActionBackend) -> ValidatorCheckReport:
+def _live_red_reference_check(
+    snapshot: RuntimeSnapshot, release, backend: PodActionBackend
+) -> ValidatorCheckReport:
     predicates = PredicateEngine(snapshot.world)
     per_trace = []
     passed = True
-    for trace_index, trace in enumerate(snapshot.reference_bundle.reference_attack_traces):
+    for trace_index, trace in enumerate(
+        snapshot.reference_bundle.reference_attack_traces
+    ):
         score, events, health, outputs = run_red_reference(
             snapshot,
             backend,
@@ -780,7 +905,11 @@ def _live_red_reference_check(snapshot: RuntimeSnapshot, release, backend: PodAc
                 outputs=outputs,
             ):
                 satisfied.add(objective.predicate)
-        trace_passed = score.winner == "red" and score.done and predicates.red_terminal_satisfied(satisfied)
+        trace_passed = (
+            score.winner == "red"
+            and score.done
+            and predicates.red_terminal_satisfied(satisfied)
+        )
         passed = passed and trace_passed
         per_trace.append(
             {
@@ -796,14 +925,20 @@ def _live_red_reference_check(snapshot: RuntimeSnapshot, release, backend: PodAc
         name="live_red_reference",
         passed=passed,
         details={"trace_count": len(per_trace), "traces": per_trace},
-        error="" if passed else "live red reference did not satisfy terminal objectives",
+        error=""
+        if passed
+        else "live red reference did not satisfy terminal objectives",
     )
 
 
-def _live_blue_reference_check(snapshot: RuntimeSnapshot, backend: PodActionBackend) -> ValidatorCheckReport:
+def _live_blue_reference_check(
+    snapshot: RuntimeSnapshot, backend: PodActionBackend
+) -> ValidatorCheckReport:
     per_trace = []
     passed = True
-    for trace_index, trace in enumerate(snapshot.reference_bundle.reference_defense_traces):
+    for trace_index, trace in enumerate(
+        snapshot.reference_bundle.reference_defense_traces
+    ):
         score, outputs = run_blue_reference(snapshot, backend, trace_index=trace_index)
         trace_passed = score.winner == "blue" and score.done
         passed = passed and trace_passed
@@ -820,13 +955,17 @@ def _live_blue_reference_check(snapshot: RuntimeSnapshot, backend: PodActionBack
         name="live_blue_reference",
         passed=passed,
         details={"trace_count": len(per_trace), "traces": per_trace},
-        error="" if passed else "live blue reference did not validate detect-and-contain path",
+        error=""
+        if passed
+        else "live blue reference did not validate detect-and-contain path",
     )
 
 
 def _live_siem_ingest_check(release) -> ValidatorCheckReport:
     result = run_async(
-        release.pods.exec("svc-siem", "grep -q 'InitialAccess' /srv/http/siem/all.log", timeout=10.0)
+        release.pods.exec(
+            "svc-siem", "grep -q 'InitialAccess' /srv/http/siem/all.log", timeout=10.0
+        )
     )
     return ValidatorCheckReport(
         name="live_siem_ingest",
@@ -836,10 +975,14 @@ def _live_siem_ingest_check(release) -> ValidatorCheckReport:
     )
 
 
-def _live_determinism_check(snapshot: RuntimeSnapshot, backend: PodActionBackend) -> ValidatorCheckReport:
+def _live_determinism_check(
+    snapshot: RuntimeSnapshot, backend: PodActionBackend
+) -> ValidatorCheckReport:
     trace_results = []
     passed = True
-    for trace_index, trace in enumerate(snapshot.reference_bundle.reference_attack_traces):
+    for trace_index, trace in enumerate(
+        snapshot.reference_bundle.reference_attack_traces
+    ):
         first_score, first_events, first_health, _first_outputs = run_red_reference(
             snapshot,
             backend,
@@ -876,19 +1019,29 @@ def _live_determinism_check(snapshot: RuntimeSnapshot, backend: PodActionBackend
     )
 
 
-def _live_necessity_check(snapshot: RuntimeSnapshot, release, backend: PodActionBackend) -> ValidatorCheckReport:
+def _live_necessity_check(
+    snapshot: RuntimeSnapshot, release, backend: PodActionBackend
+) -> ValidatorCheckReport:
     trace_bindings = []
-    for trace_index, trace in enumerate(snapshot.reference_bundle.reference_attack_traces):
+    for trace_index, trace in enumerate(
+        snapshot.reference_bundle.reference_attack_traces
+    ):
         weakness_id = _reference_weakness_id(trace)
         if not weakness_id:
             continue
         weakness = next(
-            (weak for weak in PredicateEngine(snapshot.world).active_weaknesses() if weak.id == weakness_id),
+            (
+                weak
+                for weak in PredicateEngine(snapshot.world).active_weaknesses()
+                if weak.id == weakness_id
+            ),
             None,
         )
         if weakness is not None:
             trace_bindings.append((trace_index, trace, weakness))
-    red_targets = {step.target for _idx, trace, _weak in trace_bindings for step in trace.steps}
+    red_targets = {
+        step.target for _idx, trace, _weak in trace_bindings for step in trace.steps
+    }
     candidate_weaknesses = sorted(
         (
             weak
@@ -897,7 +1050,9 @@ def _live_necessity_check(snapshot: RuntimeSnapshot, release, backend: PodAction
         ),
         key=lambda weak: (
             0 if weak.instantiation_mode == "exact_code" else 1,
-            0 if trace_bindings and weak.target == trace_bindings[0][1].steps[0].target else 1,
+            0
+            if trace_bindings and weak.target == trace_bindings[0][1].steps[0].target
+            else 1,
             weak.id,
         ),
     )
@@ -921,8 +1076,13 @@ def _live_necessity_check(snapshot: RuntimeSnapshot, release, backend: PodAction
             },
             error="weakness remediation is not executable",
         )
-    apply_result = run_async(release.pods.exec(target_weakness.target, command, timeout=10.0))
-    trace_index = next((idx for idx, _trace, weak in trace_bindings if weak.id == target_weakness.id), 0)
+    apply_result = run_async(
+        release.pods.exec(target_weakness.target, command, timeout=10.0)
+    )
+    trace_index = next(
+        (idx for idx, _trace, weak in trace_bindings if weak.id == target_weakness.id),
+        0,
+    )
     score, _events, _health, outputs = run_red_reference(
         snapshot,
         backend,
@@ -950,7 +1110,9 @@ def _live_necessity_check(snapshot: RuntimeSnapshot, release, backend: PodAction
     )
 
 
-def _live_shortcut_probe_check(snapshot: RuntimeSnapshot, release) -> ValidatorCheckReport:
+def _live_shortcut_probe_check(
+    snapshot: RuntimeSnapshot, release
+) -> ValidatorCheckReport:
     host_by_id = {host.id: host for host in snapshot.world.hosts}
     service_by_id = {service.id: service for service in snapshot.world.services}
     public_services = [
@@ -970,11 +1132,21 @@ def _live_shortcut_probe_check(snapshot: RuntimeSnapshot, release) -> ValidatorC
     unexpected: list[str] = []
     for service_id in protected_targets:
         service = service_by_id[service_id]
-        result = run_async(release.pods.exec("sandbox-red", _service_probe_command(service), timeout=10.0))
+        result = run_async(
+            release.pods.exec(
+                "sandbox-red", _service_probe_command(service), timeout=10.0
+            )
+        )
         if result.ok:
             unexpected.append(f"direct_external_access:{service_id}")
     if "svc-idp" in service_by_id:
-        admin_probe = run_async(release.pods.exec("sandbox-red", _service_probe_command(service_by_id["svc-idp"]), timeout=10.0))
+        admin_probe = run_async(
+            release.pods.exec(
+                "sandbox-red",
+                _service_probe_command(service_by_id["svc-idp"]),
+                timeout=10.0,
+            )
+        )
         if admin_probe.ok:
             unexpected.append("direct_admin_access:svc-idp")
     unexpected.extend(_web_shortcut_findings(snapshot, release, public_services))
@@ -993,7 +1165,9 @@ def _service_probe_command(service: ServiceSpec) -> str:
     return f"nc -z -w 3 {service.id} {port}"
 
 
-def _web_shortcut_findings(snapshot: RuntimeSnapshot, release, public_services: list[ServiceSpec]) -> list[str]:
+def _web_shortcut_findings(
+    snapshot: RuntimeSnapshot, release, public_services: list[ServiceSpec]
+) -> list[str]:
     findings: list[str] = []
     for service in public_services:
         if service.kind != "web_app":
@@ -1007,7 +1181,11 @@ def _web_shortcut_findings(snapshot: RuntimeSnapshot, release, public_services: 
             if kind in seeded_kinds:
                 continue
             result = run_async(
-                release.pods.exec("sandbox-red", _http_probe_command(service, path, query), timeout=10.0)
+                release.pods.exec(
+                    "sandbox-red",
+                    _http_probe_command(service, path, query),
+                    timeout=10.0,
+                )
             )
             if _looks_like_shortcut_payload(result.stdout):
                 findings.append(f"unguarded_web_route:{service.id}:{kind}")
@@ -1027,7 +1205,9 @@ def _web_shortcut_findings(snapshot: RuntimeSnapshot, release, public_services: 
     return findings
 
 
-def _http_probe_command(service: ServiceSpec, path: str, query: dict[str, str] | None = None) -> str:
+def _http_probe_command(
+    service: ServiceSpec, path: str, query: dict[str, str] | None = None
+) -> str:
     port = service.ports[0] if service.ports else 80
     suffix = ""
     if query:
@@ -1082,7 +1262,14 @@ def _artifact_shortcut_findings(world: WorldIR, artifacts: KindArtifacts) -> lis
         return findings
 
     summary_payload: dict[str, object] | None = None
-    summary_path = next((Path(path) for path in artifacts.rendered_files if path.endswith("synth-summary.json")), None)
+    summary_path = next(
+        (
+            Path(path)
+            for path in artifacts.rendered_files
+            if path.endswith("synth-summary.json")
+        ),
+        None,
+    )
     if summary_path is not None and summary_path.exists():
         try:
             summary_payload = json.loads(summary_path.read_text(encoding="utf-8"))
@@ -1093,7 +1280,11 @@ def _artifact_shortcut_findings(world: WorldIR, artifacts: KindArtifacts) -> lis
         mailboxes = summary_payload.get("mailboxes", {})
         if isinstance(mailboxes, dict):
             for mailbox, messages in mailboxes.items():
-                joined = "\n".join(str(message) for message in messages) if isinstance(messages, list) else str(messages)
+                joined = (
+                    "\n".join(str(message) for message in messages)
+                    if isinstance(messages, list)
+                    else str(messages)
+                )
                 for ref, material in materials.items():
                     if material in joined and not _mailbox_leak_allowed(world, ref):
                         findings.append(f"mailbox_secret_leak:{mailbox}:{ref}")
@@ -1114,7 +1305,9 @@ def _artifact_shortcut_findings(world: WorldIR, artifacts: KindArtifacts) -> lis
 
 def _unlogged_critical_action_findings(world: WorldIR) -> list[str]:
     service_by_id = {service.id: service for service in world.services}
-    telemetry_sources = {edge.source for edge in world.telemetry_edges if edge.target == "svc-siem"}
+    telemetry_sources = {
+        edge.source for edge in world.telemetry_edges if edge.target == "svc-siem"
+    }
     findings: list[str] = []
     for weakness in PredicateEngine(world).active_weaknesses():
         if weakness.family == "telemetry_blindspot":
@@ -1126,8 +1319,12 @@ def _unlogged_critical_action_findings(world: WorldIR) -> list[str]:
             findings.append(f"unlogged_critical_action:no_siem_edge:{weakness.id}")
             continue
         expected_surfaces = set(weakness.blue_observability_surfaces) - {"svc-siem"}
-        if expected_surfaces and not (set(service.telemetry_surfaces) & expected_surfaces):
-            findings.append(f"unlogged_critical_action:no_surface_overlap:{weakness.id}")
+        if expected_surfaces and not (
+            set(service.telemetry_surfaces) & expected_surfaces
+        ):
+            findings.append(
+                f"unlogged_critical_action:no_surface_overlap:{weakness.id}"
+            )
     return findings
 
 

--- a/src/open_range/build_config.py
+++ b/src/open_range/build_config.py
@@ -23,7 +23,9 @@ class BuildConfig(BaseModel):
     phishing_surface_enabled: bool = True
     green_artifacts_enabled: bool = True
     topology_scale: Literal["small", "medium", "large"] = "medium"
-    validation_profile: Literal["full", "no_necessity", "graph_plus_live", "graph_only"] = "full"
+    validation_profile: Literal[
+        "full", "no_necessity", "graph_plus_live", "graph_only"
+    ] = "full"
     red_reference_count: int = Field(default=1, ge=1)
     blue_reference_count: int = Field(default=1, ge=1)
 

--- a/src/open_range/cli.py
+++ b/src/open_range/cli.py
@@ -46,12 +46,16 @@ def _load_manifest(path: str) -> dict[str, Any]:
 
 def _write_json(payload: dict[str, Any], dest: Path) -> Path:
     dest.parent.mkdir(parents=True, exist_ok=True)
-    dest.write_text(json.dumps(payload, indent=2, sort_keys=True) + "\n", encoding="utf-8")
+    dest.write_text(
+        json.dumps(payload, indent=2, sort_keys=True) + "\n", encoding="utf-8"
+    )
     return dest
 
 
 @click.group()
-@click.option("-v", "--verbose", is_flag=True, default=False, help="Enable debug logging.")
+@click.option(
+    "-v", "--verbose", is_flag=True, default=False, help="Enable debug logging."
+)
 @click.version_option(package_name="openenv-open-range", prog_name="openrange")
 def cli(verbose: bool) -> None:
     """Build, admit, and run immutable OpenRange snapshots."""
@@ -59,13 +63,27 @@ def cli(verbose: bool) -> None:
 
 
 @cli.command("build")
-@click.option("-m", "--manifest", required=True, type=click.Path(exists=True), help="Path to manifest YAML.")
-@click.option("-o", "--output", required=True, type=click.Path(), help="Output directory for rendered candidate artifacts.")
+@click.option(
+    "-m",
+    "--manifest",
+    required=True,
+    type=click.Path(exists=True),
+    help="Path to manifest YAML.",
+)
+@click.option(
+    "-o",
+    "--output",
+    required=True,
+    type=click.Path(),
+    help="Output directory for rendered candidate artifacts.",
+)
 def build_cmd(manifest: str, output: str) -> None:
     """Compile and render a candidate world from a manifest."""
     output_dir = Path(output)
     candidate = BuildPipeline().build(_load_manifest(manifest), output_dir)
-    world_path = _write_json(candidate.world.model_dump(mode="json"), output_dir / "candidate-world.json")
+    world_path = _write_json(
+        candidate.world.model_dump(mode="json"), output_dir / "candidate-world.json"
+    )
 
     click.echo(f"Candidate world written to {world_path}")
     click.echo(f"  World ID: {candidate.world.world_id}")
@@ -75,17 +93,41 @@ def build_cmd(manifest: str, output: str) -> None:
 
 
 @cli.command("admit")
-@click.option("-m", "--manifest", required=True, type=click.Path(exists=True), help="Path to manifest YAML.")
-@click.option("-o", "--output", required=True, type=click.Path(), help="Render directory for candidate artifacts.")
-@click.option("--store-dir", default="snapshots", type=click.Path(), help="Snapshot store directory.")
-@click.option("--split", default="train", type=click.Choice(["train", "eval"]), help="Pool split for the admitted snapshot.")
+@click.option(
+    "-m",
+    "--manifest",
+    required=True,
+    type=click.Path(exists=True),
+    help="Path to manifest YAML.",
+)
+@click.option(
+    "-o",
+    "--output",
+    required=True,
+    type=click.Path(),
+    help="Render directory for candidate artifacts.",
+)
+@click.option(
+    "--store-dir",
+    default="snapshots",
+    type=click.Path(),
+    help="Snapshot store directory.",
+)
+@click.option(
+    "--split",
+    default="train",
+    type=click.Choice(["train", "eval"]),
+    help="Pool split for the admitted snapshot.",
+)
 @click.option(
     "--validation-profile",
     default="full",
     type=click.Choice(["full", "no_necessity", "graph_plus_live", "graph_only"]),
     help="Admission strictness. Use graph_only for explicit offline admission.",
 )
-def admit_cmd(manifest: str, output: str, store_dir: str, split: str, validation_profile: str) -> None:
+def admit_cmd(
+    manifest: str, output: str, store_dir: str, split: str, validation_profile: str
+) -> None:
     """Build and admit a snapshot into the snapshot store."""
     pipeline = BuildPipeline(store=FileSnapshotStore(store_dir))
     candidate = pipeline.build(
@@ -104,13 +146,46 @@ def admit_cmd(manifest: str, output: str, store_dir: str, split: str, validation
 
 
 @cli.command("reset")
-@click.option("--store-dir", default="snapshots", type=click.Path(), help="Snapshot store directory.")
-@click.option("--snapshot-id", default=None, help="Snapshot id to restore. If omitted, sample from the requested split.")
-@click.option("--split", default="train", type=click.Choice(["train", "eval"]), help="Pool split to sample from when --snapshot-id is omitted.")
-@click.option("--strategy", default="random", type=click.Choice(["random", "latest"]), help="Sampling strategy when --snapshot-id is omitted.")
-@click.option("--sample-seed", default=0, type=int, help="Sampling seed when --snapshot-id is omitted.")
-@click.option("--mode", default="joint_pool", type=click.Choice(["red_only", "blue_only_live", "blue_only_from_prefix", "joint_pool"]), help="Episode runtime mode.")
-@click.option("--horizon", default=25.0, type=float, help="Simulated-time episode horizon.")
+@click.option(
+    "--store-dir",
+    default="snapshots",
+    type=click.Path(),
+    help="Snapshot store directory.",
+)
+@click.option(
+    "--snapshot-id",
+    default=None,
+    help="Snapshot id to restore. If omitted, sample from the requested split.",
+)
+@click.option(
+    "--split",
+    default="train",
+    type=click.Choice(["train", "eval"]),
+    help="Pool split to sample from when --snapshot-id is omitted.",
+)
+@click.option(
+    "--strategy",
+    default="random",
+    type=click.Choice(["random", "latest"]),
+    help="Sampling strategy when --snapshot-id is omitted.",
+)
+@click.option(
+    "--sample-seed",
+    default=0,
+    type=int,
+    help="Sampling seed when --snapshot-id is omitted.",
+)
+@click.option(
+    "--mode",
+    default="joint_pool",
+    type=click.Choice(
+        ["red_only", "blue_only_live", "blue_only_from_prefix", "joint_pool"]
+    ),
+    help="Episode runtime mode.",
+)
+@click.option(
+    "--horizon", default=25.0, type=float, help="Simulated-time episode horizon."
+)
 def reset_cmd(
     store_dir: str,
     snapshot_id: str | None,
@@ -139,12 +214,41 @@ def reset_cmd(
 
 
 @cli.command("traces")
-@click.option("-m", "--manifest", required=True, type=click.Path(exists=True), help="Path to manifest YAML.")
-@click.option("-o", "--output", required=True, type=click.Path(), help="Output directory for generated trace data.")
-@click.option("--roots", default=1, type=int, help="How many independent root lineages to generate.")
-@click.option("--mutations", default=3, type=int, help="How many admitted child mutations per lineage.")
-@click.option("--include-joint-pool", is_flag=True, default=False, help="Also export runtime joint_pool traces.")
-@click.option("--no-sim", is_flag=True, default=False, help="Skip sim-plane bootstrap traces.")
+@click.option(
+    "-m",
+    "--manifest",
+    required=True,
+    type=click.Path(exists=True),
+    help="Path to manifest YAML.",
+)
+@click.option(
+    "-o",
+    "--output",
+    required=True,
+    type=click.Path(),
+    help="Output directory for generated trace data.",
+)
+@click.option(
+    "--roots",
+    default=1,
+    type=int,
+    help="How many independent root lineages to generate.",
+)
+@click.option(
+    "--mutations",
+    default=3,
+    type=int,
+    help="How many admitted child mutations per lineage.",
+)
+@click.option(
+    "--include-joint-pool",
+    is_flag=True,
+    default=False,
+    help="Also export runtime joint_pool traces.",
+)
+@click.option(
+    "--no-sim", is_flag=True, default=False, help="Skip sim-plane bootstrap traces."
+)
 def traces_cmd(
     manifest: str,
     output: str,
@@ -164,7 +268,9 @@ def traces_cmd(
         include_sim=not no_sim,
         include_joint_pool=include_joint_pool,
     )
-    report_path = _write_json(report.model_dump(mode="json"), output_dir / "report.json")
+    report_path = _write_json(
+        report.model_dump(mode="json"), output_dir / "report.json"
+    )
 
     click.echo(f"Trace dataset written to {output_dir}")
     click.echo(f"  Rows: {report.rows}")

--- a/src/open_range/cluster.py
+++ b/src/open_range/cluster.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import asyncio
 import logging
 import shutil
 import subprocess
@@ -65,7 +66,9 @@ class PodSet:
             stdout, stderr = await asyncio.wait_for(proc.communicate(), timeout=timeout)
         except asyncio.TimeoutError:
             proc.kill()
-            return ExecResult(stdout="", stderr="<timeout>", exit_code=124, timed_out=True)
+            return ExecResult(
+                stdout="", stderr="<timeout>", exit_code=124, timed_out=True
+            )
         return ExecResult(
             stdout=(stdout or b"").decode(errors="replace"),
             stderr=(stderr or b"").decode(errors="replace"),
@@ -119,7 +122,9 @@ class PodSet:
         except asyncio.TimeoutError:
             proc.kill()
 
-    async def scale(self, service: str, replicas: int, timeout: float = 30.0) -> ExecResult:
+    async def scale(
+        self, service: str, replicas: int, timeout: float = 30.0
+    ) -> ExecResult:
         namespace, _pod = self._resolve(service)
         proc = await asyncio.create_subprocess_exec(
             *self.kubectl_cmd,
@@ -136,7 +141,9 @@ class PodSet:
             stdout, stderr = await asyncio.wait_for(proc.communicate(), timeout=timeout)
         except asyncio.TimeoutError:
             proc.kill()
-            return ExecResult(stdout="", stderr="<timeout>", exit_code=124, timed_out=True)
+            return ExecResult(
+                stdout="", stderr="<timeout>", exit_code=124, timed_out=True
+            )
         result = ExecResult(
             stdout=(stdout or b"").decode(errors="replace"),
             stderr=(stderr or b"").decode(errors="replace"),
@@ -157,7 +164,9 @@ class PodSet:
             stderr=asyncio.subprocess.PIPE,
         )
         try:
-            rollout_stdout, rollout_stderr = await asyncio.wait_for(rollout.communicate(), timeout=timeout)
+            rollout_stdout, rollout_stderr = await asyncio.wait_for(
+                rollout.communicate(), timeout=timeout
+            )
         except asyncio.TimeoutError:
             rollout.kill()
             return ExecResult(
@@ -167,8 +176,18 @@ class PodSet:
                 timed_out=True,
             )
         return ExecResult(
-            stdout="\n".join(filter(None, [result.stdout, (rollout_stdout or b'').decode(errors='replace')])).strip(),
-            stderr="\n".join(filter(None, [result.stderr, (rollout_stderr or b'').decode(errors='replace')])).strip(),
+            stdout="\n".join(
+                filter(
+                    None,
+                    [result.stdout, (rollout_stdout or b"").decode(errors="replace")],
+                )
+            ).strip(),
+            stderr="\n".join(
+                filter(
+                    None,
+                    [result.stderr, (rollout_stderr or b"").decode(errors="replace")],
+                )
+            ).strip(),
             exit_code=rollout.returncode or result.exit_code,
         )
 
@@ -247,7 +266,9 @@ class KindBackend:
         self._helm_install(release_name, chart_dir)
         pod_map = self._discover_pods(release_name)
         if not pod_map:
-            raise RuntimeError(f"installed release {release_name} but discovered no pods")
+            raise RuntimeError(
+                f"installed release {release_name} but discovered no pods"
+            )
         release = BootedRelease(
             release_name=release_name,
             chart_dir=chart_dir,
@@ -284,7 +305,9 @@ class KindBackend:
             pending = still_pending
             time.sleep(self.health_poll_interval_s)
         if pending:
-            raise RuntimeError("timed out waiting for healthy services: " + ", ".join(pending))
+            raise RuntimeError(
+                "timed out waiting for healthy services: " + ", ".join(pending)
+            )
 
     def prepare_images(self, chart_dir: Path) -> None:
         for image in self._chart_images(chart_dir):
@@ -292,7 +315,9 @@ class KindBackend:
 
     @staticmethod
     def release_name_for(snapshot_id: str) -> str:
-        safe = "".join(ch.lower() if ch.isalnum() else "-" for ch in snapshot_id).strip("-")
+        safe = "".join(ch.lower() if ch.isalnum() else "-" for ch in snapshot_id).strip(
+            "-"
+        )
         return f"or-{safe}"[:53]
 
     def _helm_install(self, release_name: str, chart_dir: Path) -> None:
@@ -362,7 +387,9 @@ class KindBackend:
         if not image:
             return
         if not self._docker_image_present(image):
-            self._run(["docker", "pull", image], timeout=max(self.install_timeout_s, 300.0))
+            self._run(
+                ["docker", "pull", image], timeout=max(self.install_timeout_s, 300.0)
+            )
         self._run(
             ["kind", "load", "docker-image", image, "--name", self.kind_cluster],
             timeout=max(self.install_timeout_s, 300.0),
@@ -379,7 +406,9 @@ class KindBackend:
         return result.returncode == 0
 
     @staticmethod
-    def _run(args: list[str] | tuple[str, ...], *, timeout: float) -> subprocess.CompletedProcess[str]:
+    def _run(
+        args: list[str] | tuple[str, ...], *, timeout: float
+    ) -> subprocess.CompletedProcess[str]:
         result = subprocess.run(
             list(args),
             capture_output=True,
@@ -389,5 +418,7 @@ class KindBackend:
         )
         if result.returncode != 0:
             detail = result.stderr.strip() or result.stdout.strip() or "unknown failure"
-            raise RuntimeError(f"{' '.join(args)} failed with exit code {result.returncode}: {detail}")
+            raise RuntimeError(
+                f"{' '.join(args)} failed with exit code {result.returncode}: {detail}"
+            )
         return result

--- a/src/open_range/code_web.py
+++ b/src/open_range/code_web.py
@@ -25,7 +25,9 @@ class CodeWebTemplate:
     expected_contains: str
 
 
-def code_web_realizations(world: WorldIR, weakness: WeaknessSpec) -> tuple[WeaknessRealizationSpec, ...]:
+def code_web_realizations(
+    world: WorldIR, weakness: WeaknessSpec
+) -> tuple[WeaknessRealizationSpec, ...]:
     template = code_web_template(world, weakness)
     realizations = [
         WeaknessRealizationSpec(
@@ -120,7 +122,9 @@ def code_web_payload(world: WorldIR, weakness: WeaknessSpec) -> dict[str, object
     }
 
 
-def code_web_realization_content(world: WorldIR, weakness: WeaknessSpec, realization: WeaknessRealizationSpec) -> str:
+def code_web_realization_content(
+    world: WorldIR, weakness: WeaknessSpec, realization: WeaknessRealizationSpec
+) -> str:
     if realization.path == _foothold_path(weakness):
         return _foothold_token(world, weakness) + "\n"
     if realization.path == _protected_record_path(weakness):
@@ -292,6 +296,8 @@ def _route_template(world: WorldIR, weakness: WeaknessSpec) -> str:
         ?>
         """
     )
+
+
 def _preferred_asset(world: WorldIR) -> str:
     for asset in world.assets:
         if asset.confidentiality == "critical":

--- a/src/open_range/compiler.py
+++ b/src/open_range/compiler.py
@@ -107,7 +107,11 @@ class EnterpriseSaaSManifestCompiler:
         manifest: dict | EnterpriseSaaSManifest,
         build_config: BuildConfig = DEFAULT_BUILD_CONFIG,
     ) -> WorldIR:
-        parsed = manifest if isinstance(manifest, EnterpriseSaaSManifest) else validate_manifest(manifest)
+        parsed = (
+            manifest
+            if isinstance(manifest, EnterpriseSaaSManifest)
+            else validate_manifest(manifest)
+        )
         if build_config.world_family != parsed.world_family:
             raise ValueError(
                 f"build_config.world_family={build_config.world_family!r} does not match manifest world_family={parsed.world_family!r}"
@@ -124,12 +128,16 @@ class EnterpriseSaaSManifestCompiler:
 
         for service_name in service_names:
             if service_name not in self._SERVICE_LAYOUT:
-                raise ValueError(f"unsupported enterprise_saas_v1 service: {service_name}")
+                raise ValueError(
+                    f"unsupported enterprise_saas_v1 service: {service_name}"
+                )
             layout = self._SERVICE_LAYOUT[service_name]
             zone = self._resolve_zone(parsed.topology.zones, layout["zone"])
             telemetry = layout["telemetry"]
             if allowed_surfaces:
-                telemetry = tuple(surface for surface in telemetry if surface in allowed_surfaces)
+                telemetry = tuple(
+                    surface for surface in telemetry if surface in allowed_surfaces
+                )
             hosts.append(
                 HostSpec(
                     id=layout["host_id"],
@@ -210,7 +218,8 @@ class EnterpriseSaaSManifestCompiler:
             allowed_code_flaw_kinds=allowed_code_flaw_kinds,
             pinned_weaknesses=parsed.security.pinned_weaknesses,
             target_weakness_count=self._target_weakness_budget(parsed, build_config),
-            phishing_surface_enabled=parsed.security.phishing_surface_enabled and build_config.phishing_surface_enabled,
+            phishing_surface_enabled=parsed.security.phishing_surface_enabled
+            and build_config.phishing_surface_enabled,
             target_red_path_depth=parsed.difficulty.target_red_path_depth,
             target_blue_signal_points=parsed.difficulty.target_blue_signal_points,
             zones=parsed.topology.zones,
@@ -441,24 +450,62 @@ class EnterpriseSaaSManifestCompiler:
     def _workflow_steps(workflow_name: str) -> tuple[WorkflowStepSpec, ...]:
         if workflow_name == "helpdesk_ticketing":
             return (
-                WorkflowStepSpec(id="open-ticket", actor_role="sales", action="open_ticket", service="svc-web"),
-                WorkflowStepSpec(id="mail-update", actor_role="sales", action="send_update", service="svc-email"),
+                WorkflowStepSpec(
+                    id="open-ticket",
+                    actor_role="sales",
+                    action="open_ticket",
+                    service="svc-web",
+                ),
+                WorkflowStepSpec(
+                    id="mail-update",
+                    actor_role="sales",
+                    action="send_update",
+                    service="svc-email",
+                ),
             )
         if workflow_name == "payroll_approval":
             return (
-                WorkflowStepSpec(id="view-payroll", actor_role="finance", action="view_payroll", service="svc-web", asset="payroll_db"),
-                WorkflowStepSpec(id="approve-payroll", actor_role="finance", action="approve_payroll", service="svc-db", asset="payroll_db"),
+                WorkflowStepSpec(
+                    id="view-payroll",
+                    actor_role="finance",
+                    action="view_payroll",
+                    service="svc-web",
+                    asset="payroll_db",
+                ),
+                WorkflowStepSpec(
+                    id="approve-payroll",
+                    actor_role="finance",
+                    action="approve_payroll",
+                    service="svc-db",
+                    asset="payroll_db",
+                ),
             )
         if workflow_name == "document_sharing":
             return (
-                WorkflowStepSpec(id="share-doc", actor_role="sales", action="share_document", service="svc-fileshare", asset="finance_docs"),
+                WorkflowStepSpec(
+                    id="share-doc",
+                    actor_role="sales",
+                    action="share_document",
+                    service="svc-fileshare",
+                    asset="finance_docs",
+                ),
             )
         if workflow_name == "internal_email":
             return (
-                WorkflowStepSpec(id="check-mail", actor_role="sales", action="check_mail", service="svc-email"),
+                WorkflowStepSpec(
+                    id="check-mail",
+                    actor_role="sales",
+                    action="check_mail",
+                    service="svc-email",
+                ),
             )
         return (
-            WorkflowStepSpec(id=f"{workflow_name}-step-1", actor_role="sales", action=workflow_name, service="svc-web"),
+            WorkflowStepSpec(
+                id=f"{workflow_name}-step-1",
+                actor_role="sales",
+                action=workflow_name,
+                service="svc-web",
+            ),
         )
 
     @staticmethod

--- a/src/open_range/counterfactuals.py
+++ b/src/open_range/counterfactuals.py
@@ -4,7 +4,10 @@ from __future__ import annotations
 
 from open_range.async_utils import run_async
 from open_range.code_web import code_web_cleanup_commands
-from open_range.effect_markers import effect_marker_cleanup_command, effect_marker_service
+from open_range.effect_markers import (
+    effect_marker_cleanup_command,
+    effect_marker_service,
+)
 from open_range.world_ir import WeaknessSpec, WorldIR
 
 

--- a/src/open_range/curriculum.py
+++ b/src/open_range/curriculum.py
@@ -21,7 +21,6 @@ from open_range.world_ir import (
     ServiceSpec,
     UserSpec,
     WeaknessSpec,
-    WorkflowSpec,
     WorkflowStepSpec,
     WorldIR,
 )
@@ -86,7 +85,9 @@ class MutationPolicy(Protocol):
 class FrontierMutationPolicy:
     """Heuristic deterministic curriculum policy for admitted worlds."""
 
-    def score_parents(self, population: list[PopulationStats]) -> tuple[ParentScore, ...]:
+    def score_parents(
+        self, population: list[PopulationStats]
+    ) -> tuple[ParentScore, ...]:
         ranked: list[ParentScore] = []
         for entry in population:
             if entry.split != "train":
@@ -135,7 +136,9 @@ class FrontierMutationPolicy:
             return ()
         stats_by_snapshot = {entry.snapshot_id: entry for entry in population}
         children: list[WorldIR] = []
-        for rank, score in enumerate(self.score_parents(population)[:child_count], start=1):
+        for rank, score in enumerate(
+            self.score_parents(population)[:child_count], start=1
+        ):
             world = load_world_ir(store, score.snapshot_id)
             child_seed = _stable_seed(world.world_id, score.snapshot_id, rank)
             children.append(
@@ -164,10 +167,18 @@ class FrontierMutationPolicy:
             child = updated
             applied.append(op)
 
-        effective_seed = child_seed if child_seed is not None else _stable_seed(parent.world_id, "child", len(applied))
+        effective_seed = (
+            child_seed
+            if child_seed is not None
+            else _stable_seed(parent.world_id, "child", len(applied))
+        )
         child_generation = parent.lineage.generation + 1
         op_tokens = tuple(_op_token(op) for op in applied)
-        suffix = hashlib.sha256("|".join(op_tokens).encode("utf-8")).hexdigest()[:8] if op_tokens else "noop0000"
+        suffix = (
+            hashlib.sha256("|".join(op_tokens).encode("utf-8")).hexdigest()[:8]
+            if op_tokens
+            else "noop0000"
+        )
         lineage = parent.lineage.model_copy(
             update={
                 "generation": child_generation,
@@ -189,10 +200,15 @@ class FrontierMutationPolicy:
         parent: WorldIR,
         parent_stats: PopulationStats | None,
     ) -> tuple[MutationOp, ...]:
-        stats = parent_stats or PopulationStats(snapshot_id="synthetic", world_id=parent.world_id)
+        stats = parent_stats or PopulationStats(
+            snapshot_id="synthetic", world_id=parent.world_id
+        )
         ops: list[MutationOp] = []
 
-        if parent.mutation_bounds.max_new_hosts > 0 and parent.mutation_bounds.max_new_services > 0:
+        if (
+            parent.mutation_bounds.max_new_hosts > 0
+            and parent.mutation_bounds.max_new_services > 0
+        ):
             objective_service = _first_objective_service(parent)
             if objective_service:
                 ops.append(MutationOp(kind="add_service", target=objective_service))
@@ -200,7 +216,9 @@ class FrontierMutationPolicy:
             ops.append(MutationOp(kind="add_host", target="corp"))
 
         if parent.mutation_bounds.max_new_users > 0:
-            ops.append(MutationOp(kind="add_user", target=_least_populated_role(parent)))
+            ops.append(
+                MutationOp(kind="add_user", target=_least_populated_role(parent))
+            )
 
         if stats.red_win_rate >= 0.65:
             ops.append(MutationOp(kind="add_noise_source"))
@@ -258,7 +276,9 @@ def propose_mutations(
     policy: FrontierMutationPolicy | None = None,
 ) -> tuple[WorldIR, ...]:
     """Generate deterministic child worlds from the train split."""
-    return (policy or FrontierMutationPolicy()).propose(store, population, child_count=child_count)
+    return (policy or FrontierMutationPolicy()).propose(
+        store, population, child_count=child_count
+    )
 
 
 def _op_token(op: MutationOp) -> str:
@@ -300,18 +320,29 @@ def _add_host(world: WorldIR) -> WorldIR | None:
         return None
     host_ids = {host.id for host in world.hosts}
     host_id = _next_host_id("workstation", host_ids)
-    hosts = world.hosts + (HostSpec(id=host_id, zone="corp", exposure="corp", services=()),)
+    hosts = world.hosts + (
+        HostSpec(id=host_id, zone="corp", exposure="corp", services=()),
+    )
     users = list(world.users)
     personas = list(world.green_personas)
     if users:
         users[0] = users[0].model_copy(update={"primary_host": host_id})
     if personas:
         personas[0] = personas[0].model_copy(update={"home_host": host_id})
-    return world.model_copy(update={"hosts": tuple(hosts), "users": tuple(users), "green_personas": tuple(personas)})
+    return world.model_copy(
+        update={
+            "hosts": tuple(hosts),
+            "users": tuple(users),
+            "green_personas": tuple(personas),
+        }
+    )
 
 
 def _add_service(world: WorldIR, *, objective_service_id: str) -> WorldIR | None:
-    if world.mutation_bounds.max_new_hosts < 1 or world.mutation_bounds.max_new_services < 1:
+    if (
+        world.mutation_bounds.max_new_hosts < 1
+        or world.mutation_bounds.max_new_services < 1
+    ):
         return None
     service_by_id = {service.id: service for service in world.services}
     source_service = service_by_id.get(objective_service_id)
@@ -321,8 +352,12 @@ def _add_service(world: WorldIR, *, objective_service_id: str) -> WorldIR | None
     source_host = host_by_id[source_service.host]
 
     new_host_id = _next_host_id(source_service.kind, set(host_by_id))
-    new_service_id = _next_service_id(source_service.id, {service.id for service in world.services})
-    dependency_ids = tuple(dict.fromkeys((source_service.id,) + source_service.dependencies))
+    new_service_id = _next_service_id(
+        source_service.id, {service.id for service in world.services}
+    )
+    dependency_ids = tuple(
+        dict.fromkeys((source_service.id,) + source_service.dependencies)
+    )
     new_host = HostSpec(
         id=new_host_id,
         zone=source_host.zone,
@@ -369,12 +404,18 @@ def _add_service(world: WorldIR, *, objective_service_id: str) -> WorldIR | None
     )
 
     assets = list(world.assets)
-    first_asset_id = predicate_inner(world.red_objectives[0].predicate) if world.red_objectives else ""
+    first_asset_id = (
+        predicate_inner(world.red_objectives[0].predicate)
+        if world.red_objectives
+        else ""
+    )
     for idx, asset in enumerate(assets):
         if asset.id != first_asset_id or asset.owner_service != source_service.id:
             continue
         location = _moved_asset_location(asset.location, new_service_id)
-        assets[idx] = asset.model_copy(update={"owner_service": new_service_id, "location": location})
+        assets[idx] = asset.model_copy(
+            update={"owner_service": new_service_id, "location": location}
+        )
         break
 
     return world.replace_edges(
@@ -394,13 +435,21 @@ def _add_user(world: WorldIR, *, role: str) -> WorldIR | None:
     if world.mutation_bounds.max_new_users < 1:
         return None
     existing_role_users = [user for user in world.users if user.role == role]
-    template_user = existing_role_users[0] if existing_role_users else (world.users[0] if world.users else None)
-    template_persona = next((persona for persona in world.green_personas if persona.role == role), None)
+    template_user = (
+        existing_role_users[0]
+        if existing_role_users
+        else (world.users[0] if world.users else None)
+    )
+    template_persona = next(
+        (persona for persona in world.green_personas if persona.role == role), None
+    )
     if template_user is None:
         return None
 
     user_id = _next_user_id(role, {user.id for user in world.users})
-    home_host = template_user.primary_host or (world.hosts[0].id if world.hosts else "web-1")
+    home_host = template_user.primary_host or (
+        world.hosts[0].id if world.hosts else "web-1"
+    )
     group_id = f"group-{role}"
 
     new_user = UserSpec(
@@ -425,7 +474,9 @@ def _add_user(world: WorldIR, *, role: str) -> WorldIR | None:
         mailbox=f"{user_id}@corp.local",
         awareness=template_persona.awareness if template_persona else 0.5,
         susceptibility=template_persona.susceptibility if template_persona else {},
-        routine=template_persona.routine if template_persona else ("check_mail", "browse_app"),
+        routine=template_persona.routine
+        if template_persona
+        else ("check_mail", "browse_app"),
     )
 
     groups = list(world.groups)
@@ -435,7 +486,9 @@ def _add_user(world: WorldIR, *, role: str) -> WorldIR | None:
         groups[idx] = group.model_copy(update={"members": group.members + (user_id,)})
         break
     else:
-        groups.append(GroupSpec(id=group_id, members=(user_id,), privileges=("svc-web",)))
+        groups.append(
+            GroupSpec(id=group_id, members=(user_id,), privileges=("svc-web",))
+        )
 
     return world.model_copy(
         update={
@@ -451,7 +504,10 @@ def _add_workflow_branch(world: WorldIR) -> WorldIR | None:
     if not world.workflows:
         return None
     workflow = world.workflows[0]
-    asset = next((item for item in world.assets if item.confidentiality in {"critical", "high"}), None)
+    asset = next(
+        (item for item in world.assets if item.confidentiality in {"critical", "high"}),
+        None,
+    )
     service_id = _first_objective_service(world)
     new_step = WorkflowStepSpec(
         id=f"{workflow.id}-branch-{len(workflow.steps) + 1}",
@@ -483,15 +539,26 @@ def _add_workflow_branch(world: WorldIR) -> WorldIR | None:
                 label=new_step.action,
             )
         )
-    return world.replace_edges(data=tuple(data_edges), workflow=tuple(workflow_edges)).model_copy(
-        update={"workflows": tuple(workflows)}
-    )
+    return world.replace_edges(
+        data=tuple(data_edges), workflow=tuple(workflow_edges)
+    ).model_copy(update={"workflows": tuple(workflows)})
 
 
 def _add_trust_edge(world: WorldIR) -> WorldIR | None:
     objective_service = _first_objective_service(world)
-    public_service = next((service.id for service in world.services if service.kind in {"web_app", "email"}), "")
-    if not public_service or not objective_service or public_service == objective_service:
+    public_service = next(
+        (
+            service.id
+            for service in world.services
+            if service.kind in {"web_app", "email"}
+        ),
+        "",
+    )
+    if (
+        not public_service
+        or not objective_service
+        or public_service == objective_service
+    ):
         return None
     edge_id = f"trust-{public_service}-to-{objective_service}-mut"
     if any(edge.id == edge_id for edge in world.trust_edges):
@@ -513,16 +580,26 @@ def _add_trust_edge(world: WorldIR) -> WorldIR | None:
 def _add_noise_source(world: WorldIR) -> WorldIR | None:
     workload = world.green_workload.model_copy(
         update={
-            "max_parallel_actions": min(world.green_workload.max_parallel_actions + 1, 8),
-            "reactive_branch_budget": min(world.green_workload.reactive_branch_budget + 1, 4),
+            "max_parallel_actions": min(
+                world.green_workload.max_parallel_actions + 1, 8
+            ),
+            "reactive_branch_budget": min(
+                world.green_workload.reactive_branch_budget + 1, 4
+            ),
         }
     )
     personas = list(world.green_personas)
     if personas:
         persona = personas[0]
-        routine = persona.routine if "send_update" in persona.routine else persona.routine + ("send_update",)
+        routine = (
+            persona.routine
+            if "send_update" in persona.routine
+            else persona.routine + ("send_update",)
+        )
         personas[0] = persona.model_copy(update={"routine": routine})
-    return world.model_copy(update={"green_workload": workload, "green_personas": tuple(personas)})
+    return world.model_copy(
+        update={"green_workload": workload, "green_personas": tuple(personas)}
+    )
 
 
 def _seed_additional_weakness(world: WorldIR) -> WorldIR | None:
@@ -575,20 +652,42 @@ def _patch_weakness(world: WorldIR) -> WorldIR | None:
 def _harden_route_expose_alternate(world: WorldIR) -> WorldIR | None:
     if not world.mutation_bounds.allow_patch_old_weaknesses:
         return None
-    start = next((service.id for service in world.services if service.kind == "web_app"), "")
+    start = next(
+        (service.id for service in world.services if service.kind == "web_app"), ""
+    )
     alternate = next(
-        (service.id for service in world.services if service.kind == "email" and service.id != start),
+        (
+            service.id
+            for service in world.services
+            if service.kind == "email" and service.id != start
+        ),
         "",
     )
     objective = _first_objective_service(world)
     route_target = _route_hardening_target(world, start, objective)
-    if not start or not objective or not route_target or start == objective or not alternate:
+    if (
+        not start
+        or not objective
+        or not route_target
+        or start == objective
+        or not alternate
+    ):
         return None
 
     direct_pairs = {(start, route_target), (route_target, start)}
-    network_edges = tuple(edge for edge in world.network_edges if (edge.source, edge.target) not in direct_pairs)
-    trust_edges = tuple(edge for edge in world.trust_edges if (edge.source, edge.target) not in direct_pairs)
-    if len(network_edges) == len(world.network_edges) and len(trust_edges) == len(world.trust_edges):
+    network_edges = tuple(
+        edge
+        for edge in world.network_edges
+        if (edge.source, edge.target) not in direct_pairs
+    )
+    trust_edges = tuple(
+        edge
+        for edge in world.trust_edges
+        if (edge.source, edge.target) not in direct_pairs
+    )
+    if len(network_edges) == len(world.network_edges) and len(trust_edges) == len(
+        world.trust_edges
+    ):
         return None
 
     alt_net_id = f"net-{alternate}-to-{objective}-alt"
@@ -617,12 +716,20 @@ def _harden_route_expose_alternate(world: WorldIR) -> WorldIR | None:
 
 
 def _route_hardening_target(world: WorldIR, start: str, objective: str) -> str:
-    if any(edge.source == start and edge.target == objective for edge in world.network_edges):
+    if any(
+        edge.source == start and edge.target == objective
+        for edge in world.network_edges
+    ):
         return objective
-    objective_service = next((service for service in world.services if service.id == objective), None)
+    objective_service = next(
+        (service for service in world.services if service.id == objective), None
+    )
     if objective_service is not None:
         for dependency in objective_service.dependencies:
-            if any(edge.source == start and edge.target == dependency for edge in world.network_edges):
+            if any(
+                edge.source == start and edge.target == dependency
+                for edge in world.network_edges
+            ):
                 return dependency
     for edge in world.network_edges:
         if edge.source == start and edge.target not in {"svc-db"}:
@@ -683,7 +790,11 @@ def _weakness_target(world: WorldIR, family: str) -> str | None:
         return service_by_kind.get("email") or service_by_kind.get("web_app")
     if objective_service:
         return objective_service
-    return service_by_kind.get("fileshare") or service_by_kind.get("db") or service_by_kind.get("idp")
+    return (
+        service_by_kind.get("fileshare")
+        or service_by_kind.get("db")
+        or service_by_kind.get("idp")
+    )
 
 
 def _make_weakness(
@@ -710,21 +821,38 @@ def _make_weakness(
     )
 
 
-def _mutation_kind_target(world: WorldIR, family: str, target_service: str) -> tuple[str, str, str]:
+def _mutation_kind_target(
+    world: WorldIR, family: str, target_service: str
+) -> tuple[str, str, str]:
     if family == "code_web":
         return "sql_injection", "service", target_service
     if family == "workflow_abuse":
-        workflow = next((item for item in world.workflows if item.name == "document_sharing"), None)
+        workflow = next(
+            (item for item in world.workflows if item.name == "document_sharing"), None
+        )
         if workflow is not None:
             return "document_share_abuse", "workflow", workflow.id
-        workflow = next((item for item in world.workflows if item.name == "internal_email"), None)
+        workflow = next(
+            (item for item in world.workflows if item.name == "internal_email"), None
+        )
         if workflow is not None:
             return "phishing_credential_capture", "workflow", workflow.id
         workflow = world.workflows[0] if world.workflows else None
-        return "helpdesk_reset_bypass", "workflow", workflow.id if workflow is not None else "wf-generic"
+        return (
+            "helpdesk_reset_bypass",
+            "workflow",
+            workflow.id if workflow is not None else "wf-generic",
+        )
     if family == "config_identity":
         if any(user.role == "it_admin" for user in world.users):
-            credential = next((item for item in world.credentials if item.subject.startswith("it_admin-")), None)
+            credential = next(
+                (
+                    item
+                    for item in world.credentials
+                    if item.subject.startswith("it_admin-")
+                ),
+                None,
+            )
             if credential is not None:
                 return "weak_password", "credential", credential.id
         return "admin_surface_exposed", "service", target_service
@@ -736,7 +864,9 @@ def _mutation_kind_target(world: WorldIR, family: str, target_service: str) -> t
         return "missing_idp_logs", "telemetry", target_service
     exposed_asset = next(
         (asset.id for asset in world.assets if asset.owner_service == target_service),
-        predicate_inner(world.red_objectives[0].predicate) if world.red_objectives else target_service,
+        predicate_inner(world.red_objectives[0].predicate)
+        if world.red_objectives
+        else target_service,
     )
     if target_service == "svc-email":
         return "token_in_email", "asset", exposed_asset
@@ -756,5 +886,7 @@ def mutation_summary(world: WorldIR) -> dict[str, object]:
         "user_count": len(world.users),
         "weakness_count": len(world.weaknesses),
         "telemetry_sources": sorted(edge.source for edge in world.telemetry_edges),
-        "workflows": json.loads(json.dumps([wf.model_dump(mode="json") for wf in world.workflows])),
+        "workflows": json.loads(
+            json.dumps([wf.model_dump(mode="json") for wf in world.workflows])
+        ),
     }

--- a/src/open_range/decision_surface.py
+++ b/src/open_range/decision_surface.py
@@ -7,7 +7,11 @@ import json
 from open_range.probe_planner import runtime_action
 from open_range.runtime_types import Action, Observation
 from open_range.snapshot import RuntimeSnapshot
-from open_range.training_data import TraceCandidate, normalize_trace_action, render_action_text
+from open_range.training_data import (
+    TraceCandidate,
+    normalize_trace_action,
+    render_action_text,
+)
 
 
 def expected_step(steps, index: int):
@@ -42,16 +46,24 @@ def candidate_actions(
     if actor == "red":
         candidates.extend(_red_alternatives(expected_action))
     else:
-        candidates.extend(_blue_alternatives(snapshot, observation, expected_action, remaining_targets))
+        candidates.extend(
+            _blue_alternatives(
+                snapshot, observation, expected_action, remaining_targets
+            )
+        )
     return dedupe_candidates(candidates)
 
 
-def select_candidate(candidates: tuple[TraceCandidate, ...], chosen_action: Action) -> tuple[TraceCandidate, ...]:
+def select_candidate(
+    candidates: tuple[TraceCandidate, ...], chosen_action: Action
+) -> tuple[TraceCandidate, ...]:
     token = json.dumps(chosen_action.model_dump(mode="json"), sort_keys=True)
     selected = []
     matched = False
     for candidate in candidates:
-        candidate_token = json.dumps(candidate.action.model_dump(mode="json"), sort_keys=True)
+        candidate_token = json.dumps(
+            candidate.action.model_dump(mode="json"), sort_keys=True
+        )
         is_match = candidate_token == token and not matched
         matched = matched or is_match
         selected.append(candidate.model_copy(update={"selected": is_match}))
@@ -98,7 +110,9 @@ def scripted_choice(
     return by_label.get("teacher", candidates[0]).action
 
 
-def reference_trace_pairs(snapshot: RuntimeSnapshot, mode: str) -> tuple[tuple[int, int], ...]:
+def reference_trace_pairs(
+    snapshot: RuntimeSnapshot, mode: str
+) -> tuple[tuple[int, int], ...]:
     attack_count = max(1, len(snapshot.reference_bundle.reference_attack_traces))
     defense_count = max(1, len(snapshot.reference_bundle.reference_defense_traces))
     if mode == "red_only":
@@ -109,7 +123,9 @@ def reference_trace_pairs(snapshot: RuntimeSnapshot, mode: str) -> tuple[tuple[i
     return tuple((idx % attack_count, idx % defense_count) for idx in range(count))
 
 
-def trace_actions(snapshot: RuntimeSnapshot, actor: str, *, trace_index: int) -> list[Action]:
+def trace_actions(
+    snapshot: RuntimeSnapshot, actor: str, *, trace_index: int
+) -> list[Action]:
     trace = (
         snapshot.reference_bundle.reference_attack_traces[trace_index]
         if actor == "red"
@@ -126,7 +142,10 @@ def dedupe_candidates(candidates: list[TraceCandidate]) -> tuple[TraceCandidate,
     deduped: list[TraceCandidate] = []
     selected_seen = False
     for candidate in candidates:
-        token = (candidate.text, json.dumps(candidate.action.model_dump(mode="json"), sort_keys=True))
+        token = (
+            candidate.text,
+            json.dumps(candidate.action.model_dump(mode="json"), sort_keys=True),
+        )
         if token in seen:
             continue
         seen.add(token)
@@ -142,7 +161,12 @@ def _red_alternatives(expected_action: Action) -> list[TraceCandidate]:
     target = str(expected_action.payload.get("target", ""))
     alternatives: list[TraceCandidate] = []
     if expected_action.kind == "api":
-        root_probe = Action(actor_id="red", role="red", kind="api", payload={"target": target, "path": "/"})
+        root_probe = Action(
+            actor_id="red",
+            role="red",
+            kind="api",
+            payload={"target": target, "path": "/"},
+        )
         alternatives.append(
             TraceCandidate(
                 label="root_probe",
@@ -152,7 +176,12 @@ def _red_alternatives(expected_action: Action) -> list[TraceCandidate]:
             )
         )
         if target != "svc-web":
-            web_probe = Action(actor_id="red", role="red", kind="api", payload={"target": "svc-web", "path": "/"})
+            web_probe = Action(
+                actor_id="red",
+                role="red",
+                kind="api",
+                payload={"target": "svc-web", "path": "/"},
+            )
             alternatives.append(
                 TraceCandidate(
                     label="web_probe",
@@ -162,8 +191,18 @@ def _red_alternatives(expected_action: Action) -> list[TraceCandidate]:
                 )
             )
     else:
-        recon_hosts = Action(actor_id="red", role="red", kind="shell", payload={"target": target, "command": "cat /etc/hosts"})
-        recon_net = Action(actor_id="red", role="red", kind="shell", payload={"target": target, "command": "ip -br a"})
+        recon_hosts = Action(
+            actor_id="red",
+            role="red",
+            kind="shell",
+            payload={"target": target, "command": "cat /etc/hosts"},
+        )
+        recon_net = Action(
+            actor_id="red",
+            role="red",
+            kind="shell",
+            payload={"target": target, "command": "ip -br a"},
+        )
         alternatives.extend(
             [
                 TraceCandidate(
@@ -202,7 +241,14 @@ def _blue_alternatives(
     alternatives: list[TraceCandidate] = []
     wrong_target = _service_not_in(
         snapshot,
-        excluded={target, *{event.target_entity for event in observation.visible_events if event.malicious}},
+        excluded={
+            target,
+            *{
+                event.target_entity
+                for event in observation.visible_events
+                if event.malicious
+            },
+        },
     )
     if expected_action.kind == "submit_finding":
         false_positive = Action(
@@ -210,7 +256,9 @@ def _blue_alternatives(
             role="blue",
             kind="submit_finding",
             payload={
-                "event_type": str(expected_action.payload.get("event_type", "InitialAccess")),
+                "event_type": str(
+                    expected_action.payload.get("event_type", "InitialAccess")
+                ),
                 "target": wrong_target or "svc-email",
             },
         )
@@ -223,7 +271,11 @@ def _blue_alternatives(
             )
         )
     if expected_action.kind == "control":
-        disruptive_target = _service_not_in(snapshot, excluded={target, *remaining_targets}) or wrong_target or target
+        disruptive_target = (
+            _service_not_in(snapshot, excluded={target, *remaining_targets})
+            or wrong_target
+            or target
+        )
         disruptive = normalize_trace_action(
             snapshot,
             Action(
@@ -245,7 +297,10 @@ def _blue_alternatives(
             )
         )
     if expected_action.kind != "submit_finding" and observation.visible_events:
-        visible = next((event for event in observation.visible_events if event.malicious), observation.visible_events[0])
+        visible = next(
+            (event for event in observation.visible_events if event.malicious),
+            observation.visible_events[0],
+        )
         opportunistic = Action(
             actor_id="blue",
             role="blue",
@@ -273,8 +328,17 @@ def _blue_alternatives(
 
 
 def _service_not_in(snapshot: RuntimeSnapshot, *, excluded: set[str]) -> str:
-    for preferred in ("svc-email", "svc-web", "svc-idp", "svc-fileshare", "svc-db", "svc-siem"):
-        if preferred not in excluded and any(service.id == preferred for service in snapshot.world.services):
+    for preferred in (
+        "svc-email",
+        "svc-web",
+        "svc-idp",
+        "svc-fileshare",
+        "svc-db",
+        "svc-siem",
+    ):
+        if preferred not in excluded and any(
+            service.id == preferred for service in snapshot.world.services
+        ):
             return preferred
     for service in snapshot.world.services:
         if service.id not in excluded:

--- a/src/open_range/driver.py
+++ b/src/open_range/driver.py
@@ -56,7 +56,9 @@ class TandemEpisodeDriver:
         if state.controls_blue:
             blue_agent.reset(briefing, "blue")
 
-        trace = EpisodeTrace(snapshot_id=snapshot.snapshot_id, episode_id=state.episode_id)
+        trace = EpisodeTrace(
+            snapshot_id=snapshot.snapshot_id, episode_id=state.episode_id
+        )
 
         while not self.runtime.state().done:
             decision = self.runtime.next_decision()

--- a/src/open_range/episode_config.py
+++ b/src/open_range/episode_config.py
@@ -7,12 +7,16 @@ from typing import Any, Literal
 from pydantic import BaseModel, ConfigDict, Field, field_validator
 
 
-TrainingMode = Literal["red_only", "blue_only_live", "blue_only_from_prefix", "joint_pool"]
+TrainingMode = Literal[
+    "red_only", "blue_only_live", "blue_only_from_prefix", "joint_pool"
+]
 SchedulerMode = Literal["async", "strict_turns"]
 GreenProfile = Literal["off", "low", "medium", "high"]
 GreenBranchBackend = Literal["none", "scripted", "small_llm", "workflow_orchestrator"]
 TelemetryDelayProfile = Literal["none", "low", "medium", "high"]
-OpponentController = Literal["none", "scripted", "reference", "frozen_policy", "checkpoint_pool", "replay"]
+OpponentController = Literal[
+    "none", "scripted", "reference", "frozen_policy", "checkpoint_pool", "replay"
+]
 PromptMode = Literal["zero_day", "one_day"]
 StartState = Literal[
     "clean",
@@ -72,15 +76,24 @@ class EpisodeConfig(BaseModel):
 
     @property
     def red_shaping_enabled(self) -> bool:
-        return self.reward_profile == "terminal_plus_shaping" and self.red_milestone_shaping_enabled
+        return (
+            self.reward_profile == "terminal_plus_shaping"
+            and self.red_milestone_shaping_enabled
+        )
 
     @property
     def blue_detection_shaping(self) -> bool:
-        return self.reward_profile == "terminal_plus_shaping" and self.blue_detection_shaping_enabled
+        return (
+            self.reward_profile == "terminal_plus_shaping"
+            and self.blue_detection_shaping_enabled
+        )
 
     @property
     def blue_containment_shaping(self) -> bool:
-        return self.reward_profile == "terminal_plus_shaping" and self.blue_containment_shaping_enabled
+        return (
+            self.reward_profile == "terminal_plus_shaping"
+            and self.blue_containment_shaping_enabled
+        )
 
 
 DEFAULT_EPISODE_CONFIG = EpisodeConfig()

--- a/src/open_range/examples/bootstrap.py
+++ b/src/open_range/examples/bootstrap.py
@@ -44,10 +44,18 @@ def _load_manifest(source: str | Path | None) -> dict[str, Any]:
 
 
 def _scripted_agents(snapshot):
-    attack_idx = snapshot.seed % max(1, len(snapshot.reference_bundle.reference_attack_traces))
-    defense_idx = snapshot.seed % max(1, len(snapshot.reference_bundle.reference_defense_traces))
-    red_agent = ScriptedRuntimeAgent(trace_actions(snapshot, "red", trace_index=attack_idx)[:2])
-    blue_agent = ScriptedRuntimeAgent(trace_actions(snapshot, "blue", trace_index=defense_idx)[1:3])
+    attack_idx = snapshot.seed % max(
+        1, len(snapshot.reference_bundle.reference_attack_traces)
+    )
+    defense_idx = snapshot.seed % max(
+        1, len(snapshot.reference_bundle.reference_defense_traces)
+    )
+    red_agent = ScriptedRuntimeAgent(
+        trace_actions(snapshot, "red", trace_index=attack_idx)[:2]
+    )
+    blue_agent = ScriptedRuntimeAgent(
+        trace_actions(snapshot, "blue", trace_index=defense_idx)[1:3]
+    )
     return red_agent, blue_agent
 
 
@@ -64,10 +72,14 @@ def run_bootstrap_demo(
         store = FileSnapshotStore(root / "snapshots")
         pipeline = BuildPipeline(store=store)
         candidate = pipeline.build(payload, root / "rendered", OFFLINE_BUILD_CONFIG)
-        snapshot = hydrate_runtime_snapshot(store, pipeline.admit(candidate, split="train"))
+        snapshot = hydrate_runtime_snapshot(
+            store, pipeline.admit(candidate, split="train")
+        )
 
         sim_plane = ReferenceSimPlane()
-        bootstrap_trace = sim_plane.generate_bootstrap_trace(snapshot, episode_seed=seed)
+        bootstrap_trace = sim_plane.generate_bootstrap_trace(
+            snapshot, episode_seed=seed
+        )
 
         runtime = ReferenceDrivenRuntime()
         driver = TandemEpisodeDriver(runtime)
@@ -76,7 +88,9 @@ def run_bootstrap_demo(
             snapshot,
             red_agent=red_agent,
             blue_agent=blue_agent,
-            episode_config=EpisodeConfig(mode="joint_pool", scheduler_mode="strict_turns"),
+            episode_config=EpisodeConfig(
+                mode="joint_pool", scheduler_mode="strict_turns"
+            ),
         )
         score = runtime.score()
 

--- a/src/open_range/examples/demo.py
+++ b/src/open_range/examples/demo.py
@@ -49,12 +49,22 @@ def run_demo(
         store = FileSnapshotStore(root / "snapshots")
         pipeline = BuildPipeline(store=store)
         candidate = pipeline.build(payload, root / "rendered", OFFLINE_BUILD_CONFIG)
-        snapshot = hydrate_runtime_snapshot(store, pipeline.admit(candidate, split="train"))
+        snapshot = hydrate_runtime_snapshot(
+            store, pipeline.admit(candidate, split="train")
+        )
 
-        attack_idx = seed % max(1, len(snapshot.reference_bundle.reference_attack_traces))
-        defense_idx = seed % max(1, len(snapshot.reference_bundle.reference_defense_traces))
-        red_agent = ScriptedRuntimeAgent(trace_actions(snapshot, "red", trace_index=attack_idx)[:2])
-        blue_agent = ScriptedRuntimeAgent(trace_actions(snapshot, "blue", trace_index=defense_idx)[1:3])
+        attack_idx = seed % max(
+            1, len(snapshot.reference_bundle.reference_attack_traces)
+        )
+        defense_idx = seed % max(
+            1, len(snapshot.reference_bundle.reference_defense_traces)
+        )
+        red_agent = ScriptedRuntimeAgent(
+            trace_actions(snapshot, "red", trace_index=attack_idx)[:2]
+        )
+        blue_agent = ScriptedRuntimeAgent(
+            trace_actions(snapshot, "blue", trace_index=defense_idx)[1:3]
+        )
 
         service = OpenRange(store=store)
         driver = TandemEpisodeDriver(service.runtime)
@@ -62,7 +72,9 @@ def run_demo(
             snapshot,
             red_agent=red_agent,
             blue_agent=blue_agent,
-            episode_config=EpisodeConfig(mode="joint_pool", scheduler_mode="strict_turns"),
+            episode_config=EpisodeConfig(
+                mode="joint_pool", scheduler_mode="strict_turns"
+            ),
         )
         score = service.score()
         events = service.runtime.export_events()
@@ -81,13 +93,19 @@ def run_demo(
         if not quiet:
             print(f"world={result['world_id']}")
             print(f"snapshot={result['snapshot_id']}")
-            print(f"winner={result['winner']} done={result['done']} turns={result['turn_count']}")
-            print(f"red_reward={result['red_reward']} blue_reward={result['blue_reward']}")
+            print(
+                f"winner={result['winner']} done={result['done']} turns={result['turn_count']}"
+            )
+            print(
+                f"red_reward={result['red_reward']} blue_reward={result['blue_reward']}"
+            )
         return result
 
 
 def main() -> None:
-    parser = argparse.ArgumentParser(description="Run a deterministic OpenRange demo episode.")
+    parser = argparse.ArgumentParser(
+        description="Run a deterministic OpenRange demo episode."
+    )
     parser.add_argument(
         "--manifest",
         default=None,

--- a/src/open_range/execution.py
+++ b/src/open_range/execution.py
@@ -50,7 +50,9 @@ class PodActionBackend:
     def bind(self, snapshot: RuntimeSnapshot, release: BootedRelease) -> None:
         self._snapshot = snapshot
         self._release = release
-        self._service_by_id = {service.id: service for service in snapshot.world.services}
+        self._service_by_id = {
+            service.id: service for service in snapshot.world.services
+        }
 
     def clear(self) -> None:
         self._snapshot = None
@@ -69,8 +71,12 @@ class PodActionBackend:
                 "source_entity": getattr(event, "source_entity", ""),
                 "target_entity": getattr(event, "target_entity", ""),
                 "malicious": getattr(event, "malicious", False),
-                "observability_surfaces": list(getattr(event, "observability_surfaces", ())),
-                "linked_objective_predicates": list(getattr(event, "linked_objective_predicates", ())),
+                "observability_surfaces": list(
+                    getattr(event, "observability_surfaces", ())
+                ),
+                "linked_objective_predicates": list(
+                    getattr(event, "linked_objective_predicates", ())
+                ),
             },
             sort_keys=True,
         )
@@ -105,7 +111,9 @@ class PodActionBackend:
         if self._release is None:
             return {}
         return {
-            service_id: 1.0 if run_async(self._release.pods.is_healthy(service_id)) else 0.0
+            service_id: 1.0
+            if run_async(self._release.pods.is_healthy(service_id))
+            else 0.0
             for service_id in sorted(self._service_by_id)
         }
 
@@ -125,13 +133,16 @@ class PodActionBackend:
             command = self._patch_command_for(target)
         else:
             command = "touch /tmp/openrange-contained"
-        result = run_async(self._release.pods.exec(target, command, timeout=action.timeout_s))
+        result = run_async(
+            self._release.pods.exec(target, command, timeout=action.timeout_s)
+        )
         return ActionExecution(
             stdout=result.stdout.strip(),
             stderr=result.stderr.strip(),
             ok=result.ok,
             service_health=self.service_health(),
-            containment_applied=result.ok and directive not in {"recover", "restore", "patch", "mitigate"},
+            containment_applied=result.ok
+            and directive not in {"recover", "restore", "patch", "mitigate"},
             patch_applied=result.ok and directive in {"patch", "mitigate"},
             recovery_applied=result.ok and directive in {"recover", "restore"},
         )
@@ -159,7 +170,9 @@ class PodActionBackend:
                     service_health=self.service_health(),
                 )
         runner = self._runner_for(action)
-        result = run_async(self._release.pods.exec(runner, command, timeout=action.timeout_s))
+        result = run_async(
+            self._release.pods.exec(runner, command, timeout=action.timeout_s)
+        )
         return ActionExecution(
             stdout=result.stdout.strip(),
             stderr=result.stderr.strip(),
@@ -188,7 +201,9 @@ class PodActionBackend:
                 ok=False,
                 service_health=self.service_health(),
             )
-        result = run_async(self._release.pods.exec(target, command, timeout=action.timeout_s))
+        result = run_async(
+            self._release.pods.exec(target, command, timeout=action.timeout_s)
+        )
         return ActionExecution(
             stdout=result.stdout.strip(),
             stderr=result.stderr.strip(),
@@ -272,7 +287,9 @@ class PodActionBackend:
     def _is_contained(self, target: str) -> bool:
         assert self._release is not None
         result = run_async(
-            self._release.pods.exec(target, "test ! -f /tmp/openrange-contained", timeout=5.0)
+            self._release.pods.exec(
+                target, "test ! -f /tmp/openrange-contained", timeout=5.0
+            )
         )
         return not result.ok
 
@@ -289,13 +306,19 @@ class PodActionBackend:
             )
             return not result.ok
         result = run_async(
-            self._release.pods.exec(target, "test ! -f /tmp/openrange-patched", timeout=5.0)
+            self._release.pods.exec(
+                target, "test ! -f /tmp/openrange-patched", timeout=5.0
+            )
         )
         return not result.ok
 
     def _patch_command_for(self, target: str) -> str:
         weakness = self._weakness_for(target)
-        if weakness is not None and weakness.remediation_kind == "shell" and weakness.remediation_command:
+        if (
+            weakness is not None
+            and weakness.remediation_kind == "shell"
+            and weakness.remediation_command
+        ):
             cleanup = effect_marker_cleanup_command(weakness)
             if cleanup:
                 return f"{weakness.remediation_command}\n{cleanup}"
@@ -315,7 +338,11 @@ class PodActionBackend:
 
     def _weakness_for(self, target: str) -> WeaknessSpec | None:
         assert self._snapshot is not None
-        return next((weak for weak in self._snapshot.world.weaknesses if weak.target == target), None)
+        return next(
+            (weak for weak in self._snapshot.world.weaknesses if weak.target == target),
+            None,
+        )
+
 
 def _green_sandbox_name(persona_id: str) -> str:
     safe = "".join(ch.lower() if ch.isalnum() else "-" for ch in persona_id).strip("-")

--- a/src/open_range/green.py
+++ b/src/open_range/green.py
@@ -13,7 +13,9 @@ from open_range.snapshot import RuntimeSnapshot
 
 
 class GreenScheduler(Protocol):
-    def reset(self, snapshot: RuntimeSnapshot, episode_config: EpisodeConfig) -> None: ...
+    def reset(
+        self, snapshot: RuntimeSnapshot, episode_config: EpisodeConfig
+    ) -> None: ...
     def advance_until(self, sim_time: float) -> None: ...
     def pop_ready_actions(self) -> tuple[Action, ...]: ...
     def record_event(self, event: RuntimeEvent) -> None: ...
@@ -63,7 +65,10 @@ class ScriptedGreenScheduler:
             or not event.malicious
         ):
             return
-        personas = sorted(self._snapshot.world.green_personas, key=lambda persona: (-persona.awareness, persona.id))
+        personas = sorted(
+            self._snapshot.world.green_personas,
+            key=lambda persona: (-persona.awareness, persona.id),
+        )
         if not personas:
             return
         backend = self._episode_config.green_branch_backend
@@ -97,13 +102,23 @@ class ScriptedGreenScheduler:
 
         rng = random.Random(self._seed + slot)
         personas.sort(key=lambda persona: persona.id)
-        max_parallel = min(self._parallel_budget(workload.max_parallel_actions), len(personas))
-        chosen = personas if max_parallel == len(personas) else rng.sample(personas, k=max_parallel)
+        max_parallel = min(
+            self._parallel_budget(workload.max_parallel_actions), len(personas)
+        )
+        chosen = (
+            personas
+            if max_parallel == len(personas)
+            else rng.sample(personas, k=max_parallel)
+        )
         chosen.sort(key=lambda persona: persona.id)
 
         actions = []
         for persona in chosen:
-            routine = persona.routine[slot % len(persona.routine)] if persona.routine else "browse_app"
+            routine = (
+                persona.routine[slot % len(persona.routine)]
+                if persona.routine
+                else "browse_app"
+            )
             service = _routine_service(routine)
             kind = "mail" if "mail" in routine else "api"
             actions.append(
@@ -158,13 +173,21 @@ class ScriptedGreenScheduler:
             return base_budget + 1
         return base_budget
 
-    def _schedule_scripted_reaction(self, event: RuntimeEvent, personas: list[Any], slot: int) -> None:
+    def _schedule_scripted_reaction(
+        self, event: RuntimeEvent, personas: list[Any], slot: int
+    ) -> None:
         reporter = personas[0]
-        self._reactive_queue[slot].append(self._report_action(reporter.id, event.target_entity, event.event_type))
+        self._reactive_queue[slot].append(
+            self._report_action(reporter.id, event.target_entity, event.event_type)
+        )
         if event.event_type in {"CredentialObtained", "UnauthorizedCredentialUse"}:
-            self._reactive_queue[slot].append(self._recover_action(reporter.id, event.target_entity))
+            self._reactive_queue[slot].append(
+                self._recover_action(reporter.id, event.target_entity)
+            )
 
-    def _schedule_small_llm_reaction(self, event: RuntimeEvent, personas: list[Any], slot: int) -> None:
+    def _schedule_small_llm_reaction(
+        self, event: RuntimeEvent, personas: list[Any], slot: int
+    ) -> None:
         reporter = max(
             personas,
             key=lambda persona: (
@@ -175,17 +198,25 @@ class ScriptedGreenScheduler:
         delay = 2 if event.event_type == "InitialAccess" else 1
         llm_slot = slot + delay - 1
         self._reactive_queue[llm_slot].append(
-            self._report_action(reporter.id, event.target_entity, event.event_type, depth=40)
+            self._report_action(
+                reporter.id, event.target_entity, event.event_type, depth=40
+            )
         )
-        if (
-            event.event_type in {"CredentialObtained", "UnauthorizedCredentialUse"}
-            and reporter.awareness >= (reporter.susceptibility * 0.8)
-        ):
-            self._reactive_queue[llm_slot].append(self._recover_action(reporter.id, event.target_entity))
+        if event.event_type in {
+            "CredentialObtained",
+            "UnauthorizedCredentialUse",
+        } and reporter.awareness >= (reporter.susceptibility * 0.8):
+            self._reactive_queue[llm_slot].append(
+                self._recover_action(reporter.id, event.target_entity)
+            )
 
-    def _schedule_workflow_orchestrator_reaction(self, event: RuntimeEvent, personas: list[Any], slot: int) -> None:
+    def _schedule_workflow_orchestrator_reaction(
+        self, event: RuntimeEvent, personas: list[Any], slot: int
+    ) -> None:
         reporter = personas[0]
-        self._reactive_queue[slot].append(self._report_action(reporter.id, event.target_entity, event.event_type))
+        self._reactive_queue[slot].append(
+            self._report_action(reporter.id, event.target_entity, event.event_type)
+        )
         self._reactive_queue[slot].append(
             Action(
                 actor_id=reporter.id,
@@ -200,11 +231,19 @@ class ScriptedGreenScheduler:
                 },
             )
         )
-        if event.event_type in {"CredentialObtained", "UnauthorizedCredentialUse", "InitialAccess"}:
-            self._reactive_queue[slot].append(self._recover_action(reporter.id, event.target_entity))
+        if event.event_type in {
+            "CredentialObtained",
+            "UnauthorizedCredentialUse",
+            "InitialAccess",
+        }:
+            self._reactive_queue[slot].append(
+                self._recover_action(reporter.id, event.target_entity)
+            )
 
     @staticmethod
-    def _report_action(actor_id: str, target: str, event_type: str, *, depth: int = 20) -> Action:
+    def _report_action(
+        actor_id: str, target: str, event_type: str, *, depth: int = 20
+    ) -> Action:
         return Action(
             actor_id=actor_id,
             role="green",

--- a/src/open_range/manifest.py
+++ b/src/open_range/manifest.py
@@ -13,6 +13,7 @@ from pydantic import BaseModel, ConfigDict, Field, PositiveInt, model_validator
 from open_range.objectives import PUBLIC_OBJECTIVE_PREDICATE_NAMES
 from open_range.predicate_expr import parse_predicate
 
+
 class _StrictModel(BaseModel):
     model_config = ConfigDict(extra="forbid", frozen=True, populate_by_name=True)
 
@@ -162,7 +163,9 @@ class ObjectivePredicate(_StrictModel):
         if expr.name not in PUBLIC_OBJECTIVE_PREDICATE_NAMES:
             raise ValueError(f"unsupported objective predicate {expr.name!r}")
         if "(" in self.predicate and not self.predicate.endswith(")"):
-            raise ValueError("objective predicate must end with ')' when using arguments")
+            raise ValueError(
+                "objective predicate must end with ')' when using arguments"
+            )
         return self
 
 
@@ -186,7 +189,9 @@ class PinnedWeaknessSpec(_StrictModel):
     @model_validator(mode="after")
     def _validate_family_kind_pair(self) -> "PinnedWeaknessSpec":
         if self.kind not in WEAKNESS_KIND_CATALOG[self.family]:
-            raise ValueError(f"unsupported kind {self.kind!r} for family {self.family!r}")
+            raise ValueError(
+                f"unsupported kind {self.kind!r} for family {self.family!r}"
+            )
         return self
 
 
@@ -204,13 +209,19 @@ class SecuritySpec(_StrictModel):
     def _validate_security_catalog(self) -> "SecuritySpec":
         allowed = set(self.allowed_weakness_families)
         if self.code_flaw_kinds and "code_web" not in allowed:
-            raise ValueError("code_flaw_kinds requires code_web in allowed_weakness_families")
+            raise ValueError(
+                "code_flaw_kinds requires code_web in allowed_weakness_families"
+            )
         for pinned in self.pinned_weaknesses:
             if pinned.family not in allowed:
                 raise ValueError(
                     f"pinned weakness family {pinned.family!r} is not enabled in allowed_weakness_families"
                 )
-            if pinned.family == "code_web" and self.code_flaw_kinds and pinned.kind not in self.code_flaw_kinds:
+            if (
+                pinned.family == "code_web"
+                and self.code_flaw_kinds
+                and pinned.kind not in self.code_flaw_kinds
+            ):
                 raise ValueError(
                     f"pinned code_web kind {pinned.kind!r} must be present in code_flaw_kinds when that list is set"
                 )

--- a/src/open_range/objectives.py
+++ b/src/open_range/objectives.py
@@ -6,10 +6,14 @@ from collections.abc import Iterable, Mapping
 import shlex
 from typing import Literal
 
-from pydantic import BaseModel, ConfigDict, Field
+from pydantic import BaseModel, ConfigDict
 
 from open_range.async_utils import run_async
-from open_range.effect_markers import effect_marker_path, effect_marker_service, effect_marker_token
+from open_range.effect_markers import (
+    effect_marker_path,
+    effect_marker_service,
+    effect_marker_token,
+)
 from open_range.predicate_expr import parse_predicate
 
 
@@ -66,7 +70,9 @@ class ObjectiveGraderSpec(_StrictModel):
     expected_ref: str = ""
 
 
-def weakness_objective_tags(family: str, kind: str) -> tuple[StandardAttackObjective, ...]:
+def weakness_objective_tags(
+    family: str, kind: str
+) -> tuple[StandardAttackObjective, ...]:
     catalog: dict[tuple[str, str], tuple[StandardAttackObjective, ...]] = {
         ("code_web", "sql_injection"): ("db_access",),
         ("code_web", "broken_authorization"): ("file_access",),
@@ -87,8 +93,12 @@ def weakness_objective_tags(family: str, kind: str) -> tuple[StandardAttackObjec
         ("workflow_abuse", "helpdesk_reset_bypass"): ("unauthorized_admin_login",),
         ("workflow_abuse", "approval_chain_bypass"): ("privilege_escalation",),
         ("workflow_abuse", "document_share_abuse"): ("file_access",),
-        ("workflow_abuse", "phishing_credential_capture"): ("unauthorized_admin_login",),
-        ("workflow_abuse", "internal_request_impersonation"): ("unauthorized_admin_login",),
+        ("workflow_abuse", "phishing_credential_capture"): (
+            "unauthorized_admin_login",
+        ),
+        ("workflow_abuse", "internal_request_impersonation"): (
+            "unauthorized_admin_login",
+        ),
     }
     return catalog.get((family, kind), ())
 
@@ -114,7 +124,11 @@ def objective_tags_for_predicate(
     }:
         return (expr.name,)  # type: ignore[return-value]
     if expr.name == "asset_read":
-        is_db = owner_service == "svc-db" or "db" in target.lower() or "mysql" in asset_location.lower()
+        is_db = (
+            owner_service == "svc-db"
+            or "db" in target.lower()
+            or "mysql" in asset_location.lower()
+        )
         return ("db_access",) if is_db else ("file_access",)
     if expr.name == "credential_obtained":
         return ("privilege_escalation",)
@@ -199,7 +213,11 @@ def objective_grader_for_predicate(
             target_id=resolved_target,
             expected_ref=resolved_target,
         )
-    event_type = "UnauthorizedCredentialUse" if tag == "unauthorized_admin_login" else "PrivilegeEscalation"
+    event_type = (
+        "UnauthorizedCredentialUse"
+        if tag == "unauthorized_admin_login"
+        else "PrivilegeEscalation"
+    )
     return ObjectiveGraderSpec(
         objective_tag=tag,
         grader_kind="event_present",
@@ -218,7 +236,9 @@ def evaluate_objective_grader(
     events: Iterable[object],
     service_health: Mapping[str, float],
 ) -> bool:
-    linked_events = [event for event in events if predicate in _event_linked_predicates(event)]
+    linked_events = [
+        event for event in events if predicate in _event_linked_predicates(event)
+    ]
     if grader.grader_kind == "event_present":
         return any(
             _event_type(event) == grader.event_type
@@ -227,10 +247,14 @@ def evaluate_objective_grader(
         )
     if grader.grader_kind == "service_health":
         health = service_health.get(grader.service_id or grader.target_id, 1.0)
-        return health < 0.9 or any(_event_type(event) == "ServiceDegraded" for event in linked_events)
+        return health < 0.9 or any(
+            _event_type(event) == "ServiceDegraded" for event in linked_events
+        )
     if grader.grader_kind == "file_exists":
         file_assets = _snapshot_mapping(snapshot, "file_assets")
-        has_target = grader.target_id in file_assets or grader.path in file_assets.values()
+        has_target = (
+            grader.target_id in file_assets or grader.path in file_assets.values()
+        )
         return has_target and bool(linked_events)
     if grader.grader_kind in {"db_row_read", "db_row_write"}:
         db_seed_state = _snapshot_mapping(snapshot, "db_seed_state")
@@ -251,7 +275,9 @@ def evaluate_objective_grader_live(
     service_health: Mapping[str, float],
     outputs: Iterable[str],
 ) -> bool:
-    linked_events = [event for event in events if predicate in _event_linked_predicates(event)]
+    linked_events = [
+        event for event in events if predicate in _event_linked_predicates(event)
+    ]
     combined_output = "\n".join(output for output in outputs if output)
     if grader.grader_kind == "event_present":
         matched = any(
@@ -270,7 +296,9 @@ def evaluate_objective_grader_live(
         return True
     if grader.grader_kind == "service_health":
         health = service_health.get(grader.service_id or grader.target_id, 1.0)
-        return health < 0.9 or any(_event_type(event) == "ServiceDegraded" for event in linked_events)
+        return health < 0.9 or any(
+            _event_type(event) == "ServiceDegraded" for event in linked_events
+        )
     if not getattr(pods, "exec", None):
         return False
     if grader.grader_kind == "file_exists":
@@ -278,28 +306,35 @@ def evaluate_objective_grader_live(
         if grader.expected_ref:
             command += f" && grep -q {shlex.quote(grader.expected_ref)} {shlex.quote(grader.path)}"
         result = run_async(pods.exec(grader.service_id, command, timeout=10.0))
-        return result.ok and (grader.expected_ref in combined_output or bool(linked_events))
+        return result.ok and (
+            grader.expected_ref in combined_output or bool(linked_events)
+        )
     if grader.grader_kind == "db_row_read":
-        query = (
-            "mysql -uapp -papp-pass app -Nse "
-            + shlex.quote(
-                "SELECT contents FROM assets "
-                f"WHERE asset_id = '{grader.target_id}' "
-                "LIMIT 1;"
+        query = "mysql -uapp -papp-pass app -Nse " + shlex.quote(
+            "SELECT contents FROM assets "
+            f"WHERE asset_id = '{grader.target_id}' "
+            "LIMIT 1;"
+        )
+        result = run_async(
+            pods.exec(grader.service_id or "svc-db", query, timeout=10.0)
+        )
+        return (
+            result.ok
+            and bool(result.stdout.strip())
+            and (
+                grader.target_id in result.stdout
+                or grader.expected_ref in result.stdout
             )
         )
-        result = run_async(pods.exec(grader.service_id or "svc-db", query, timeout=10.0))
-        return result.ok and bool(result.stdout.strip()) and (grader.target_id in result.stdout or grader.expected_ref in result.stdout)
     if grader.grader_kind == "db_row_write":
-        query = (
-            "mysql -uapp -papp-pass app -Nse "
-            + shlex.quote(
-                "SELECT COUNT(*) FROM assets "
-                f"WHERE asset_id = '{grader.target_id}' "
-                "LIMIT 1;"
-            )
+        query = "mysql -uapp -papp-pass app -Nse " + shlex.quote(
+            "SELECT COUNT(*) FROM assets "
+            f"WHERE asset_id = '{grader.target_id}' "
+            "LIMIT 1;"
         )
-        result = run_async(pods.exec(grader.service_id or "svc-db", query, timeout=10.0))
+        result = run_async(
+            pods.exec(grader.service_id or "svc-db", query, timeout=10.0)
+        )
         return result.ok and result.stdout.strip() not in {"", "0"}
     if grader.grader_kind == "outbound_request":
         if not linked_events:
@@ -328,7 +363,9 @@ def evaluate_red_objectives(
             continue
         grader = graders.get(predicate)
         if grader is None:
-            if any(predicate in _event_linked_predicates(event) for event in event_list):
+            if any(
+                predicate in _event_linked_predicates(event) for event in event_list
+            ):
                 satisfied.add(predicate)
             continue
         if evaluate_objective_grader(
@@ -349,7 +386,9 @@ def _snapshot_mapping(snapshot: object, attr: str) -> dict[str, object]:
     return {}
 
 
-def _probe_live_objective_effect(snapshot: object, pods: object, grader: ObjectiveGraderSpec) -> bool:
+def _probe_live_objective_effect(
+    snapshot: object, pods: object, grader: ObjectiveGraderSpec
+) -> bool:
     effect_paths = _effect_marker_specs(snapshot, grader)
     if effect_paths and _probe_effect_paths(pods, effect_paths):
         return True
@@ -368,14 +407,20 @@ def _probe_live_objective_effect(snapshot: object, pods: object, grader: Objecti
 
 
 def _requires_effect_probe(snapshot: object, grader: ObjectiveGraderSpec) -> bool:
-    if grader.objective_tag not in {"unauthorized_admin_login", "privilege_escalation", "outbound_service"}:
+    if grader.objective_tag not in {
+        "unauthorized_admin_login",
+        "privilege_escalation",
+        "outbound_service",
+    }:
         return False
     if _relevant_weaknesses(snapshot, grader):
         return True
     return bool(_relevant_realizations(snapshot, grader))
 
 
-def _effect_marker_specs(snapshot: object, grader: ObjectiveGraderSpec) -> tuple[tuple[str, str, str], ...]:
+def _effect_marker_specs(
+    snapshot: object, grader: ObjectiveGraderSpec
+) -> tuple[tuple[str, str, str], ...]:
     matches: list[tuple[str, str, str]] = []
     for weakness in _relevant_weaknesses(snapshot, grader):
         service = effect_marker_service(weakness)
@@ -386,7 +431,9 @@ def _effect_marker_specs(snapshot: object, grader: ObjectiveGraderSpec) -> tuple
     return tuple(dict.fromkeys(matches))
 
 
-def _relevant_weaknesses(snapshot: object, grader: ObjectiveGraderSpec) -> tuple[object, ...]:
+def _relevant_weaknesses(
+    snapshot: object, grader: ObjectiveGraderSpec
+) -> tuple[object, ...]:
     world = getattr(snapshot, "world", None)
     weaknesses = getattr(world, "weaknesses", ()) if world is not None else ()
     matches: list[object] = []
@@ -407,7 +454,9 @@ def _relevant_weaknesses(snapshot: object, grader: ObjectiveGraderSpec) -> tuple
     return tuple(matches)
 
 
-def _relevant_realizations(snapshot: object, grader: ObjectiveGraderSpec) -> tuple[tuple[str, str], ...]:
+def _relevant_realizations(
+    snapshot: object, grader: ObjectiveGraderSpec
+) -> tuple[tuple[str, str], ...]:
     matches: list[tuple[str, str]] = []
     for weakness in _relevant_weaknesses(snapshot, grader):
         for realization in getattr(weakness, "realization", ()):
@@ -433,32 +482,99 @@ def _live_effect_probe_commands(
         path = _first_realization_path(realizations, "config")
         if path:
             if kind == "weak_password":
-                commands.append((target, _grep_all(path, '"min_password_length": 6', '"password_reuse_allowed": true')))
+                commands.append(
+                    (
+                        target,
+                        _grep_all(
+                            path,
+                            '"min_password_length": 6',
+                            '"password_reuse_allowed": true',
+                        ),
+                    )
+                )
             elif kind == "default_credential":
-                commands.append((target, _grep_all(path, '"default_username": "admin"', '"default_password": "admin"')))
+                commands.append(
+                    (
+                        target,
+                        _grep_all(
+                            path,
+                            '"default_username": "admin"',
+                            '"default_password": "admin"',
+                        ),
+                    )
+                )
             elif kind == "overbroad_service_account":
-                commands.append((target, _grep_all(path, '"service_account_scope"', "svc-db", "svc-idp")))
+                commands.append(
+                    (
+                        target,
+                        _grep_all(path, '"service_account_scope"', "svc-db", "svc-idp"),
+                    )
+                )
             elif kind == "admin_surface_exposed":
-                commands.append((target, _grep_all(path, '"admin_surface_public": true')))
+                commands.append(
+                    (target, _grep_all(path, '"admin_surface_public": true'))
+                )
             elif kind == "trust_edge_misconfig":
-                commands.append((target, _grep_all(path, '"trust_scope": "corp-wide"', '"peer_validation": false')))
+                commands.append(
+                    (
+                        target,
+                        _grep_all(
+                            path,
+                            '"trust_scope": "corp-wide"',
+                            '"peer_validation": false',
+                        ),
+                    )
+                )
 
     if family == "workflow_abuse":
         workflow_path = _first_realization_path(realizations, "workflow")
         mailbox_path = _first_realization_path(realizations, "mailbox")
         if workflow_path:
             if kind == "helpdesk_reset_bypass":
-                commands.append((target, _grep_all(workflow_path, '"identity_verification": "none"', '"reset_without_ticket_owner": true')))
+                commands.append(
+                    (
+                        target,
+                        _grep_all(
+                            workflow_path,
+                            '"identity_verification": "none"',
+                            '"reset_without_ticket_owner": true',
+                        ),
+                    )
+                )
             elif kind == "approval_chain_bypass":
-                commands.append((target, _grep_all(workflow_path, '"secondary_approval_skipped": true')))
+                commands.append(
+                    (
+                        target,
+                        _grep_all(workflow_path, '"secondary_approval_skipped": true'),
+                    )
+                )
             elif kind == "document_share_abuse":
-                commands.append((target, _grep_all(workflow_path, '"share_visibility": "public_link"')))
+                commands.append(
+                    (
+                        target,
+                        _grep_all(workflow_path, '"share_visibility": "public_link"'),
+                    )
+                )
             elif kind == "phishing_credential_capture":
-                commands.append((target, _grep_all(workflow_path, '"credential_capture_landing": "/login"')))
+                commands.append(
+                    (
+                        target,
+                        _grep_all(
+                            workflow_path, '"credential_capture_landing": "/login"'
+                        ),
+                    )
+                )
             elif kind == "internal_request_impersonation":
-                commands.append((target, _grep_all(workflow_path, '"internal_alias_trust": true')))
+                commands.append(
+                    (target, _grep_all(workflow_path, '"internal_alias_trust": true'))
+                )
         if mailbox_path:
-            commands.append((target, _grep_any(mailbox_path, f"kind={kind}", "Subject:", target_ref)))
+            commands.append(
+                (
+                    target,
+                    _grep_any(mailbox_path, f"kind={kind}", "Subject:", target_ref),
+                )
+            )
 
     if family == "secret_exposure":
         for realization in realizations:
@@ -468,27 +584,70 @@ def _live_effect_probe_commands(
             if not service or not path:
                 continue
             if kind_name == "mailbox":
-                commands.append((service, _grep_any(path, "secret_material=", target_ref, grader.expected_ref)))
+                commands.append(
+                    (
+                        service,
+                        _grep_any(
+                            path, "secret_material=", target_ref, grader.expected_ref
+                        ),
+                    )
+                )
             elif kind == "backup_leak":
-                commands.append((service, _grep_any(path, "INSERT INTO leaked_credentials", target_ref)))
+                commands.append(
+                    (
+                        service,
+                        _grep_any(path, "INSERT INTO leaked_credentials", target_ref),
+                    )
+                )
             elif kind == "env_file_leak":
-                commands.append((service, _grep_any(path, "OPENRANGE_APP_SECRET=", "OPENRANGE_WORLD_ID=")))
+                commands.append(
+                    (
+                        service,
+                        _grep_any(path, "OPENRANGE_APP_SECRET=", "OPENRANGE_WORLD_ID="),
+                    )
+                )
             elif kind == "hardcoded_app_secret":
-                commands.append((service, _grep_any(path, "OPENRANGE_APP_SECRET", "define('OPENRANGE_WORLD_ID'")))
+                commands.append(
+                    (
+                        service,
+                        _grep_any(
+                            path, "OPENRANGE_APP_SECRET", "define('OPENRANGE_WORLD_ID'"
+                        ),
+                    )
+                )
             else:
                 commands.append((service, _nonempty_file(path)))
 
     if family == "code_web":
-        code_paths = [str(getattr(realization, "path", "")) for realization in realizations if getattr(realization, "kind", "") == "code"]
-        seed_paths = [str(getattr(realization, "path", "")) for realization in realizations if getattr(realization, "kind", "") == "seed_data"]
+        code_paths = [
+            str(getattr(realization, "path", ""))
+            for realization in realizations
+            if getattr(realization, "kind", "") == "code"
+        ]
+        seed_paths = [
+            str(getattr(realization, "path", ""))
+            for realization in realizations
+            if getattr(realization, "kind", "") == "seed_data"
+        ]
         if kind == "auth_bypass" and code_paths:
-            commands.append((target, _grep_all(code_paths[0], "impersonate", "$debug === '1'")))
+            commands.append(
+                (target, _grep_all(code_paths[0], "impersonate", "$debug === '1'"))
+            )
         elif kind == "command_injection" and code_paths:
-            commands.append((target, _grep_all(code_paths[0], "shell_exec", "printf 'scan=%s")))
+            commands.append(
+                (target, _grep_all(code_paths[0], "shell_exec", "printf 'scan=%s"))
+            )
         elif kind == "ssrf" and code_paths:
             parts = [_grep_all(code_paths[0], "file_get_contents($url")]
             if seed_paths:
-                commands.append((effect_marker_service(weakness), _grep_any(seed_paths[0], effect_marker_token(weakness), weakness.id)))
+                commands.append(
+                    (
+                        effect_marker_service(weakness),
+                        _grep_any(
+                            seed_paths[0], effect_marker_token(weakness), weakness.id
+                        ),
+                    )
+                )
             commands.append((target, " && ".join(parts)))
 
     return tuple(commands)
@@ -550,7 +709,11 @@ def _grep_all(path: str, *needles: str) -> str:
 
 
 def _grep_any(path: str, *needles: str) -> str:
-    clauses = [f"grep -Fq {shlex.quote(needle)} {shlex.quote(path)}" for needle in needles if needle]
+    clauses = [
+        f"grep -Fq {shlex.quote(needle)} {shlex.quote(path)}"
+        for needle in needles
+        if needle
+    ]
     if not clauses:
         return _nonempty_file(path)
     return f"test -f {shlex.quote(path)} && (" + " || ".join(clauses) + ")"

--- a/src/open_range/pipeline.py
+++ b/src/open_range/pipeline.py
@@ -57,17 +57,30 @@ class BuildPipeline:
         world = self._prepare_world(source, build_config)
         synth = self.synthesizer.synthesize(world, Path(outdir) / "synth")
         artifacts = self.renderer.render(world, synth, Path(outdir))
-        return CandidateWorld(world=world, synth=synth, artifacts=artifacts, build_config=build_config)
+        return CandidateWorld(
+            world=world, synth=synth, artifacts=artifacts, build_config=build_config
+        )
 
-    def admit(self, candidate: CandidateWorld, *, split: PoolSplit = "train") -> Snapshot:
+    def admit(
+        self, candidate: CandidateWorld, *, split: PoolSplit = "train"
+    ) -> Snapshot:
         reference_bundle, report = self.admission.admit(
             candidate.world,
             candidate.artifacts,
             candidate.build_config,
         )
         if not report.admitted:
-            raise ValueError(f"candidate world {candidate.world.world_id} was not admitted")
-        return self.store.create(candidate.world, candidate.artifacts, reference_bundle, report, split=split, synth=candidate.synth)
+            raise ValueError(
+                f"candidate world {candidate.world.world_id} was not admitted"
+            )
+        return self.store.create(
+            candidate.world,
+            candidate.artifacts,
+            reference_bundle,
+            report,
+            split=split,
+            synth=candidate.synth,
+        )
 
     def admit_child(
         self,
@@ -86,7 +99,11 @@ class BuildPipeline:
     ) -> WorldIR:
         if isinstance(source, WorldIR):
             return source if source.weaknesses else self.seeder.apply(source)
-        parsed = source if isinstance(source, EnterpriseSaaSManifest) else validate_manifest(source)
+        parsed = (
+            source
+            if isinstance(source, EnterpriseSaaSManifest)
+            else validate_manifest(source)
+        )
         world = self.compiler.compile(parsed, build_config)
         return self.seeder.apply(world)
 
@@ -113,4 +130,6 @@ def admit_child(
     build_config: BuildConfig = DEFAULT_BUILD_CONFIG,
 ) -> Snapshot:
     """Render, admit, and persist a mutated child world."""
-    return BuildPipeline().admit_child(world, outdir, split=split, build_config=build_config)
+    return BuildPipeline().admit_child(
+        world, outdir, split=split, build_config=build_config
+    )

--- a/src/open_range/predicates.py
+++ b/src/open_range/predicates.py
@@ -7,7 +7,11 @@ from dataclasses import dataclass
 
 from collections.abc import Mapping
 
-from open_range.objectives import ObjectiveGraderSpec, evaluate_red_objectives, objective_grader_for_predicate
+from open_range.objectives import (
+    ObjectiveGraderSpec,
+    evaluate_red_objectives,
+    objective_grader_for_predicate,
+)
 from open_range.predicate_expr import parse_predicate, predicate_inner
 from open_range.world_ir import AssetSpec, ServiceSpec, WeaknessSpec, WorldIR
 
@@ -19,13 +23,23 @@ class PredicateEngine:
     world: WorldIR
 
     def active_weaknesses(self) -> tuple[WeaknessSpec, ...]:
-        return tuple(weakness for weakness in self.world.weaknesses if weakness.status == "seeded")
+        return tuple(
+            weakness
+            for weakness in self.world.weaknesses
+            if weakness.status == "seeded"
+        )
 
     def objective_target_asset(self, predicate: str) -> AssetSpec | None:
         expr = parse_predicate(predicate)
         if not expr.inner:
             return None
-        if expr.name in {"dos", "intrusion_detected", "intrusion_contained", "service_health_above", "outbound_service"}:
+        if expr.name in {
+            "dos",
+            "intrusion_detected",
+            "intrusion_contained",
+            "service_health_above",
+            "outbound_service",
+        }:
             return None
         for asset in self.world.assets:
             if asset.id == expr.inner:
@@ -37,9 +51,25 @@ class PredicateEngine:
         asset = self.objective_target_asset(predicate)
         if asset is not None:
             return asset.owner_service
-        if any(token in predicate for token in ("service_health_above", "intrusion_detected", "intrusion_contained")):
+        if any(
+            token in predicate
+            for token in (
+                "service_health_above",
+                "intrusion_detected",
+                "intrusion_contained",
+            )
+        ):
             return "svc-siem"
-        if expr.name in {"dos", "outbound_service", "unauthorized_admin_login", "privilege_escalation"} and expr.inner:
+        if (
+            expr.name
+            in {
+                "dos",
+                "outbound_service",
+                "unauthorized_admin_login",
+                "privilege_escalation",
+            }
+            and expr.inner
+        ):
             for service in self.world.services:
                 if service.id == expr.inner:
                     return service.id
@@ -66,10 +96,15 @@ class PredicateEngine:
     def is_groundable(self, predicate: str) -> bool:
         if self.objective_target_asset(predicate) is not None:
             return True
-        return self.objective_grader(predicate) is not None or self.objective_target_service(predicate) is not None
+        return (
+            self.objective_grader(predicate) is not None
+            or self.objective_target_service(predicate) is not None
+        )
 
     def service_graph(self) -> dict[str, set[str]]:
-        adjacency: dict[str, set[str]] = {service.id: set() for service in self.world.services}
+        adjacency: dict[str, set[str]] = {
+            service.id: set() for service in self.world.services
+        }
         for service in self.world.services:
             for dep in service.dependencies:
                 adjacency.setdefault(service.id, set()).add(dep)
@@ -111,12 +146,26 @@ class PredicateEngine:
         return service.kind in {"web_app", "email"}
 
     def red_path_depth(self) -> int:
-        start = next((service.id for service in self.world.services if self.is_public_service(service)), self.world.services[0].id)
-        target = self.objective_target_service(self.world.red_objectives[0].predicate) or self.world.services[-1].id
+        start = next(
+            (
+                service.id
+                for service in self.world.services
+                if self.is_public_service(service)
+            ),
+            self.world.services[0].id,
+        )
+        target = (
+            self.objective_target_service(self.world.red_objectives[0].predicate)
+            or self.world.services[-1].id
+        )
         return len(self.shortest_path(start, target))
 
     def red_alt_path_count(self) -> int:
-        start_services = [service.id for service in self.world.services if self.is_public_service(service)]
+        start_services = [
+            service.id
+            for service in self.world.services
+            if self.is_public_service(service)
+        ]
         target_services = {
             self.objective_target_service(objective.predicate)
             for objective in self.world.red_objectives
@@ -126,12 +175,23 @@ class PredicateEngine:
         reachable_starts = sum(
             1
             for start in start_services
-            if any(target in _shortest_path(start, target, adjacency) for target in target_services)
+            if any(
+                target in _shortest_path(start, target, adjacency)
+                for target in target_services
+            )
         )
         return max(0, reachable_starts - 1)
 
     def benchmark_tags_covered(self) -> tuple[str, ...]:
-        return tuple(sorted({tag for weak in self.active_weaknesses() for tag in weak.benchmark_tags}))
+        return tuple(
+            sorted(
+                {
+                    tag
+                    for weak in self.active_weaknesses()
+                    for tag in weak.benchmark_tags
+                }
+            )
+        )
 
     def objective_graders(self) -> tuple[ObjectiveGraderSpec, ...]:
         graders = []
@@ -161,7 +221,11 @@ class PredicateEngine:
         )
 
     def red_terminal_satisfied(self, satisfied_predicates: set[str]) -> bool:
-        required = {objective.predicate for objective in self.world.red_objectives if objective.terminal}
+        required = {
+            objective.predicate
+            for objective in self.world.red_objectives
+            if objective.terminal
+        }
         return bool(required) and required <= satisfied_predicates
 
     def blue_terminal_satisfied(
@@ -174,7 +238,9 @@ class PredicateEngine:
         continuity_threshold: float,
         continuity_enforced: bool,
     ) -> bool:
-        continuity_ok = continuity >= continuity_threshold if continuity_enforced else True
+        continuity_ok = (
+            continuity >= continuity_threshold if continuity_enforced else True
+        )
         return not red_terminal and blue_detected and blue_contained and continuity_ok
 
 
@@ -182,7 +248,9 @@ def predicate_engine(world: WorldIR) -> PredicateEngine:
     return PredicateEngine(world=world)
 
 
-def _shortest_path(start: str, target: str, adjacency: dict[str, set[str]]) -> tuple[str, ...]:
+def _shortest_path(
+    start: str, target: str, adjacency: dict[str, set[str]]
+) -> tuple[str, ...]:
     if start == target:
         return (start,)
     queue: deque[tuple[str, tuple[str, ...]]] = deque([(start, (start,))])

--- a/src/open_range/probe_planner.py
+++ b/src/open_range/probe_planner.py
@@ -6,10 +6,19 @@ from dataclasses import dataclass
 import json
 import shlex
 
-from open_range.admission import ProbeSpec, ReferenceAction, ReferenceBundle, ReferenceTrace
+from open_range.admission import (
+    ProbeSpec,
+    ReferenceAction,
+    ReferenceBundle,
+    ReferenceTrace,
+)
 from open_range.build_config import BuildConfig, DEFAULT_BUILD_CONFIG
 from open_range.code_web import code_web_payload
-from open_range.effect_markers import effect_marker_content, effect_marker_path, effect_marker_token
+from open_range.effect_markers import (
+    effect_marker_content,
+    effect_marker_path,
+    effect_marker_token,
+)
 from open_range.predicates import PredicateEngine
 from open_range.runtime_types import Action
 from open_range.world_ir import WorldIR
@@ -35,14 +44,34 @@ class ProbePlanner:
             for service in self.world.services
         )
         shortcut_probes = (
-            ProbeSpec(id="shortcut-direct-asset", kind="shortcut", description="direct external crown-jewel access"),
-            ProbeSpec(id="shortcut-admin", kind="shortcut", description="direct admin access"),
-            ProbeSpec(id="shortcut-cross-zone", kind="shortcut", description="unintended cross-zone reachability"),
-            ProbeSpec(id="shortcut-secret", kind="shortcut", description="leaked secrets"),
-            ProbeSpec(id="shortcut-unlogged", kind="shortcut", description="unlogged critical actions"),
+            ProbeSpec(
+                id="shortcut-direct-asset",
+                kind="shortcut",
+                description="direct external crown-jewel access",
+            ),
+            ProbeSpec(
+                id="shortcut-admin", kind="shortcut", description="direct admin access"
+            ),
+            ProbeSpec(
+                id="shortcut-cross-zone",
+                kind="shortcut",
+                description="unintended cross-zone reachability",
+            ),
+            ProbeSpec(
+                id="shortcut-secret", kind="shortcut", description="leaked secrets"
+            ),
+            ProbeSpec(
+                id="shortcut-unlogged",
+                kind="shortcut",
+                description="unlogged critical actions",
+            ),
         )
         determinism_probes = (
-            ProbeSpec(id="determinism-red", kind="determinism", description="replay red reference"),
+            ProbeSpec(
+                id="determinism-red",
+                kind="determinism",
+                description="replay red reference",
+            ),
         )
         engine = PredicateEngine(self.world)
         necessity_probes = tuple(
@@ -65,7 +94,9 @@ class ProbePlanner:
     def build_red_references(self) -> tuple[ReferenceTrace, ...]:
         engine = PredicateEngine(self.world)
         starts = tuple(
-            service.id for service in self.world.services if engine.is_public_service(service)
+            service.id
+            for service in self.world.services
+            if engine.is_public_service(service)
         ) or (self.world.services[0].id,)
         weaknesses = engine.active_weaknesses()
         ranked = sorted(
@@ -76,14 +107,22 @@ class ProbePlanner:
                 weak.id,
             ),
         )
-        candidates = [(start, weak) for weak in ranked for start in _starts_for_weakness(starts, weak.target)]
+        candidates = [
+            (start, weak)
+            for weak in ranked
+            for start in _starts_for_weakness(starts, weak.target)
+        ]
         if not candidates:
             candidates = [(starts[0], None)]
         traces: list[ReferenceTrace] = []
         seen: set[str] = set()
         for start, exploit in candidates:
-            trace = self.build_red_reference(start=start, exploit=exploit, ordinal=len(traces) + 1)
-            token = json.dumps(trace.model_dump(mode="json", exclude={"id"}), sort_keys=True)
+            trace = self.build_red_reference(
+                start=start, exploit=exploit, ordinal=len(traces) + 1
+            )
+            token = json.dumps(
+                trace.model_dump(mode="json", exclude={"id"}), sort_keys=True
+            )
             if token in seen:
                 continue
             seen.add(token)
@@ -91,15 +130,21 @@ class ProbePlanner:
             if len(traces) >= self.build_config.red_reference_count:
                 break
         if not traces:
-            traces.append(self.build_red_reference(start=starts[0], exploit=None, ordinal=1))
+            traces.append(
+                self.build_red_reference(start=starts[0], exploit=None, ordinal=1)
+            )
         return tuple(traces)
 
-    def build_blue_references(self, attack_traces: tuple[ReferenceTrace, ...]) -> tuple[ReferenceTrace, ...]:
+    def build_blue_references(
+        self, attack_traces: tuple[ReferenceTrace, ...]
+    ) -> tuple[ReferenceTrace, ...]:
         if not attack_traces:
             attack_traces = (self.build_red_reference(ordinal=1),)
         count = max(1, self.build_config.blue_reference_count)
         return tuple(
-            self.build_blue_reference(attack_traces[idx % len(attack_traces)], ordinal=idx + 1)
+            self.build_blue_reference(
+                attack_traces[idx % len(attack_traces)], ordinal=idx + 1
+            )
             for idx in range(count)
         )
 
@@ -112,7 +157,11 @@ class ProbePlanner:
     ) -> ReferenceTrace:
         engine = PredicateEngine(self.world)
         start = start or next(
-            (service.id for service in self.world.services if engine.is_public_service(service)),
+            (
+                service.id
+                for service in self.world.services
+                if engine.is_public_service(service)
+            ),
             self.world.services[0].id,
         )
         weaknesses = engine.active_weaknesses()
@@ -121,7 +170,9 @@ class ProbePlanner:
         steps: list[ReferenceAction] = []
         current = start
         if exploit is not None:
-            exploit_steps, current, satisfied_predicates = _weakness_red_steps(self.world, engine, start, exploit)
+            exploit_steps, current, satisfied_predicates = _weakness_red_steps(
+                self.world, engine, start, exploit
+            )
             steps.extend(exploit_steps)
         if not steps:
             steps.append(
@@ -162,19 +213,23 @@ class ProbePlanner:
             current = target
 
         events: list[str] = []
-        for weak in ((exploit,) if exploit is not None else weaknesses):
+        for weak in (exploit,) if exploit is not None else weaknesses:
             if weak is None:
                 continue
             events.extend(weak.expected_event_signatures)
         return ReferenceTrace(
             id=f"red-{self.world.world_id}-{ordinal}",
             role="red",
-            objective_ids=tuple(objective.id for objective in self.world.red_objectives),
+            objective_ids=tuple(
+                objective.id for objective in self.world.red_objectives
+            ),
             expected_events=tuple(dict.fromkeys(events + ["SensitiveAssetRead"])),
             steps=tuple(steps),
         )
 
-    def build_blue_reference(self, red_trace: ReferenceTrace, *, ordinal: int = 1) -> ReferenceTrace:
+    def build_blue_reference(
+        self, red_trace: ReferenceTrace, *, ordinal: int = 1
+    ) -> ReferenceTrace:
         blindspot_targets = {
             weak.target
             for weak in PredicateEngine(self.world).active_weaknesses()
@@ -192,23 +247,42 @@ class ProbePlanner:
         detect_event, detect_target = _detection_for_red_step(detect_step)
         contain_target = red_trace.steps[-1].target if red_trace.steps else "svc-siem"
         observe_steps = tuple(
-            ReferenceAction(actor="blue", kind="shell", target="svc-siem", payload={"action": "observe_events"})
+            ReferenceAction(
+                actor="blue",
+                kind="shell",
+                target="svc-siem",
+                payload={"action": "observe_events"},
+            )
             for _ in range(max(1, detect_index + 1))
         )
         return ReferenceTrace(
             id=f"blue-{self.world.world_id}-{ordinal}",
             role="blue",
-            objective_ids=tuple(objective.id for objective in self.world.blue_objectives),
+            objective_ids=tuple(
+                objective.id for objective in self.world.blue_objectives
+            ),
             expected_events=("DetectionAlertRaised", "ContainmentApplied"),
             steps=observe_steps
             + (
-                ReferenceAction(actor="blue", kind="submit_finding", target=detect_target, payload={"event": detect_event}),
-                ReferenceAction(actor="blue", kind="control", target=contain_target, payload={"action": "contain"}),
+                ReferenceAction(
+                    actor="blue",
+                    kind="submit_finding",
+                    target=detect_target,
+                    payload={"event": detect_event},
+                ),
+                ReferenceAction(
+                    actor="blue",
+                    kind="control",
+                    target=contain_target,
+                    payload={"action": "contain"},
+                ),
             ),
         )
 
 
-def build_reference_bundle(world: WorldIR, build_config: BuildConfig = DEFAULT_BUILD_CONFIG) -> ReferenceBundle:
+def build_reference_bundle(
+    world: WorldIR, build_config: BuildConfig = DEFAULT_BUILD_CONFIG
+) -> ReferenceBundle:
     return ProbePlanner(world=world, build_config=build_config).build()
 
 
@@ -217,17 +291,15 @@ def runtime_action(actor: str, step: ReferenceAction) -> Action:
     if step.target:
         payload.setdefault("target", step.target)
     if actor == "blue" and step.kind == "submit_finding":
-        event_type = str(payload.get("event", payload.get("event_type", "InitialAccess")))
+        event_type = str(
+            payload.get("event", payload.get("event_type", "InitialAccess"))
+        )
         payload["event_type"] = event_type
     return Action(actor_id=actor, role=actor, kind=step.kind, payload=payload)
 
 
 def _primary_red_weakness(start: str, weaknesses):
-    ranked = [
-        weak
-        for weak in weaknesses
-        if weak.family != "telemetry_blindspot"
-    ]
+    ranked = [weak for weak in weaknesses if weak.family != "telemetry_blindspot"]
     if not ranked:
         return next(iter(weaknesses), None)
     ranked.sort(
@@ -252,10 +324,20 @@ def _detection_for_red_step(step: ReferenceAction | None) -> tuple[str, str]:
         return ("CrossZoneTraversal", step.target)
     if action in {"collect_secret", "abuse_identity"}:
         target = asset or step.target
-        return ("CredentialObtained" if (asset and ("cred" in asset or "token" in asset)) else "SensitiveAssetRead", target)
+        return (
+            "CredentialObtained"
+            if (asset and ("cred" in asset or "token" in asset))
+            else "SensitiveAssetRead",
+            target,
+        )
     if action == "abuse_workflow":
         target = asset or step.target
-        return ("CredentialObtained" if (asset and ("cred" in asset or "token" in asset)) else "SensitiveAssetRead", target)
+        return (
+            "CredentialObtained"
+            if (asset and ("cred" in asset or "token" in asset))
+            else "SensitiveAssetRead",
+            target,
+        )
     if action == "satisfy_objective" and objective.startswith("credential_obtained("):
         return ("CredentialObtained", asset or step.target)
     if action == "satisfy_objective":
@@ -278,7 +360,10 @@ def _step_is_blue_detectable(
     if action in {"initial_access", "click_lure"}:
         return step.target not in blindspot_targets
     if action == "traverse":
-        return step.target not in blindspot_targets and source_target not in blindspot_targets
+        return (
+            step.target not in blindspot_targets
+            and source_target not in blindspot_targets
+        )
     return step.target not in blindspot_targets
 
 
@@ -298,14 +383,27 @@ def _weakness_red_steps(
     satisfied: set[str] = set()
     current = start
     if weakness.family == "code_web":
-        payload = {"action": "initial_access", "weakness_id": weakness.id, "weakness": weakness.id}
+        payload = {
+            "action": "initial_access",
+            "weakness_id": weakness.id,
+            "weakness": weakness.id,
+        }
         payload.update(code_web_payload(world, weakness))
-        steps.append(ReferenceAction(actor="red", kind="api", target=weakness.target, payload=payload))
+        steps.append(
+            ReferenceAction(
+                actor="red", kind="api", target=weakness.target, payload=payload
+            )
+        )
         return steps, weakness.target, satisfied
 
-    if weakness.family == "workflow_abuse" and weakness.kind in {"phishing_credential_capture", "internal_request_impersonation"}:
+    if weakness.family == "workflow_abuse" and weakness.kind in {
+        "phishing_credential_capture",
+        "internal_request_impersonation",
+    }:
         mailbox_path = _first_realization_path(weakness, kind="mailbox")
-        mailbox = _mailbox_from_path(mailbox_path) if mailbox_path else "user@corp.local"
+        mailbox = (
+            _mailbox_from_path(mailbox_path) if mailbox_path else "user@corp.local"
+        )
         steps.append(
             ReferenceAction(
                 actor="red",
@@ -373,7 +471,11 @@ def _weakness_red_steps(
             payload["asset"] = weakness.target_ref
             payload["objective"] = _target_ref_objective(world, weakness.target_ref)
             satisfied.add(_target_ref_objective(world, weakness.target_ref))
-        steps.append(ReferenceAction(actor="red", kind="shell", target=weakness.target, payload=payload))
+        steps.append(
+            ReferenceAction(
+                actor="red", kind="shell", target=weakness.target, payload=payload
+            )
+        )
         return steps, weakness.target, satisfied
 
     if weakness.family == "config_identity":
@@ -392,11 +494,17 @@ def _weakness_red_steps(
         if objective is not None:
             payload["objective"] = objective
             satisfied.add(objective)
-        steps.append(ReferenceAction(actor="red", kind="shell", target=weakness.target, payload=payload))
+        steps.append(
+            ReferenceAction(
+                actor="red", kind="shell", target=weakness.target, payload=payload
+            )
+        )
         return steps, weakness.target, satisfied
 
     if weakness.family == "workflow_abuse":
-        realization_path = _first_realization_path(weakness, kind="workflow") or _first_realization_path(weakness)
+        realization_path = _first_realization_path(
+            weakness, kind="workflow"
+        ) or _first_realization_path(weakness)
         effect_token = effect_marker_token(weakness)
         payload = _shell_payload(
             action="abuse_workflow",
@@ -413,7 +521,11 @@ def _weakness_red_steps(
         if objective is not None:
             payload["objective"] = objective
             satisfied.add(objective)
-        steps.append(ReferenceAction(actor="red", kind="shell", target=weakness.target, payload=payload))
+        steps.append(
+            ReferenceAction(
+                actor="red", kind="shell", target=weakness.target, payload=payload
+            )
+        )
         return steps, weakness.target, satisfied
 
     steps.append(
@@ -475,7 +587,9 @@ def _secret_material(world, target_ref: str) -> str:
     user = next((item for item in world.users if item.id == target_ref), None)
     if user is not None:
         return f"{user.id}-pass"
-    credential = next((item for item in world.credentials if item.id == target_ref), None)
+    credential = next(
+        (item for item in world.credentials if item.id == target_ref), None
+    )
     if credential is not None:
         return f"seeded-secret-{credential.id}"
     return target_ref
@@ -498,14 +612,23 @@ def _identity_effect_command(weakness, realization_path: str) -> str:
     effect_content = effect_marker_content(weakness)
     markers = {
         "weak_password": ('"min_password_length": 6', '"password_reuse_allowed": true'),
-        "default_credential": ('"default_username": "admin"', '"default_password": "admin"'),
+        "default_credential": (
+            '"default_username": "admin"',
+            '"default_password": "admin"',
+        ),
         "overbroad_service_account": ('"service_account_scope"', "svc-db", "svc-idp"),
         "admin_surface_exposed": ('"admin_surface_public": true',),
-        "trust_edge_misconfig": ('"trust_scope": "corp-wide"', '"peer_validation": false'),
+        "trust_edge_misconfig": (
+            '"trust_scope": "corp-wide"',
+            '"peer_validation": false',
+        ),
     }[weakness.kind]
     tests = " && ".join(
         [f"test -f {shlex.quote(realization_path)}"]
-        + [f"grep -Fq {shlex.quote(marker)} {shlex.quote(realization_path)}" for marker in markers]
+        + [
+            f"grep -Fq {shlex.quote(marker)} {shlex.quote(realization_path)}"
+            for marker in markers
+        ]
     )
     return (
         f"{tests} && mkdir -p {shlex.quote(effect_path.rsplit('/', 1)[0])} && "
@@ -518,7 +641,10 @@ def _workflow_effect_command(weakness, realization_path: str) -> str:
     effect_path = effect_marker_path(weakness)
     effect_content = effect_marker_content(weakness)
     markers = {
-        "helpdesk_reset_bypass": ('"identity_verification": "none"', '"reset_without_ticket_owner": true'),
+        "helpdesk_reset_bypass": (
+            '"identity_verification": "none"',
+            '"reset_without_ticket_owner": true',
+        ),
         "approval_chain_bypass": ('"secondary_approval_skipped": true',),
         "document_share_abuse": ('"share_visibility": "public_link"',),
         "phishing_credential_capture": ('"credential_capture_landing": "/login"',),
@@ -526,7 +652,10 @@ def _workflow_effect_command(weakness, realization_path: str) -> str:
     }[weakness.kind]
     tests = " && ".join(
         [f"test -f {shlex.quote(realization_path)}"]
-        + [f"grep -Fq {shlex.quote(marker)} {shlex.quote(realization_path)}" for marker in markers]
+        + [
+            f"grep -Fq {shlex.quote(marker)} {shlex.quote(realization_path)}"
+            for marker in markers
+        ]
     )
     return (
         f"{tests} && mkdir -p {shlex.quote(effect_path.rsplit('/', 1)[0])} && "

--- a/src/open_range/probe_runner.py
+++ b/src/open_range/probe_runner.py
@@ -50,6 +50,7 @@ def run_red_reference(
     health = tuple(sorted(runtime.state().service_health.items()))
     return score, events, health, outputs
 
+
 def run_blue_reference(
     snapshot: RuntimeSnapshot,
     backend: PodActionBackend | None = None,
@@ -57,7 +58,9 @@ def run_blue_reference(
     trace_index: int = 0,
 ):
     trace = snapshot.reference_bundle.reference_defense_traces[trace_index]
-    attack_index = trace_index % max(1, len(snapshot.reference_bundle.reference_attack_traces))
+    attack_index = trace_index % max(
+        1, len(snapshot.reference_bundle.reference_attack_traces)
+    )
     runtime = ReferenceDrivenRuntime(action_backend=backend)
     runtime.reset(
         snapshot,
@@ -80,7 +83,11 @@ def run_blue_reference(
                 break
             raise
         step = blue_steps[step_idx] if step_idx < len(blue_steps) else None
-        action = runtime_action("blue", step) if step is not None else Action(actor_id="blue", role="blue", kind="sleep", payload={})
+        action = (
+            runtime_action("blue", step)
+            if step is not None
+            else Action(actor_id="blue", role="blue", kind="sleep", payload={})
+        )
         result = runtime.act("blue", action)
         outputs.append(result.stdout or result.stderr)
         if decision.actor != "blue":

--- a/src/open_range/render.py
+++ b/src/open_range/render.py
@@ -34,7 +34,9 @@ _SANDBOX_IMAGE_BY_ROLE = {
 
 
 class KindRenderer(Protocol):
-    def render(self, world: WorldIR, synth: SynthArtifacts, outdir: Path) -> KindArtifacts: ...
+    def render(
+        self, world: WorldIR, synth: SynthArtifacts, outdir: Path
+    ) -> KindArtifacts: ...
 
 
 class EnterpriseSaaSKindRenderer:
@@ -43,7 +45,9 @@ class EnterpriseSaaSKindRenderer:
     def __init__(self, chart_dir: Path | None = None) -> None:
         self.chart_dir = chart_dir or _CHART_DIR
 
-    def render(self, world: WorldIR, synth: SynthArtifacts, outdir: Path) -> KindArtifacts:
+    def render(
+        self, world: WorldIR, synth: SynthArtifacts, outdir: Path
+    ) -> KindArtifacts:
         outdir = Path(outdir)
         outdir.mkdir(parents=True, exist_ok=True)
 
@@ -57,9 +61,13 @@ class EnterpriseSaaSKindRenderer:
         summary = self._build_summary(world, values)
 
         values_path = chart_out / "values.yaml"
-        values_path.write_text(yaml.safe_dump(values, sort_keys=False), encoding="utf-8")
+        values_path.write_text(
+            yaml.safe_dump(values, sort_keys=False), encoding="utf-8"
+        )
         kind_config_path = outdir / "kind-config.yaml"
-        kind_config_path.write_text(yaml.safe_dump(kind_config, sort_keys=False), encoding="utf-8")
+        kind_config_path.write_text(
+            yaml.safe_dump(kind_config, sort_keys=False), encoding="utf-8"
+        )
         summary_path = outdir / "manifest-summary.json"
         summary_path.write_text(
             json.dumps(summary, indent=2, sort_keys=True) + "\n",
@@ -76,7 +84,14 @@ class EnterpriseSaaSKindRenderer:
             values_path=str(values_path),
             kind_config_path=str(kind_config_path),
             manifest_summary_path=str(summary_path),
-            rendered_files=tuple([str(values_path), str(kind_config_path), str(summary_path), *synth.generated_files]),
+            rendered_files=tuple(
+                [
+                    str(values_path),
+                    str(kind_config_path),
+                    str(summary_path),
+                    *synth.generated_files,
+                ]
+            ),
             chart_values=values,
             pinned_image_digests=pinned,
         )
@@ -125,7 +140,9 @@ class EnterpriseSaaSKindRenderer:
             },
             "sandbox-blue": {
                 "enabled": True,
-                "zone": "management" if "management" in world.zones else world.zones[-1],
+                "zone": "management"
+                if "management" in world.zones
+                else world.zones[-1],
                 "image": _SANDBOX_IMAGE_BY_ROLE["blue"],
                 "role": "blue",
                 "command": ["/bin/sh", "-lc", "sleep infinity"],
@@ -159,11 +176,17 @@ class EnterpriseSaaSKindRenderer:
             "services": services,
             "sandboxes": sandboxes,
             "users": users,
-            "mailboxes": {mailbox: list(messages) for mailbox, messages in synth.mailboxes.items()},
+            "mailboxes": {
+                mailbox: list(messages) for mailbox, messages in synth.mailboxes.items()
+            },
             "firewallRules": _firewall_rules(world, host_by_id, service_by_id),
             "assets": [asset.model_dump(mode="json") for asset in world.assets],
-            "weaknesses": [weakness.model_dump(mode="json") for weakness in world.weaknesses],
-            "telemetryEdges": [edge.model_dump(mode="json") for edge in world.telemetry_edges],
+            "weaknesses": [
+                weakness.model_dump(mode="json") for weakness in world.weaknesses
+            ],
+            "telemetryEdges": [
+                edge.model_dump(mode="json") for edge in world.telemetry_edges
+            ],
         }
 
     @staticmethod
@@ -193,7 +216,9 @@ class EnterpriseSaaSKindRenderer:
             "asset_count": len(world.assets),
             "weakness_count": len(world.weaknesses),
             "values_hash": hashlib.sha256(
-                json.dumps(values, sort_keys=True, separators=(",", ":")).encode("utf-8")
+                json.dumps(values, sort_keys=True, separators=(",", ":")).encode(
+                    "utf-8"
+                )
             ).hexdigest(),
         }
 
@@ -244,8 +269,8 @@ def _service_command(service: ServiceSpec) -> list[str]:
                 "printf '%s\\n' \"$request_line\" >> /srv/http/siem/egress-canary.log; "
                 "path=$(printf '%s' \"$request_line\" | awk '{print $2}'); "
                 "slug=${path##*/}; slug=${slug%%\\?*}; "
-                "body=\"OPENRANGE-EFFECT:egress:${slug}\"; "
-                "printf 'HTTP/1.1 200 OK\\r\\nContent-Type: text/plain\\r\\nContent-Length: %s\\r\\n\\r\\n%s' \"${#body}\" \"$body\"; "
+                'body="OPENRANGE-EFFECT:egress:${slug}"; '
+                'printf \'HTTP/1.1 200 OK\\r\\nContent-Type: text/plain\\r\\nContent-Length: %s\\r\\n\\r\\n%s\' "${#body}" "$body"; '
                 "} | busybox nc -lp 9201 -q 1; "
                 "done"
                 ") & "
@@ -303,7 +328,11 @@ def _firewall_rules(
             service = service_by_id.get(step.service)
             if service is None:
                 continue
-            allow(role_zone_map[step.actor_role], host_by_id[service.host].zone, service.ports)
+            allow(
+                role_zone_map[step.actor_role],
+                host_by_id[service.host].zone,
+                service.ports,
+            )
 
     return [
         {
@@ -317,7 +346,11 @@ def _firewall_rules(
 
 
 def _green_sandbox(persona: GreenPersona, host_by_id: dict[str, Any]) -> dict[str, Any]:
-    zone = host_by_id[persona.home_host].zone if persona.home_host in host_by_id else "corp"
+    zone = (
+        host_by_id[persona.home_host].zone
+        if persona.home_host in host_by_id
+        else "corp"
+    )
     return {
         "enabled": True,
         "zone": zone,

--- a/src/open_range/resources.py
+++ b/src/open_range/resources.py
@@ -44,7 +44,9 @@ def load_bundled_manifest(name: str) -> dict[str, Any]:
 
 
 def load_bundled_manifest_registry() -> dict[str, Any]:
-    payload = yaml.safe_load((bundled_manifest_dir() / "registry.yaml").read_text(encoding="utf-8"))
+    payload = yaml.safe_load(
+        (bundled_manifest_dir() / "registry.yaml").read_text(encoding="utf-8")
+    )
     if not isinstance(payload, dict):
         raise ValueError("expected a YAML mapping in bundled registry")
     return payload

--- a/src/open_range/rewards.py
+++ b/src/open_range/rewards.py
@@ -8,12 +8,14 @@ from typing import Any
 from open_range.runtime_types import Action
 
 
-_RED_MILESTONES = frozenset({
-    "InitialAccess",
-    "CredentialObtained",
-    "CrossZoneTraversal",
-    "SensitiveAssetRead",
-})
+_RED_MILESTONES = frozenset(
+    {
+        "InitialAccess",
+        "CredentialObtained",
+        "CrossZoneTraversal",
+        "SensitiveAssetRead",
+    }
+)
 
 
 @dataclass
@@ -42,7 +44,9 @@ class RewardEngine:
         reward = self.red_tick_cost if shaping_enabled else 0.0
         claim = str(action.payload.get("claim_objective", ""))
         if claim and hallucination_penalty_enabled:
-            objective_hit = any(claim in event.linked_objective_predicates for event in emitted)
+            objective_hit = any(
+                claim in event.linked_objective_predicates for event in emitted
+            )
             if not objective_hit:
                 reward -= 0.3
         for event in emitted:
@@ -82,7 +86,11 @@ class RewardEngine:
         shaping_enabled: bool = True,
     ) -> float:
         reward = 0.0
-        if shaping_enabled and path_broken and target not in self.blue_contained_targets:
+        if (
+            shaping_enabled
+            and path_broken
+            and target not in self.blue_contained_targets
+        ):
             self.blue_contained_targets.add(target)
             reward += 0.2
         continuity_drop = max(0.0, continuity_before - continuity_after)

--- a/src/open_range/runtime.py
+++ b/src/open_range/runtime.py
@@ -12,7 +12,11 @@ from open_range.green import GreenScheduler, ScriptedGreenScheduler
 from open_range.predicates import PredicateEngine
 from open_range.probe_planner import runtime_action as reference_runtime_action
 from open_range.rewards import RewardEngine
-from open_range.runtime_events import action_target, green_events_for_action, red_events_for_step
+from open_range.runtime_events import (
+    action_target,
+    green_events_for_action,
+    red_events_for_step,
+)
 from open_range.runtime_types import (
     Action,
     ActionResult,
@@ -116,7 +120,11 @@ class ReferenceDrivenRuntime:
             live_health = self.action_backend.service_health()
             if live_health:
                 service_health.update(live_health)
-        continuity = sum(service_health.values()) / len(service_health) if service_health else 1.0
+        continuity = (
+            sum(service_health.values()) / len(service_health)
+            if service_health
+            else 1.0
+        )
         self._state = EpisodeState(
             snapshot_id=snapshot.snapshot_id,
             episode_id=f"ep-{uuid4()}",
@@ -130,8 +138,12 @@ class ReferenceDrivenRuntime:
             controls_blue=episode_config.controls_blue,
             next_actor="",
             decision_count=0,
-            red_session=ActorSessionState(session_id=f"red-{uuid4()}", actor_id="red", role="red"),
-            blue_session=ActorSessionState(session_id=f"blue-{uuid4()}", actor_id="blue", role="blue"),
+            red_session=ActorSessionState(
+                session_id=f"red-{uuid4()}", actor_id="red", role="red"
+            ),
+            blue_session=ActorSessionState(
+                session_id=f"blue-{uuid4()}", actor_id="blue", role="blue"
+            ),
         )
         self.green_scheduler.reset(snapshot, episode_config)
         self._apply_prefix_start()
@@ -145,11 +157,15 @@ class ReferenceDrivenRuntime:
         if self._snapshot is None:
             raise RuntimeError("runtime must be reset before next_decision()")
         if self._state.done:
-            raise RuntimeError("episode is done; reset() is required before more decisions")
+            raise RuntimeError(
+                "episode is done; reset() is required before more decisions"
+            )
         if not self._pending_actor:
             self._advance_until_external_decision()
         if self._state.done:
-            raise RuntimeError("episode is done; reset() is required before more decisions")
+            raise RuntimeError(
+                "episode is done; reset() is required before more decisions"
+            )
         if not self._pending_actor:
             raise RuntimeError("no external decision is available")
 
@@ -164,11 +180,15 @@ class ReferenceDrivenRuntime:
         if self._snapshot is None:
             raise RuntimeError("runtime must be reset before act()")
         if self._state.done:
-            raise RuntimeError("episode is done; reset() is required before more actions")
+            raise RuntimeError(
+                "episode is done; reset() is required before more actions"
+            )
         if actor not in {"red", "blue"}:
             raise ValueError("public act() only supports red and blue")
         if self._pending_actor != actor:
-            raise RuntimeError(f"cannot act as {actor!r}; next actor is {self._pending_actor!r}")
+            raise RuntimeError(
+                f"cannot act as {actor!r}; next actor is {self._pending_actor!r}"
+            )
         if action.role != actor:
             raise ValueError("action.role must match the acting external role")
 
@@ -177,7 +197,12 @@ class ReferenceDrivenRuntime:
         self._state.next_actor = ""
         self._advance_due_time(actor)
         self._check_terminal_conditions()
-        return result.model_copy(update={"done": self._state.done, "sim_time": round(self._state.sim_time, 4)})
+        return result.model_copy(
+            update={
+                "done": self._state.done,
+                "sim_time": round(self._state.sim_time, 4),
+            }
+        )
 
     def score(self) -> EpisodeScore:
         red_terminal, blue_terminal = self.reward_engine.terminal_rewards(
@@ -200,8 +225,12 @@ class ReferenceDrivenRuntime:
         )
 
     def state(self) -> EpisodeState:
-        self._state.red_objectives_satisfied = tuple(sorted(self._red_objectives_satisfied))
-        self._state.blue_objectives_satisfied = tuple(sorted(self._blue_objectives_satisfied))
+        self._state.red_objectives_satisfied = tuple(
+            sorted(self._red_objectives_satisfied)
+        )
+        self._state.blue_objectives_satisfied = tuple(
+            sorted(self._blue_objectives_satisfied)
+        )
         self._state.next_actor = self._pending_actor
         return self._state.model_copy(deep=True)
 
@@ -230,7 +259,10 @@ class ReferenceDrivenRuntime:
     def _apply_prefix_start(self) -> None:
         if self._snapshot is None:
             return
-        if self._episode_config.mode != "blue_only_from_prefix" or self._episode_config.start_state == "clean":
+        if (
+            self._episode_config.mode != "blue_only_from_prefix"
+            or self._episode_config.start_state == "clean"
+        ):
             return
         attack_trace = self._reference_attack_trace()
         if self._episode_config.start_state == "prefix_delivery":
@@ -251,7 +283,9 @@ class ReferenceDrivenRuntime:
                 break
             due = max(self._state.sim_time, self._next_due_time["red"])
             self._advance_time(due)
-            emitted = self._act_red(reference_runtime_action("red", step), internal=True).emitted_events
+            emitted = self._act_red(
+                reference_runtime_action("red", step), internal=True
+            ).emitted_events
             self._advance_due_time("red")
             self._check_terminal_conditions()
             if self._prefix_satisfied(
@@ -309,7 +343,10 @@ class ReferenceDrivenRuntime:
             (
                 (role, due_time)
                 for role, due_time in self._next_due_time.items()
-                if not (self._episode_config.mode == "blue_only_from_prefix" and role == "red")
+                if not (
+                    self._episode_config.mode == "blue_only_from_prefix"
+                    and role == "red"
+                )
             ),
             key=lambda item: (item[1], 0 if item[0] == "red" else 1),
         )
@@ -345,12 +382,20 @@ class ReferenceDrivenRuntime:
             event
             for event in visible
             if event.malicious
-            or event.event_type in {"DetectionAlertRaised", "ContainmentApplied", "PatchApplied", "ServiceDegraded"}
+            or event.event_type
+            in {
+                "DetectionAlertRaised",
+                "ContainmentApplied",
+                "PatchApplied",
+                "ServiceDegraded",
+            }
         )
         reward_delta = self._last_reward_delta[actor]
         self._last_reward_delta[actor] = 0.0
         self._observed_event_ids[actor].update(event.id for event in visible)
-        session = self._state.red_session if actor == "red" else self._state.blue_session
+        session = (
+            self._state.red_session if actor == "red" else self._state.blue_session
+        )
         first_observation = session is not None and session.observation_count == 0
         if session is not None:
             session.observation_count += 1
@@ -380,7 +425,9 @@ class ReferenceDrivenRuntime:
             if live.ok
             else ()
         )
-        self._state.sim_time = round(min(self._state.sim_time + 0.01, self._episode_config.episode_horizon), 4)
+        self._state.sim_time = round(
+            min(self._state.sim_time + 0.01, self._episode_config.episode_horizon), 4
+        )
         return ActionResult(
             action=action,
             sim_time=self._state.sim_time,
@@ -412,9 +459,15 @@ class ReferenceDrivenRuntime:
         blocked_reason = self._path_block_reason(target)
         if blocked_reason:
             blocked_msg = f"target {target} is {blocked_reason}"
-            if blocked_msg not in {line.strip() for line in stderr.splitlines() if line.strip()}:
+            if blocked_msg not in {
+                line.strip() for line in stderr.splitlines() if line.strip()
+            }:
                 stderr = "\n".join(filter(None, [stderr, blocked_msg])).strip()
-        elif expected is not None and live.ok and self._matches_step(action, expected, live.stdout):
+        elif (
+            expected is not None
+            and live.ok
+            and self._matches_step(action, expected, live.stdout)
+        ):
             self._red_progress += 1
             stdout = f"red advanced on {target}"
             batch = red_events_for_step(
@@ -464,7 +517,9 @@ class ReferenceDrivenRuntime:
         stderr = live.stderr
 
         if action.kind == "submit_finding":
-            event_type = str(action.payload.get("event_type", action.payload.get("event", "")))
+            event_type = str(
+                action.payload.get("event_type", action.payload.get("event", ""))
+            )
             target = str(action.payload.get("target", ""))
             matched = self._find_detectable_event(event_type, target, visible_only=True)
             if matched is not None:
@@ -476,11 +531,15 @@ class ReferenceDrivenRuntime:
                         target_entity=matched.target_entity,
                         malicious=False,
                         observability_surfaces=("svc-siem",),
-                        linked_objective_predicates=("intrusion_detected(initial_access)",),
+                        linked_objective_predicates=(
+                            "intrusion_detected(initial_access)",
+                        ),
                     )
                 )
                 self._blue_detected = True
-                self._blue_objectives_satisfied.add("intrusion_detected(initial_access)")
+                self._blue_objectives_satisfied.add(
+                    "intrusion_detected(initial_access)"
+                )
                 self._detected_event_ids.add(matched.id)
                 reward_delta += self.reward_engine.on_blue_detection(
                     matched,
@@ -500,7 +559,11 @@ class ReferenceDrivenRuntime:
             directive = str(action.payload.get("action", "contain")).lower()
             remaining_targets = self._remaining_red_targets()
             continuity_before = self._state.continuity
-            path_broken = bool(target and target in remaining_targets and (live.containment_applied or live.patch_applied))
+            path_broken = bool(
+                target
+                and target in remaining_targets
+                and (live.containment_applied or live.patch_applied)
+            )
             if target and live.containment_applied:
                 self._contained_targets.add(target)
                 self._patched_targets.discard(target)
@@ -512,7 +575,11 @@ class ReferenceDrivenRuntime:
                         target_entity=target,
                         malicious=False,
                         observability_surfaces=("svc-siem",),
-                        linked_objective_predicates=("intrusion_contained(before_asset_read)",) if path_broken else (),
+                        linked_objective_predicates=(
+                            "intrusion_contained(before_asset_read)",
+                        )
+                        if path_broken
+                        else (),
                     )
                 )
             elif target and live.patch_applied:
@@ -526,7 +593,11 @@ class ReferenceDrivenRuntime:
                         target_entity=target,
                         malicious=False,
                         observability_surfaces=("svc-siem",),
-                        linked_objective_predicates=("intrusion_contained(before_asset_read)",) if path_broken else (),
+                        linked_objective_predicates=(
+                            "intrusion_contained(before_asset_read)",
+                        )
+                        if path_broken
+                        else (),
                     )
                 )
             elif target and live.recovery_applied:
@@ -545,7 +616,9 @@ class ReferenceDrivenRuntime:
 
             if path_broken:
                 self._blue_contained = True
-                self._blue_objectives_satisfied.add("intrusion_contained(before_asset_read)")
+                self._blue_objectives_satisfied.add(
+                    "intrusion_contained(before_asset_read)"
+                )
                 if live.patch_applied:
                     if directive == "mitigate":
                         stdout = f"mitigation applied to {target}"
@@ -563,14 +636,26 @@ class ReferenceDrivenRuntime:
                 )
             else:
                 if live.recovery_applied:
-                    stdout = live.stdout or f"recovery applied to {target or 'unknown target'}"
+                    stdout = (
+                        live.stdout
+                        or f"recovery applied to {target or 'unknown target'}"
+                    )
                 elif live.patch_applied:
                     noun = "mitigation" if directive == "mitigate" else "patch"
-                    stdout = live.stdout or f"{noun} on {target or 'unknown target'} did not break the remaining path"
+                    stdout = (
+                        live.stdout
+                        or f"{noun} on {target or 'unknown target'} did not break the remaining path"
+                    )
                 elif directive == "contain":
-                    stdout = live.stdout or f"control action on {target or 'unknown target'} had no path-breaking effect"
+                    stdout = (
+                        live.stdout
+                        or f"control action on {target or 'unknown target'} had no path-breaking effect"
+                    )
                 else:
-                    stdout = live.stdout or f"{directive} on {target or 'unknown target'} had no path-breaking effect"
+                    stdout = (
+                        live.stdout
+                        or f"{directive} on {target or 'unknown target'} had no path-breaking effect"
+                    )
                 self._update_continuity()
                 reward_delta += self.reward_engine.on_blue_containment(
                     target=target,
@@ -587,7 +672,9 @@ class ReferenceDrivenRuntime:
         self._blue_reward_shaping += reward_delta
         if not internal:
             self._last_reward_delta["blue"] += reward_delta
-        elif expected_internal is not None and self._matches_step(action, expected_internal, live.stdout):
+        elif expected_internal is not None and self._matches_step(
+            action, expected_internal, live.stdout
+        ):
             self._blue_internal_progress += 1
 
         return ActionResult(
@@ -642,10 +729,15 @@ class ReferenceDrivenRuntime:
                 return False
         if action.kind == "control":
             expected_directive = expected.payload.get("action")
-            if expected_directive and action.payload.get("action") != expected_directive:
+            if (
+                expected_directive
+                and action.payload.get("action") != expected_directive
+            ):
                 return False
         if action.kind == "submit_finding":
-            expected_event = expected.payload.get("event_type", expected.payload.get("event"))
+            expected_event = expected.payload.get(
+                "event_type", expected.payload.get("event")
+            )
             actual_event = action.payload.get("event_type", action.payload.get("event"))
             if expected_event and actual_event != expected_event:
                 return False
@@ -674,7 +766,7 @@ class ReferenceDrivenRuntime:
         if self._snapshot is None:
             return set()
         trace = self._reference_attack_trace()
-        return {step.target for step in trace.steps[self._red_progress:]}
+        return {step.target for step in trace.steps[self._red_progress :]}
 
     def _path_block_reason(self, target: str) -> str:
         if not target:
@@ -728,8 +820,13 @@ class ReferenceDrivenRuntime:
         if not self._state.service_health:
             self._state.continuity = 1.0
             return
-        self._state.continuity = sum(self._state.service_health.values()) / len(self._state.service_health)
-        if self._episode_config.continuity_enforced and self._state.continuity < self._episode_config.continuity_threshold:
+        self._state.continuity = sum(self._state.service_health.values()) / len(
+            self._state.service_health
+        )
+        if (
+            self._episode_config.continuity_enforced
+            and self._state.continuity < self._episode_config.continuity_threshold
+        ):
             self._blue_objectives_satisfied.discard("service_health_above(0.9)")
         elif self._episode_config.continuity_enforced:
             self._blue_objectives_satisfied.add("service_health_above(0.9)")
@@ -838,7 +935,9 @@ class ReferenceDrivenRuntime:
             service_health=self._state.service_health,
         )
 
-    def _observation_stdout(self, actor: ExternalRole, *, first_observation: bool) -> str:
+    def _observation_stdout(
+        self, actor: ExternalRole, *, first_observation: bool
+    ) -> str:
         base = f"sim_time={self._state.sim_time:.2f}"
         if not first_observation or self._snapshot is None:
             return base
@@ -848,7 +947,11 @@ class ReferenceDrivenRuntime:
         assert self._snapshot is not None
         world = self._snapshot.world
         objectives = world.red_objectives if actor == "red" else world.blue_objectives
-        public_services = ",".join(service.id for service in world.services if self._predicates and self._predicates.is_public_service(service))
+        public_services = ",".join(
+            service.id
+            for service in world.services
+            if self._predicates and self._predicates.is_public_service(service)
+        )
         lines = [
             f"briefing_mode={self._episode_config.prompt_mode}",
             f"business={world.business_archetype}",
@@ -866,7 +969,9 @@ class ReferenceDrivenRuntime:
 
     @staticmethod
     def _briefing_surface_summary(world, weak) -> str:
-        service = next((service for service in world.services if service.id == weak.target), None)
+        service = next(
+            (service for service in world.services if service.id == weak.target), None
+        )
         service_label = service.kind if service is not None else weak.target_kind
         family_label = {
             "code_web": "web surface",
@@ -880,19 +985,28 @@ class ReferenceDrivenRuntime:
     def _execute_live_action(self, action: Action) -> ActionExecution:
         if self.action_backend is None:
             directive = str(action.payload.get("action", "contain")).lower()
-            weakness_id = str(action.payload.get("weakness_id", action.payload.get("weakness", ""))).strip()
+            weakness_id = str(
+                action.payload.get("weakness_id", action.payload.get("weakness", ""))
+            ).strip()
             if action.kind in {"api", "shell", "mail"} and weakness_id:
                 weakness = self._active_weakness(weakness_id)
                 if weakness is None:
-                    return ActionExecution(stderr=f"weakness {weakness_id} unavailable", ok=False)
+                    return ActionExecution(
+                        stderr=f"weakness {weakness_id} unavailable", ok=False
+                    )
                 return ActionExecution(
-                    stdout=str(action.payload.get("expect_contains", "")) or f"exercised {weakness.kind}",
+                    stdout=str(action.payload.get("expect_contains", ""))
+                    or f"exercised {weakness.kind}",
                 )
             return ActionExecution(
-                stdout=str(action.payload.get("expect_contains", "")) if action.kind in {"api", "shell", "mail"} else "",
+                stdout=str(action.payload.get("expect_contains", ""))
+                if action.kind in {"api", "shell", "mail"}
+                else "",
                 containment_applied=action.kind == "control" and directive == "contain",
-                patch_applied=action.kind == "control" and directive in {"patch", "mitigate"},
-                recovery_applied=action.kind == "control" and directive in {"recover", "restore"},
+                patch_applied=action.kind == "control"
+                and directive in {"patch", "mitigate"},
+                recovery_applied=action.kind == "control"
+                and directive in {"recover", "restore"},
             )
         result = self.action_backend.execute(action)
         if result.service_health:
@@ -902,7 +1016,9 @@ class ReferenceDrivenRuntime:
 
     def _advance_due_time(self, actor: ExternalRole) -> None:
         cadence = 1.0 if self._is_controlled(actor) else self._opponent_cadence(actor)
-        self._next_due_time[actor] = round(max(self._next_due_time[actor], self._state.sim_time) + cadence, 4)
+        self._next_due_time[actor] = round(
+            max(self._next_due_time[actor], self._state.sim_time) + cadence, 4
+        )
 
     def _is_controlled(self, actor: ExternalRole) -> bool:
         return self._state.controls_red if actor == "red" else self._state.controls_blue
@@ -935,15 +1051,27 @@ class ReferenceDrivenRuntime:
                     actor_id="blue",
                     role="blue",
                     kind="submit_finding",
-                    payload={"event_type": event.event_type, "target": event.target_entity},
+                    payload={
+                        "event_type": event.event_type,
+                        "target": event.target_entity,
+                    },
                 )
         remaining = sorted(self._remaining_red_targets() - self._contained_targets)
         if remaining and self._blue_detected:
-            return Action(actor_id="blue", role="blue", kind="control", payload={"target": remaining[0], "action": "contain"})
+            return Action(
+                actor_id="blue",
+                role="blue",
+                kind="control",
+                payload={"target": remaining[0], "action": "contain"},
+            )
         return Action(actor_id="blue", role="blue", kind="sleep", payload={})
 
     def _resolved_opponent_mode(self, actor: ExternalRole) -> str:
-        mode = self._episode_config.opponent_red if actor == "red" else self._episode_config.opponent_blue
+        mode = (
+            self._episode_config.opponent_red
+            if actor == "red"
+            else self._episode_config.opponent_blue
+        )
         if mode != "checkpoint_pool":
             return mode
         if self._snapshot is None:
@@ -973,7 +1101,14 @@ class ReferenceDrivenRuntime:
     def _active_weakness(self, weakness_id: str):
         if self._predicates is None:
             return None
-        return next((weakness for weakness in self._predicates.active_weaknesses() if weakness.id == weakness_id), None)
+        return next(
+            (
+                weakness
+                for weakness in self._predicates.active_weaknesses()
+                if weakness.id == weakness_id
+            ),
+            None,
+        )
 
     def _reference_attack_trace(self):
         assert self._snapshot is not None

--- a/src/open_range/runtime_events.py
+++ b/src/open_range/runtime_events.py
@@ -172,13 +172,19 @@ def objective_events(
     if not objective and not asset_id:
         return RedEventBatch(events=(), satisfied_objectives=(), last_red_target=target)
     resolved_objective = objective or (
-        f"credential_obtained({asset_id})" if "cred" in asset_id else f"asset_read({asset_id})"
+        f"credential_obtained({asset_id})"
+        if "cred" in asset_id
+        else f"asset_read({asset_id})"
     )
     target_ref = predicate_inner(resolved_objective) or asset_id or target
     name = predicate_name(resolved_objective)
     surfaces = service_surfaces(target)
     if name in {"credential_obtained", "unauthorized_admin_login"}:
-        event_type = "CredentialObtained" if name == "credential_obtained" else "UnauthorizedCredentialUse"
+        event_type = (
+            "CredentialObtained"
+            if name == "credential_obtained"
+            else "UnauthorizedCredentialUse"
+        )
     elif name in {"asset_read", "file_access", "db_access"}:
         event_type = "SensitiveAssetRead"
     elif name in {"file_creation", "outbound_service"}:
@@ -230,7 +236,9 @@ def _secret_collection_events(
             malicious=True,
             observability_surfaces=service_surfaces(target),
         )
-        return RedEventBatch(events=(event,), satisfied_objectives=(), last_red_target=target)
+        return RedEventBatch(
+            events=(event,), satisfied_objectives=(), last_red_target=target
+        )
     if "cred" in asset_id or "token" in asset_id:
         objective = f"credential_obtained({asset_id})"
         event = emit_event(
@@ -242,7 +250,9 @@ def _secret_collection_events(
             observability_surfaces=service_surfaces(target),
             linked_objective_predicates=(objective,),
         )
-        return RedEventBatch(events=(event,), satisfied_objectives=(objective,), last_red_target=target)
+        return RedEventBatch(
+            events=(event,), satisfied_objectives=(objective,), last_red_target=target
+        )
     objective = f"asset_read({asset_id})"
     event = emit_event(
         event_type="SensitiveAssetRead",
@@ -253,7 +263,9 @@ def _secret_collection_events(
         observability_surfaces=service_surfaces(target),
         linked_objective_predicates=(objective,),
     )
-    return RedEventBatch(events=(event,), satisfied_objectives=(objective,), last_red_target=target)
+    return RedEventBatch(
+        events=(event,), satisfied_objectives=(objective,), last_red_target=target
+    )
 
 
 def _identity_abuse_events(
@@ -315,4 +327,6 @@ def _workflow_abuse_events(
         malicious=True,
         observability_surfaces=service_surfaces(target),
     )
-    return RedEventBatch(events=(event,), satisfied_objectives=(), last_red_target=target)
+    return RedEventBatch(
+        events=(event,), satisfied_objectives=(), last_red_target=target
+    )

--- a/src/open_range/service.py
+++ b/src/open_range/service.py
@@ -9,7 +9,13 @@ from open_range.cluster import BootedRelease, LiveBackend
 from open_range.episode_config import DEFAULT_EPISODE_CONFIG, EpisodeConfig
 from open_range.execution import ActionBackend, PodActionBackend
 from open_range.runtime import ReferenceDrivenRuntime
-from open_range.runtime_types import Action, ActionResult, Decision, EpisodeScore, EpisodeState
+from open_range.runtime_types import (
+    Action,
+    ActionResult,
+    Decision,
+    EpisodeScore,
+    EpisodeState,
+)
 from open_range.store import FileSnapshotStore, PoolSplit
 
 

--- a/src/open_range/sim.py
+++ b/src/open_range/sim.py
@@ -32,17 +32,27 @@ class SimTrace(_StrictModel):
 
 
 class SimPlane(Protocol):
-    def generate_bootstrap_trace(self, snapshot: RuntimeSnapshot, *, episode_seed: int) -> SimTrace: ...
+    def generate_bootstrap_trace(
+        self, snapshot: RuntimeSnapshot, *, episode_seed: int
+    ) -> SimTrace: ...
 
 
 class ReferenceSimPlane:
     """Replay hidden reference traces through the public decision loop."""
 
-    def generate_bootstrap_trace(self, snapshot: RuntimeSnapshot, *, episode_seed: int) -> SimTrace:
-        attack_index = episode_seed % max(1, len(snapshot.reference_bundle.reference_attack_traces))
-        defense_index = episode_seed % max(1, len(snapshot.reference_bundle.reference_defense_traces))
+    def generate_bootstrap_trace(
+        self, snapshot: RuntimeSnapshot, *, episode_seed: int
+    ) -> SimTrace:
+        attack_index = episode_seed % max(
+            1, len(snapshot.reference_bundle.reference_attack_traces)
+        )
+        defense_index = episode_seed % max(
+            1, len(snapshot.reference_bundle.reference_defense_traces)
+        )
         attack_trace = snapshot.reference_bundle.reference_attack_traces[attack_index]
-        defense_trace = snapshot.reference_bundle.reference_defense_traces[defense_index]
+        defense_trace = snapshot.reference_bundle.reference_defense_traces[
+            defense_index
+        ]
         runtime = ReferenceDrivenRuntime()
         runtime.reset(
             snapshot,
@@ -102,5 +112,7 @@ class ReferenceSimPlane:
         if step.target:
             payload.setdefault("target", step.target)
         if step.kind == "submit_finding":
-            payload["event_type"] = str(payload.get("event", payload.get("event_type", "InitialAccess")))
+            payload["event_type"] = str(
+                payload.get("event", payload.get("event_type", "InitialAccess"))
+            )
         return Action(actor_id="blue", role="blue", kind=step.kind, payload=payload)

--- a/src/open_range/snapshot.py
+++ b/src/open_range/snapshot.py
@@ -54,5 +54,7 @@ class RuntimeSnapshot(Snapshot):
 
 
 def world_hash(world: WorldIR) -> str:
-    payload = json.dumps(world.model_dump(mode="json"), sort_keys=True, separators=(",", ":"))
+    payload = json.dumps(
+        world.model_dump(mode="json"), sort_keys=True, separators=(",", ":")
+    )
     return hashlib.sha256(payload.encode("utf-8")).hexdigest()

--- a/src/open_range/store.py
+++ b/src/open_range/store.py
@@ -56,17 +56,27 @@ class FileSnapshotStore:
         *,
         split: PoolSplit = "train",
     ) -> Snapshot:
-        db_seed_state = {"services": [svc.id for svc in world.services if svc.kind == "db"]}
-        mail_state = {"mailboxes": [persona.mailbox for persona in world.green_personas if persona.mailbox]}
+        db_seed_state = {
+            "services": [svc.id for svc in world.services if svc.kind == "db"]
+        }
+        mail_state = {
+            "mailboxes": [
+                persona.mailbox for persona in world.green_personas if persona.mailbox
+            ]
+        }
         file_assets = {asset.id: asset.location for asset in world.assets}
         identity_seed = {"users": [user.id for user in world.users]}
         state_seed_dir = artifacts.render_dir
         if synth is not None:
             db_seed_state = {
                 "services": [svc.id for svc in world.services if svc.kind == "db"],
-                "payload_files": [item.key for item in synth.service_payloads.get("svc-db", ())],
+                "payload_files": [
+                    item.key for item in synth.service_payloads.get("svc-db", ())
+                ],
             }
-            mail_state = {mailbox: list(messages) for mailbox, messages in synth.mailboxes.items()}
+            mail_state = {
+                mailbox: list(messages) for mailbox, messages in synth.mailboxes.items()
+            }
             file_assets = {
                 synth_file.key: synth_file.mount_path
                 for synth_file in synth.service_payloads.get("svc-fileshare", ())
@@ -103,7 +113,9 @@ class FileSnapshotStore:
             parent_snapshot_id=None,
             parent_world_id=world.lineage.parent_world_id,
         )
-        self._snapshot_path(snapshot_id).write_text(snapshot.model_dump_json(indent=2), encoding="utf-8")
+        self._snapshot_path(snapshot_id).write_text(
+            snapshot.model_dump_json(indent=2), encoding="utf-8"
+        )
         self._metadata_path(snapshot_id).write_text(
             json.dumps(
                 {
@@ -117,7 +129,8 @@ class FileSnapshotStore:
                 },
                 indent=2,
                 sort_keys=True,
-            ) + "\n",
+            )
+            + "\n",
             encoding="utf-8",
         )
         return snapshot

--- a/src/open_range/synth.py
+++ b/src/open_range/synth.py
@@ -10,7 +10,12 @@ from typing import Protocol
 from pydantic import BaseModel, ConfigDict, Field
 
 from open_range.code_web import code_web_realization_content
-from open_range.world_ir import AssetSpec, WeaknessRealizationSpec, WeaknessSpec, WorldIR
+from open_range.world_ir import (
+    AssetSpec,
+    WeaknessRealizationSpec,
+    WeaknessSpec,
+    WorldIR,
+)
 
 
 class _StrictModel(BaseModel):
@@ -63,11 +68,17 @@ class EnterpriseSaaSWorldSynthesizer:
         }
         summary = {
             "world_id": world.world_id,
-            "service_payload_counts": {service_id: len(files) for service_id, files in payloads.items()},
-            "mailboxes": {mailbox: list(messages) for mailbox, messages in mailboxes.items()},
+            "service_payload_counts": {
+                service_id: len(files) for service_id, files in payloads.items()
+            },
+            "mailboxes": {
+                mailbox: list(messages) for mailbox, messages in mailboxes.items()
+            },
         }
         summary_path = outdir / "synth-summary.json"
-        summary_path.write_text(json.dumps(summary, indent=2, sort_keys=True) + "\n", encoding="utf-8")
+        summary_path.write_text(
+            json.dumps(summary, indent=2, sort_keys=True) + "\n", encoding="utf-8"
+        )
         generated.append(str(summary_path))
 
         return SynthArtifacts(
@@ -122,8 +133,14 @@ class EnterpriseSaaSWorldSynthesizer:
             return payloads
         if service_id == "svc-siem":
             payloads = [
-                SynthFile(key="all.log", mount_path="/srv/http/siem/all.log", content=""),
-                SynthFile(key="index.html", mount_path="/srv/http/siem/index.html", content="OpenRange SIEM log sink\n"),
+                SynthFile(
+                    key="all.log", mount_path="/srv/http/siem/all.log", content=""
+                ),
+                SynthFile(
+                    key="index.html",
+                    mount_path="/srv/http/siem/index.html",
+                    content="OpenRange SIEM log sink\n",
+                ),
             ]
             payloads.extend(self._weakness_payloads(world, service_id))
             return payloads
@@ -153,18 +170,23 @@ class EnterpriseSaaSWorldSynthesizer:
                     SynthFile(
                         key=key,
                         mount_path=realization.path,
-                        content=_weakness_realization_content(world, weakness, realization),
+                        content=_weakness_realization_content(
+                            world, weakness, realization
+                        ),
                     )
                 )
         return payloads
 
 
 def _web_index_html(world: WorldIR) -> str:
-    asset_links = "\n".join(
-        f"<li><a href=\"/content/{asset.id}.txt\">{asset.id}</a></li>"
-        for asset in world.assets
-        if asset.owner_service == "svc-web"
-    ) or "<li>No web-hosted assets</li>"
+    asset_links = (
+        "\n".join(
+            f'<li><a href="/content/{asset.id}.txt">{asset.id}</a></li>'
+            for asset in world.assets
+            if asset.owner_service == "svc-web"
+        )
+        or "<li>No web-hosted assets</li>"
+    )
     return textwrap.dedent(
         f"""\
         <html>
@@ -268,7 +290,14 @@ def _secret_material(world: WorldIR, exposed_ref: str) -> str:
     user = next((user for user in world.users if user.id == exposed_ref), None)
     if user is not None:
         return _default_password(user.id)
-    credential = next((credential for credential in world.credentials if credential.id == exposed_ref), None)
+    credential = next(
+        (
+            credential
+            for credential in world.credentials
+            if credential.id == exposed_ref
+        ),
+        None,
+    )
     if credential is not None:
         return f"seeded-secret-{credential.id}"
     if exposed_ref.endswith("_cred") or exposed_ref.endswith("_token"):
@@ -291,7 +320,9 @@ def _config_identity_content(world: WorldIR, weakness: WeaknessSpec) -> str:
     elif weakness.kind == "default_credential":
         payload.update({"default_username": "admin", "default_password": "admin"})
     elif weakness.kind == "overbroad_service_account":
-        payload.update({"service_account_scope": ["svc-db", "svc-fileshare", "svc-idp"]})
+        payload.update(
+            {"service_account_scope": ["svc-db", "svc-fileshare", "svc-idp"]}
+        )
     elif weakness.kind == "admin_surface_exposed":
         payload.update({"admin_surface_public": True, "debug_toggle": True})
     elif weakness.kind == "trust_edge_misconfig":
@@ -308,19 +339,29 @@ def _workflow_content(world: WorldIR, weakness: WeaknessSpec) -> str:
         "approval_guard": "disabled",
     }
     if weakness.kind == "helpdesk_reset_bypass":
-        payload.update({"identity_verification": "none", "reset_without_ticket_owner": True})
+        payload.update(
+            {"identity_verification": "none", "reset_without_ticket_owner": True}
+        )
     elif weakness.kind == "approval_chain_bypass":
         payload.update({"required_approvals": 1, "secondary_approval_skipped": True})
     elif weakness.kind == "document_share_abuse":
-        payload.update({"share_visibility": "public_link", "expiration_required": False})
+        payload.update(
+            {"share_visibility": "public_link", "expiration_required": False}
+        )
     elif weakness.kind == "phishing_credential_capture":
-        payload.update({"mail_filtering": "allow", "credential_capture_landing": "/login"})
+        payload.update(
+            {"mail_filtering": "allow", "credential_capture_landing": "/login"}
+        )
     elif weakness.kind == "internal_request_impersonation":
-        payload.update({"sender_verification": "disabled", "internal_alias_trust": True})
+        payload.update(
+            {"sender_verification": "disabled", "internal_alias_trust": True}
+        )
     return json.dumps(payload, indent=2, sort_keys=True) + "\n"
 
 
-def _workflow_mailbox_content(world: WorldIR, weakness: WeaknessSpec, realization: WeaknessRealizationSpec) -> str:
+def _workflow_mailbox_content(
+    world: WorldIR, weakness: WeaknessSpec, realization: WeaknessRealizationSpec
+) -> str:
     subject = "Password reset verification"
     body = "Confirm your account details to complete the request."
     if weakness.kind == "internal_request_impersonation":
@@ -356,11 +397,15 @@ def _telemetry_content(world: WorldIR, weakness: WeaknessSpec) -> str:
     elif weakness.kind == "unmonitored_admin_action":
         payload.update({"admin_actions_logged": False})
     elif weakness.kind == "silent_mail_rule":
-        payload.update({"mail_rule_logging": False, "mailbox_auto_forward_alerting": False})
+        payload.update(
+            {"mail_rule_logging": False, "mailbox_auto_forward_alerting": False}
+        )
     return json.dumps(payload, indent=2, sort_keys=True) + "\n"
 
 
-def _secret_mailbox_content(world: WorldIR, weakness: WeaknessSpec, realization: WeaknessRealizationSpec) -> str:
+def _secret_mailbox_content(
+    world: WorldIR, weakness: WeaknessSpec, realization: WeaknessRealizationSpec
+) -> str:
     secret_material = _secret_material(world, weakness.target_ref or weakness.target)
     return textwrap.dedent(
         f"""\

--- a/src/open_range/tracegen.py
+++ b/src/open_range/tracegen.py
@@ -85,7 +85,9 @@ class TraceDatasetGenerator:
             lineage_dir.mkdir(parents=True, exist_ok=True)
             store_split = "train" if root_idx == 0 else "eval"
             base_public = pipeline.admit(
-                pipeline.build(payload, lineage_dir / "rendered-base", self.build_config),
+                pipeline.build(
+                    payload, lineage_dir / "rendered-base", self.build_config
+                ),
                 split=store_split,
             )
             base = hydrate_runtime_snapshot(store, base_public)
@@ -109,7 +111,8 @@ class TraceDatasetGenerator:
                     try:
                         child_public = pipeline.admit_child(
                             child_world,
-                            lineage_dir / f"rendered-child-{mutation_idx}-attempt-{attempt_idx}",
+                            lineage_dir
+                            / f"rendered-child-{mutation_idx}-attempt-{attempt_idx}",
                             split=store_split,
                             build_config=self.build_config,
                         )
@@ -124,11 +127,15 @@ class TraceDatasetGenerator:
 
             for snapshot_idx, snapshot in enumerate(snapshots):
                 if include_sim:
-                    for attack_idx, defense_idx in reference_trace_pairs(snapshot, "joint_pool"):
+                    for attack_idx, defense_idx in reference_trace_pairs(
+                        snapshot, "joint_pool"
+                    ):
                         raw_rows.extend(
                             self._episode_rows(
                                 snapshot,
-                                EpisodeConfig(mode="joint_pool", scheduler_mode="strict_turns"),
+                                EpisodeConfig(
+                                    mode="joint_pool", scheduler_mode="strict_turns"
+                                ),
                                 trace_source="sim",
                                 teacher_source="reference_sim",
                                 split=dataset_split,
@@ -138,7 +145,9 @@ class TraceDatasetGenerator:
                             )
                         )
                 for mode in DEFAULT_RUNTIME_MODES:
-                    for attack_idx, defense_idx in reference_trace_pairs(snapshot, mode):
+                    for attack_idx, defense_idx in reference_trace_pairs(
+                        snapshot, mode
+                    ):
                         raw_rows.extend(
                             self._episode_rows(
                                 snapshot,
@@ -164,11 +173,15 @@ class TraceDatasetGenerator:
                             )
                         )
                 if include_joint_pool:
-                    for attack_idx, defense_idx in reference_trace_pairs(snapshot, "joint_pool"):
+                    for attack_idx, defense_idx in reference_trace_pairs(
+                        snapshot, "joint_pool"
+                    ):
                         raw_rows.extend(
                             self._episode_rows(
                                 snapshot,
-                                EpisodeConfig(mode="joint_pool", scheduler_mode="strict_turns"),
+                                EpisodeConfig(
+                                    mode="joint_pool", scheduler_mode="strict_turns"
+                                ),
                                 trace_source="runtime",
                                 teacher_source="reference_runtime",
                                 split=dataset_split,
@@ -180,7 +193,9 @@ class TraceDatasetGenerator:
                         raw_rows.extend(
                             self._episode_rows(
                                 snapshot,
-                                EpisodeConfig(mode="joint_pool", scheduler_mode="strict_turns"),
+                                EpisodeConfig(
+                                    mode="joint_pool", scheduler_mode="strict_turns"
+                                ),
                                 trace_source="runtime",
                                 teacher_source="scripted_runtime",
                                 split=dataset_split,
@@ -233,8 +248,16 @@ class TraceDatasetGenerator:
             reference_defense_index=defense_trace_index,
         )
         teacher_steps = {
-            "red": list(snapshot.reference_bundle.reference_attack_traces[attack_trace_index].steps),
-            "blue": list(snapshot.reference_bundle.reference_defense_traces[defense_trace_index].steps),
+            "red": list(
+                snapshot.reference_bundle.reference_attack_traces[
+                    attack_trace_index
+                ].steps
+            ),
+            "blue": list(
+                snapshot.reference_bundle.reference_defense_traces[
+                    defense_trace_index
+                ].steps
+            ),
         }
         teacher_progress = {"red": 0, "blue": 0}
         actor_decisions = {"red": 0, "blue": 0}
@@ -269,11 +292,15 @@ class TraceDatasetGenerator:
             else:
                 chosen_action = teacher_choice
             result = runtime.act(actor, chosen_action)
-            if expected is not None and runtime.matches_reference_step(chosen_action, expected, result.stdout):
+            if expected is not None and runtime.matches_reference_step(
+                chosen_action, expected, result.stdout
+            ):
                 teacher_progress[actor] += 1
             actor_decisions[actor] += 1
             public_candidates = tuple(
-                candidate.model_copy(update={"action": public_trace_action(candidate.action)})
+                candidate.model_copy(
+                    update={"action": public_trace_action(candidate.action)}
+                )
                 for candidate in candidates
             )
             public_action = public_trace_action(chosen_action)
@@ -356,7 +383,7 @@ def generate_trace_dataset(
         mutations_per_root=mutations_per_root,
         include_sim=include_sim,
         include_joint_pool=include_joint_pool,
-        )
+    )
 
 
 def _dataset_split(root_idx: int, roots: int) -> str:
@@ -375,9 +402,15 @@ def _dataset_split(root_idx: int, roots: int) -> str:
 
 def _episode_config_for(mode: str) -> EpisodeConfig:
     if mode == "red_only":
-        return EpisodeConfig(mode="red_only", scheduler_mode="strict_turns", opponent_blue="reference")
+        return EpisodeConfig(
+            mode="red_only", scheduler_mode="strict_turns", opponent_blue="reference"
+        )
     if mode == "blue_only_live":
-        return EpisodeConfig(mode="blue_only_live", scheduler_mode="strict_turns", opponent_red="reference")
+        return EpisodeConfig(
+            mode="blue_only_live",
+            scheduler_mode="strict_turns",
+            opponent_red="reference",
+        )
     if mode == "blue_only_from_prefix":
         return EpisodeConfig(
             mode="blue_only_from_prefix",
@@ -395,7 +428,9 @@ def _seed_manifest_copy(manifest: dict[str, Any], root_idx: int) -> dict[str, An
     return payload
 
 
-def _parent_stats(snapshot: RuntimeSnapshot, *, root_idx: int, mutation_idx: int, attempt_idx: int = 1) -> PopulationStats:
+def _parent_stats(
+    snapshot: RuntimeSnapshot, *, root_idx: int, mutation_idx: int, attempt_idx: int = 1
+) -> PopulationStats:
     offset = mutation_idx + attempt_idx - 1
     parity = (root_idx + offset) % 2
     return PopulationStats(
@@ -427,7 +462,9 @@ def _write_jsonl(path: Path, rows: list[dict[str, Any]]) -> None:
             handle.write(json.dumps(row, sort_keys=True) + "\n")
 
 
-def _write_role_source_shards(root_dir: Path, rows: list[TraceDecisionRow]) -> dict[str, str]:
+def _write_role_source_shards(
+    root_dir: Path, rows: list[TraceDecisionRow]
+) -> dict[str, str]:
     shards: dict[str, str] = {}
     shard_rows: dict[str, list[TraceDecisionRow]] = {}
 
@@ -439,8 +476,15 @@ def _write_role_source_shards(root_dir: Path, rows: list[TraceDecisionRow]) -> d
         role_rows = [row for row in rows if row.role == role]
         add(f"raw.{role}.all", role_rows)
         for source in ("runtime", "sim"):
-            add(f"raw.{role}.{source}", [row for row in role_rows if row.trace_source == source])
-        for teacher_source in ("reference_runtime", "scripted_runtime", "reference_sim"):
+            add(
+                f"raw.{role}.{source}",
+                [row for row in role_rows if row.trace_source == source],
+            )
+        for teacher_source in (
+            "reference_runtime",
+            "scripted_runtime",
+            "reference_sim",
+        ):
             add(
                 f"raw.{role}.teacher.{teacher_source}",
                 [row for row in role_rows if row.teacher_source == teacher_source],
@@ -460,11 +504,21 @@ def _write_role_source_shards(root_dir: Path, rows: list[TraceDecisionRow]) -> d
         for source in ("runtime", "sim"):
             selected = [row for row in role_rows if row.trace_source == source]
             if selected:
-                sft_rows[f"sft.{role}.{source}"] = [row_to_sft_record(row) for row in selected]
-        for teacher_source in ("reference_runtime", "scripted_runtime", "reference_sim"):
-            selected = [row for row in role_rows if row.teacher_source == teacher_source]
+                sft_rows[f"sft.{role}.{source}"] = [
+                    row_to_sft_record(row) for row in selected
+                ]
+        for teacher_source in (
+            "reference_runtime",
+            "scripted_runtime",
+            "reference_sim",
+        ):
+            selected = [
+                row for row in role_rows if row.teacher_source == teacher_source
+            ]
             if selected:
-                sft_rows[f"sft.{role}.teacher.{teacher_source}"] = [row_to_sft_record(row) for row in selected]
+                sft_rows[f"sft.{role}.teacher.{teacher_source}"] = [
+                    row_to_sft_record(row) for row in selected
+                ]
 
     for name, payloads in sft_rows.items():
         path = root_dir / f"{name.replace('.', '_')}.jsonl"

--- a/src/open_range/training_data.py
+++ b/src/open_range/training_data.py
@@ -139,7 +139,9 @@ def render_action_text(action: Action) -> str:
         query = action.payload.get("query")
         query_text = ""
         if isinstance(query, dict) and query:
-            query_text = "?" + urlencode([(str(key), str(value)) for key, value in query.items()], doseq=True)
+            query_text = "?" + urlencode(
+                [(str(key), str(value)) for key, value in query.items()], doseq=True
+            )
         return f"curl -s http://{target}{path}{query_text}"
     if action.kind == "shell":
         command = str(action.payload.get("command", "")).strip()
@@ -155,7 +157,11 @@ def render_action_text(action: Action) -> str:
         directive = str(action.payload.get("action", "contain")).lower()
         return f"{directive} {target}".strip()
     if action.kind == "submit_finding":
-        event_type = str(action.payload.get("event_type", action.payload.get("event", "InitialAccess")))
+        event_type = str(
+            action.payload.get(
+                "event_type", action.payload.get("event", "InitialAccess")
+            )
+        )
         return f"submit_finding event={event_type} target={target}".strip()
     if action.kind == "sleep":
         return "sleep 1"
@@ -172,7 +178,9 @@ def render_candidate_completion(candidate: TraceCandidate) -> str:
 
 
 def row_to_sft_record(row: TraceDecisionRow) -> dict[str, Any]:
-    selected = next((candidate for candidate in row.candidate_actions if candidate.selected), None)
+    selected = next(
+        (candidate for candidate in row.candidate_actions if candidate.selected), None
+    )
     if selected is None:
         raise ValueError("trace row must contain exactly one selected candidate")
     return {
@@ -248,7 +256,9 @@ def build_decision_prompt(
     include_hidden_context: bool = False,
 ) -> str:
     visible = _visible_event_lines(observation.visible_events)
-    candidates = "\n".join(f"- [{candidate.label}] {candidate.text}" for candidate in candidate_actions)
+    candidates = "\n".join(
+        f"- [{candidate.label}] {candidate.text}" for candidate in candidate_actions
+    )
     lines = [
         f"sim_time={observation.sim_time:.2f}\n"
         f"last_stdout={observation.stdout or 'none'}\n"
@@ -300,7 +310,9 @@ def system_prompt_for_role(role: Literal["red", "blue"]) -> str:
 def _service_health_text(observation: Observation) -> str:
     if not observation.service_health:
         return "unknown"
-    return ", ".join(f"{entry.service_id}={entry.health:.2f}" for entry in observation.service_health)
+    return ", ".join(
+        f"{entry.service_id}={entry.health:.2f}" for entry in observation.service_health
+    )
 
 
 def _visible_event_lines(events: tuple[RuntimeEvent, ...]) -> str:
@@ -327,7 +339,9 @@ def trace_weaknesses(snapshot: RuntimeSnapshot) -> tuple[TraceWeakness, ...]:
 
 
 def trace_benchmark_tags(snapshot: RuntimeSnapshot) -> tuple[str, ...]:
-    tags = {tag for weakness in snapshot.world.weaknesses for tag in weakness.benchmark_tags}
+    tags = {
+        tag for weakness in snapshot.world.weaknesses for tag in weakness.benchmark_tags
+    }
     return tuple(sorted(tags))
 
 
@@ -339,7 +353,8 @@ def grounded_effects_for_result(
     labels = {
         event.event_type
         for event in emitted_events
-        if event.event_type in {
+        if event.event_type
+        in {
             "CredentialObtained",
             "UnauthorizedCredentialUse",
             "PrivilegeEscalation",
@@ -351,7 +366,8 @@ def grounded_effects_for_result(
     labels.update(
         token
         for token in stdout.split()
-        if token.startswith("OPENRANGE-EFFECT:") or token.startswith("OPENRANGE-FOOTHOLD:")
+        if token.startswith("OPENRANGE-EFFECT:")
+        or token.startswith("OPENRANGE-FOOTHOLD:")
     )
     return tuple(sorted(labels))
 
@@ -365,12 +381,16 @@ def mitigation_effects_for_result(
     labels = {
         event.event_type
         for event in emitted_events
-        if event.event_type in {"ContainmentApplied", "PatchApplied", "RecoveryCompleted"}
+        if event.event_type
+        in {"ContainmentApplied", "PatchApplied", "RecoveryCompleted"}
     }
     if action.kind == "control":
         directive = str(action.payload.get("action", "")).lower()
         target = str(action.payload.get("target", ""))
-        if directive in {"contain", "patch", "mitigate", "recover", "restore"} and target:
+        if (
+            directive in {"contain", "patch", "mitigate", "recover", "restore"}
+            and target
+        ):
             labels.add(f"{directive}:{target}")
     if "mitigation applied to " in stdout:
         labels.add("mitigation_applied")

--- a/src/open_range/weaknesses.py
+++ b/src/open_range/weaknesses.py
@@ -7,7 +7,11 @@ import shlex
 from typing import Protocol
 
 from open_range.code_web import code_web_realizations, code_web_remediation_command
-from open_range.manifest import PinnedWeaknessSpec, WEAKNESS_KIND_CATALOG, WeaknessFamily
+from open_range.manifest import (
+    PinnedWeaknessSpec,
+    WEAKNESS_KIND_CATALOG,
+    WeaknessFamily,
+)
 from open_range.objectives import weakness_objective_tags
 from open_range.world_ir import WeaknessRealizationSpec, WeaknessSpec, WorldIR
 
@@ -22,7 +26,9 @@ class CatalogWeaknessSeeder:
     def apply(self, world: WorldIR, seed: int | None = None) -> WorldIR:
         rng = random.Random(world.seed if seed is None else seed)
         if world.pinned_weaknesses:
-            weaknesses = tuple(self._seed_pinned(world, pinned) for pinned in world.pinned_weaknesses)
+            weaknesses = tuple(
+                self._seed_pinned(world, pinned) for pinned in world.pinned_weaknesses
+            )
         else:
             available = sorted(self._available_families(world))
             if not available:
@@ -34,14 +40,17 @@ class CatalogWeaknessSeeder:
                 selected_families.append("code_web")
                 remaining.remove("code_web")
             if len(selected_families) < weakness_count:
-                selected_families.extend(sorted(rng.sample(remaining, k=weakness_count - len(selected_families))))
+                selected_families.extend(
+                    sorted(
+                        rng.sample(remaining, k=weakness_count - len(selected_families))
+                    )
+                )
             selected = tuple(selected_families)
             weaknesses = tuple(self._seed_family(world, family) for family in selected)
         lineage = world.lineage.model_copy(
             update={
-                "mutation_ops": tuple(world.lineage.mutation_ops) + tuple(
-                    f"seed:{weak.family}:{weak.target}" for weak in weaknesses
-                )
+                "mutation_ops": tuple(world.lineage.mutation_ops)
+                + tuple(f"seed:{weak.family}:{weak.target}" for weak in weaknesses)
             }
         )
         return world.model_copy(update={"weaknesses": weaknesses, "lineage": lineage})
@@ -83,9 +92,17 @@ class CatalogWeaknessSeeder:
             target = "svc-web"
             target_ref = world.workflows[0].id if world.workflows else "wf-generic"
         elif family == "secret_exposure":
-            target = "svc-fileshare" if any(service.id == "svc-fileshare" for service in world.services) else "svc-idp"
+            target = (
+                "svc-fileshare"
+                if any(service.id == "svc-fileshare" for service in world.services)
+                else "svc-idp"
+            )
             sensitive_asset = next(
-                (asset.id for asset in world.assets if asset.asset_class == "sensitive"),
+                (
+                    asset.id
+                    for asset in world.assets
+                    if asset.asset_class == "sensitive"
+                ),
                 world.assets[0].id if world.assets else target,
             )
             target_ref = sensitive_asset
@@ -93,7 +110,11 @@ class CatalogWeaknessSeeder:
             target = "svc-idp"
             target_ref = "svc-idp"
         else:
-            target = "svc-email" if any(service.id == "svc-email" for service in world.services) else "svc-web"
+            target = (
+                "svc-email"
+                if any(service.id == "svc-email" for service in world.services)
+                else "svc-web"
+            )
             target_ref = target
         return CatalogWeaknessSeeder._build_weakness(
             world,
@@ -140,7 +161,9 @@ def build_catalog_weakness(
 ) -> WeaknessSpec:
     if kind not in WEAKNESS_KIND_CATALOG[family]:
         raise ValueError(f"unsupported kind {kind!r} for family {family!r}")
-    target, target_kind, target_ref = _normalize_target_for_kind(world, family, kind, target, target_kind, target_ref)
+    target, target_kind, target_ref = _normalize_target_for_kind(
+        world, family, kind, target, target_kind, target_ref
+    )
     weak_id = weakness_id or _weakness_id(family, kind, target, target_ref)
     if family == "code_web":
         base = WeaknessSpec(
@@ -171,7 +194,9 @@ def build_catalog_weakness(
             ),
             instantiation_mode="exact_code",
         )
-        return base.model_copy(update={"realization": code_web_realizations(world, base)})
+        return base.model_copy(
+            update={"realization": code_web_realizations(world, base)}
+        )
     if family == "workflow_abuse":
         realizations = _workflow_realizations(world, kind, target, target_ref)
         return WeaknessSpec(
@@ -211,7 +236,9 @@ def build_catalog_weakness(
             remediation=_remediation_text(kind),
             remediation_id=f"remediate-{kind}",
             remediation_kind="shell",
-            remediation_command=_secret_exposure_remediation_command(kind, realizations),
+            remediation_command=_secret_exposure_remediation_command(
+                kind, realizations
+            ),
             instantiation_mode="exact_config",
         )
     if family == "config_identity":
@@ -232,7 +259,9 @@ def build_catalog_weakness(
             remediation=_remediation_text(kind),
             remediation_id=f"remediate-{kind}",
             remediation_kind="shell",
-            remediation_command=_config_identity_remediation_command(kind, realizations),
+            remediation_command=_config_identity_remediation_command(
+                kind, realizations
+            ),
             instantiation_mode="exact_config",
         )
     realizations = _telemetry_realizations(kind, target)
@@ -267,14 +296,22 @@ def _default_target_kind(family: WeaknessFamily) -> str:
     return "service"
 
 
-def _default_kind(world: WorldIR, family: WeaknessFamily, target: str, target_ref: str) -> str:
+def _default_kind(
+    world: WorldIR, family: WeaknessFamily, target: str, target_ref: str
+) -> str:
     del target_ref
     if family == "code_web":
-        return world.allowed_code_flaw_kinds[0] if world.allowed_code_flaw_kinds else "sql_injection"
+        return (
+            world.allowed_code_flaw_kinds[0]
+            if world.allowed_code_flaw_kinds
+            else "sql_injection"
+        )
     if family == "config_identity":
         if any(user.role == "it_admin" for user in world.users):
             return "weak_password"
-        return "admin_surface_exposed" if target == "svc-idp" else "trust_edge_misconfig"
+        return (
+            "admin_surface_exposed" if target == "svc-idp" else "trust_edge_misconfig"
+        )
     if family == "secret_exposure":
         if target == "svc-email":
             return "token_in_email"
@@ -304,7 +341,10 @@ def _resolve_pinned_target(world: WorldIR, pinned_target: str) -> tuple[str, str
     if target_kind == "service":
         if any(service.id == target_value for service in world.services):
             return target_value, target_kind, target_value
-        match = next((service.id for service in world.services if service.kind == target_value), None)
+        match = next(
+            (service.id for service in world.services if service.kind == target_value),
+            None,
+        )
         if match:
             return match, target_kind, match
         raise ValueError(f"unknown pinned service target: {target_value}")
@@ -321,10 +361,14 @@ def _resolve_pinned_target(world: WorldIR, pinned_target: str) -> tuple[str, str
         )
         if workflow is None:
             raise ValueError(f"unknown pinned workflow target: {target_value}")
-        target = next((step.service for step in workflow.steps if step.service), "svc-web")
+        target = next(
+            (step.service for step in workflow.steps if step.service), "svc-web"
+        )
         return target, target_kind, workflow.id
     if target_kind == "asset":
-        asset = next((asset for asset in world.assets if asset.id == target_value), None)
+        asset = next(
+            (asset for asset in world.assets if asset.id == target_value), None
+        )
         if asset is None:
             raise ValueError(f"unknown pinned asset target: {target_value}")
         return asset.owner_service, target_kind, asset.id
@@ -342,7 +386,14 @@ def _resolve_pinned_target(world: WorldIR, pinned_target: str) -> tuple[str, str
         service = credential.scope[0] if credential.scope else "svc-idp"
         return service, target_kind, credential.id
     if target_kind == "telemetry":
-        service = next((edge.source for edge in world.telemetry_edges if edge.source == target_value), None)
+        service = next(
+            (
+                edge.source
+                for edge in world.telemetry_edges
+                if edge.source == target_value
+            ),
+            None,
+        )
         if service is None:
             raise ValueError(f"unknown pinned telemetry target: {target_value}")
         return service, target_kind, service
@@ -361,35 +412,54 @@ def _normalize_target_for_kind(
     if family == "secret_exposure":
         if kind == "token_in_email" and "svc-email" in service_ids:
             return "svc-email", target_kind, target_ref
-        if kind in {"env_file_leak", "hardcoded_app_secret"} and "svc-web" in service_ids:
+        if (
+            kind in {"env_file_leak", "hardcoded_app_secret"}
+            and "svc-web" in service_ids
+        ):
             return "svc-web", target_kind, target_ref
-        if kind in {"credential_in_share", "backup_leak"} and "svc-fileshare" in service_ids:
+        if (
+            kind in {"credential_in_share", "backup_leak"}
+            and "svc-fileshare" in service_ids
+        ):
             return "svc-fileshare", target_kind, target_ref
     if family == "workflow_abuse":
-        if kind in {"phishing_credential_capture", "internal_request_impersonation"} and "svc-email" in service_ids:
+        if (
+            kind in {"phishing_credential_capture", "internal_request_impersonation"}
+            and "svc-email" in service_ids
+        ):
             return "svc-email", target_kind, target_ref
         if kind == "document_share_abuse" and "svc-fileshare" in service_ids:
             return "svc-fileshare", target_kind, target_ref
-        if kind in {"helpdesk_reset_bypass", "approval_chain_bypass"} and "svc-web" in service_ids:
+        if (
+            kind in {"helpdesk_reset_bypass", "approval_chain_bypass"}
+            and "svc-web" in service_ids
+        ):
             return "svc-web", target_kind, target_ref
     if family == "config_identity" and "svc-idp" in service_ids:
         return "svc-idp", target_kind, target_ref
     if family == "telemetry_blindspot":
         if kind == "missing_web_logs" and "svc-web" in service_ids:
             return "svc-web", "telemetry", "svc-web"
-        if kind in {"missing_idp_logs", "unmonitored_admin_action"} and "svc-idp" in service_ids:
+        if (
+            kind in {"missing_idp_logs", "unmonitored_admin_action"}
+            and "svc-idp" in service_ids
+        ):
             return "svc-idp", "telemetry", "svc-idp"
         if kind == "silent_mail_rule" and "svc-email" in service_ids:
             return "svc-email", "telemetry", "svc-email"
     return target, target_kind, target_ref
 
 
-def _weakness_id(family: WeaknessFamily, kind: str, target: str, target_ref: str) -> str:
+def _weakness_id(
+    family: WeaknessFamily, kind: str, target: str, target_ref: str
+) -> str:
     suffix = target_ref or target
     return f"wk-{kind.replace('_', '-')}-{suffix}"
 
 
-def _preconditions(family: WeaknessFamily, kind: str, target_ref: str) -> tuple[str, ...]:
+def _preconditions(
+    family: WeaknessFamily, kind: str, target_ref: str
+) -> tuple[str, ...]:
     if family == "code_web":
         return ("public_reachability", "user_input_surface", kind)
     if family == "config_identity":
@@ -418,7 +488,9 @@ def _expected_events(family: WeaknessFamily, kind: str) -> tuple[str, ...]:
 
 
 def _realization_summary(family: WeaknessFamily, kind: str) -> str:
-    return f"{family}::{kind} realized for deterministic admission and runtime validation"
+    return (
+        f"{family}::{kind} realized for deterministic admission and runtime validation"
+    )
 
 
 def _remediation_text(kind: str) -> str:
@@ -428,7 +500,10 @@ def _remediation_text(kind: str) -> str:
 def _workflow_surfaces(kind: str, target: str) -> tuple[str, ...]:
     if kind == "document_share_abuse" or target == "svc-fileshare":
         return ("share_access", "audit", "ingest")
-    if kind in {"phishing_credential_capture", "internal_request_impersonation"} or target == "svc-email":
+    if (
+        kind in {"phishing_credential_capture", "internal_request_impersonation"}
+        or target == "svc-email"
+    ):
         return ("smtp", "imap", "audit", "ingest")
     return ("web_access", "audit", "ingest")
 
@@ -502,7 +577,12 @@ def _secret_exposure_realizations(
     if kind == "env_file_leak":
         path = "/var/www/html/.env" if target == "svc-web" else "/etc/openrange/.env"
         return (
-            WeaknessRealizationSpec(kind="config", service=target, path=path, summary=_realization_summary("secret_exposure", kind)),
+            WeaknessRealizationSpec(
+                kind="config",
+                service=target,
+                path=path,
+                summary=_realization_summary("secret_exposure", kind),
+            ),
         )
     if kind == "credential_in_share":
         return (
@@ -520,7 +600,12 @@ def _secret_exposure_realizations(
             else f"/var/backups/openrange-{target_ref}.sql"
         )
         return (
-            WeaknessRealizationSpec(kind="seed_data", service=target, path=path, summary=_realization_summary("secret_exposure", kind)),
+            WeaknessRealizationSpec(
+                kind="seed_data",
+                service=target,
+                path=path,
+                summary=_realization_summary("secret_exposure", kind),
+            ),
         )
     if kind == "token_in_email":
         mailbox = _mailbox_for_ref(world, target_ref)
@@ -532,13 +617,24 @@ def _secret_exposure_realizations(
                 summary=_realization_summary("secret_exposure", kind),
             ),
         )
-    path = "/var/www/html/.openrange/app-secret.php" if target == "svc-web" else "/etc/openrange/app-secret.txt"
+    path = (
+        "/var/www/html/.openrange/app-secret.php"
+        if target == "svc-web"
+        else "/etc/openrange/app-secret.txt"
+    )
     return (
-        WeaknessRealizationSpec(kind="config", service=target, path=path, summary=_realization_summary("secret_exposure", kind)),
+        WeaknessRealizationSpec(
+            kind="config",
+            service=target,
+            path=path,
+            summary=_realization_summary("secret_exposure", kind),
+        ),
     )
 
 
-def _config_identity_realizations(kind: str, target: str) -> tuple[WeaknessRealizationSpec, ...]:
+def _config_identity_realizations(
+    kind: str, target: str
+) -> tuple[WeaknessRealizationSpec, ...]:
     filename = {
         "weak_password": "password-policy.json",
         "default_credential": "default-credential.json",
@@ -556,7 +652,9 @@ def _config_identity_realizations(kind: str, target: str) -> tuple[WeaknessReali
     )
 
 
-def _telemetry_realizations(kind: str, target: str) -> tuple[WeaknessRealizationSpec, ...]:
+def _telemetry_realizations(
+    kind: str, target: str
+) -> tuple[WeaknessRealizationSpec, ...]:
     return (
         WeaknessRealizationSpec(
             kind="telemetry",
@@ -567,7 +665,9 @@ def _telemetry_realizations(kind: str, target: str) -> tuple[WeaknessRealization
     )
 
 
-def _workflow_remediation_command(kind: str, realizations: tuple[WeaknessRealizationSpec, ...]) -> str:
+def _workflow_remediation_command(
+    kind: str, realizations: tuple[WeaknessRealizationSpec, ...]
+) -> str:
     payload = _workflow_remediation_payload(kind)
     commands = [
         _write_text_command(realization.path, payload)
@@ -576,32 +676,46 @@ def _workflow_remediation_command(kind: str, realizations: tuple[WeaknessRealiza
     ]
     for realization in realizations:
         if realization.kind == "mailbox":
-            commands.append(_write_text_command(realization.path, _mailbox_remediated_message(kind)))
+            commands.append(
+                _write_text_command(realization.path, _mailbox_remediated_message(kind))
+            )
     commands.append("touch /tmp/openrange-patched")
     return "\n".join(commands)
 
 
-def _secret_exposure_remediation_command(kind: str, realizations: tuple[WeaknessRealizationSpec, ...]) -> str:
+def _secret_exposure_remediation_command(
+    kind: str, realizations: tuple[WeaknessRealizationSpec, ...]
+) -> str:
     commands = []
     for realization in realizations:
         if realization.kind == "mailbox":
-            commands.append(_write_text_command(realization.path, _mailbox_remediated_message(kind)))
+            commands.append(
+                _write_text_command(realization.path, _mailbox_remediated_message(kind))
+            )
         else:
             commands.append(_write_text_command(realization.path, "access revoked\n"))
     commands.append("touch /tmp/openrange-patched")
     return "\n".join(commands)
 
 
-def _config_identity_remediation_command(kind: str, realizations: tuple[WeaknessRealizationSpec, ...]) -> str:
+def _config_identity_remediation_command(
+    kind: str, realizations: tuple[WeaknessRealizationSpec, ...]
+) -> str:
     payload = _config_identity_remediation_payload(kind)
-    commands = [_write_text_command(realization.path, payload) for realization in realizations]
+    commands = [
+        _write_text_command(realization.path, payload) for realization in realizations
+    ]
     commands.append("touch /tmp/openrange-patched")
     return "\n".join(commands)
 
 
-def _telemetry_remediation_command(kind: str, realizations: tuple[WeaknessRealizationSpec, ...]) -> str:
+def _telemetry_remediation_command(
+    kind: str, realizations: tuple[WeaknessRealizationSpec, ...]
+) -> str:
     payload = _telemetry_remediation_payload(kind)
-    commands = [_write_text_command(realization.path, payload) for realization in realizations]
+    commands = [
+        _write_text_command(realization.path, payload) for realization in realizations
+    ]
     commands.append("touch /tmp/openrange-patched")
     return "\n".join(commands)
 
@@ -656,21 +770,49 @@ def _mailbox_for_ref(world: WorldIR, target_ref: str) -> str:
     user = next((item for item in world.users if item.id == target_ref), None)
     if user is not None and user.email:
         return user.email
-    credential = next((item for item in world.credentials if item.id == target_ref or item.subject == target_ref), None)
+    credential = next(
+        (
+            item
+            for item in world.credentials
+            if item.id == target_ref or item.subject == target_ref
+        ),
+        None,
+    )
     if credential is not None:
-        subject = next((item for item in world.users if item.id == credential.subject), None)
+        subject = next(
+            (item for item in world.users if item.id == credential.subject), None
+        )
         if subject is not None and subject.email:
             return subject.email
-    workflow = next((item for item in world.workflows if item.id == target_ref or item.name == target_ref), None)
+    workflow = next(
+        (
+            item
+            for item in world.workflows
+            if item.id == target_ref or item.name == target_ref
+        ),
+        None,
+    )
     if workflow is not None:
         for step in workflow.steps:
-            subject = next((item for item in world.users if item.role == step.actor_role and item.email), None)
+            subject = next(
+                (
+                    item
+                    for item in world.users
+                    if item.role == step.actor_role and item.email
+                ),
+                None,
+            )
             if subject is not None:
                 return subject.email
-    fallback = next((item.email for item in world.users if item.email and item.role != "it_admin"), "")
+    fallback = next(
+        (item.email for item in world.users if item.email and item.role != "it_admin"),
+        "",
+    )
     if fallback:
         return fallback
-    return next((item.email for item in world.users if item.email), "openrange@corp.local")
+    return next(
+        (item.email for item in world.users if item.email), "openrange@corp.local"
+    )
 
 
 def _mailbox_slug(mailbox: str) -> str:

--- a/src/open_range/world_ir.py
+++ b/src/open_range/world_ir.py
@@ -8,7 +8,13 @@ from typing import Literal
 
 from pydantic import BaseModel, ConfigDict, Field
 
-from open_range.manifest import CodeFlawKind, NoiseDensity, PinnedWeaknessSpec, WeaknessFamily, WeaknessTargetKind
+from open_range.manifest import (
+    CodeFlawKind,
+    NoiseDensity,
+    PinnedWeaknessSpec,
+    WeaknessFamily,
+    WeaknessTargetKind,
+)
 from open_range.objectives import StandardAttackObjective
 
 
@@ -21,7 +27,9 @@ EdgeKind = Literal["network", "trust", "data", "workflow", "telemetry"]
 ExposureKind = Literal["public", "corp", "data", "management", "sandbox"]
 WeaknessStatus = Literal["seeded", "mitigated", "disabled"]
 ObjectiveOwner = Literal["red", "blue"]
-WeaknessRealizationKind = Literal["code", "config", "seed_data", "workflow", "mailbox", "telemetry"]
+WeaknessRealizationKind = Literal[
+    "code", "config", "seed_data", "workflow", "mailbox", "telemetry"
+]
 WeaknessRemediationKind = Literal["shell", "manual"]
 WeaknessInstantiationMode = Literal["exact_code", "exact_config", "exact_workflow"]
 

--- a/tests/support.py
+++ b/tests/support.py
@@ -4,6 +4,8 @@ from copy import deepcopy
 
 from open_range.build_config import OFFLINE_BUILD_CONFIG, OFFLINE_REFERENCE_BUILD_CONFIG
 
+__all__ = ["OFFLINE_BUILD_CONFIG", "OFFLINE_REFERENCE_BUILD_CONFIG", "manifest_payload"]
+
 
 _BASE_MANIFEST_PAYLOAD = {
     "version": 1,

--- a/tests/test_build_pipeline.py
+++ b/tests/test_build_pipeline.py
@@ -12,7 +12,9 @@ def _manifest_payload() -> dict:
 
 def test_pipeline_builds_and_admits_snapshot(tmp_path: Path):
     pipeline = BuildPipeline()
-    candidate = pipeline.build(_manifest_payload(), tmp_path / "rendered", OFFLINE_BUILD_CONFIG)
+    candidate = pipeline.build(
+        _manifest_payload(), tmp_path / "rendered", OFFLINE_BUILD_CONFIG
+    )
     snapshot = pipeline.admit(candidate)
 
     assert candidate.world.weaknesses

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -16,7 +16,9 @@ def _manifest_payload() -> dict:
 
 def _write_manifest(tmp_path: Path) -> Path:
     manifest_path = tmp_path / "manifest.yaml"
-    manifest_path.write_text(yaml.safe_dump(_manifest_payload(), sort_keys=False), encoding="utf-8")
+    manifest_path.write_text(
+        yaml.safe_dump(_manifest_payload(), sort_keys=False), encoding="utf-8"
+    )
     return manifest_path
 
 
@@ -24,7 +26,9 @@ def test_build_command_writes_candidate_world(tmp_path: Path):
     manifest_path = _write_manifest(tmp_path)
     output_dir = tmp_path / "rendered"
 
-    result = CliRunner().invoke(cli, ["build", "--manifest", str(manifest_path), "--output", str(output_dir)])
+    result = CliRunner().invoke(
+        cli, ["build", "--manifest", str(manifest_path), "--output", str(output_dir)]
+    )
 
     assert result.exit_code == 0, result.output
     world_path = output_dir / "candidate-world.json"
@@ -59,7 +63,9 @@ def test_admit_command_persists_snapshot(tmp_path: Path):
     assert result.exit_code == 0, result.output
     snapshot_dirs = [path for path in store_dir.iterdir() if path.is_dir()]
     assert len(snapshot_dirs) == 1
-    metadata = json.loads((snapshot_dirs[0] / "metadata.json").read_text(encoding="utf-8"))
+    metadata = json.loads(
+        (snapshot_dirs[0] / "metadata.json").read_text(encoding="utf-8")
+    )
     assert metadata["split"] == "eval"
     assert "Admitted snapshot written to" in result.output
 

--- a/tests/test_compiler.py
+++ b/tests/test_compiler.py
@@ -25,7 +25,14 @@ def test_compiler_builds_hand_checkable_world_ir():
     world = EnterpriseSaaSManifestCompiler().compile(_manifest_payload())
 
     assert world.world_id == "enterprise_saas_v1-1337"
-    assert world.allowed_service_kinds == ("web_app", "email", "idp", "fileshare", "db", "siem")
+    assert world.allowed_service_kinds == (
+        "web_app",
+        "email",
+        "idp",
+        "fileshare",
+        "db",
+        "siem",
+    )
     assert world.allowed_weakness_families == (
         "config_identity",
         "workflow_abuse",
@@ -58,7 +65,10 @@ def test_compiler_builds_hand_checkable_world_ir():
     }
     assert world.red_objectives[0].objective_tags == ("file_access",)
     assert world.red_objectives[1].objective_tags == ("privilege_escalation",)
-    assert any(edge.kind == "telemetry" and edge.target == "svc-siem" for edge in world.telemetry_edges)
+    assert any(
+        edge.kind == "telemetry" and edge.target == "svc-siem"
+        for edge in world.telemetry_edges
+    )
 
 
 def test_compiler_creates_role_groups_and_identity_credentials():
@@ -71,13 +81,19 @@ def test_compiler_creates_role_groups_and_identity_credentials():
         "group-it_admin",
     }
     assert len(world.credentials) == len(world.users)
-    assert all(cred.secret_ref.startswith("secret://idp/") for cred in world.credentials)
+    assert all(
+        cred.secret_ref.startswith("secret://idp/") for cred in world.credentials
+    )
 
 
 def test_compiler_threads_pinned_weaknesses_into_world():
     payload = _manifest_payload()
     payload["security"]["pinned_weaknesses"] = [
-        {"family": "secret_exposure", "kind": "credential_in_share", "target": "asset:finance_docs"},
+        {
+            "family": "secret_exposure",
+            "kind": "credential_in_share",
+            "target": "asset:finance_docs",
+        },
     ]
 
     world = EnterpriseSaaSManifestCompiler().compile(payload)

--- a/tests/test_configs.py
+++ b/tests/test_configs.py
@@ -10,7 +10,7 @@ from open_range.episode_config import EpisodeConfig
 from open_range.manifest import validate_manifest
 from open_range.pipeline import BuildPipeline
 from open_range.store import FileSnapshotStore
-from tests.support import OFFLINE_BUILD_CONFIG, manifest_payload
+from tests.support import manifest_payload
 
 
 def _manifest_payload() -> dict:
@@ -46,7 +46,14 @@ def test_build_config_threads_through_build_and_admission(tmp_path: Path):
     runtime_snapshot = hydrate_runtime_snapshot(store, snapshot)
 
     assert candidate.build_config == build_config
-    assert candidate.world.allowed_service_kinds == ("web_app", "email", "idp", "fileshare", "db", "siem")
+    assert candidate.world.allowed_service_kinds == (
+        "web_app",
+        "email",
+        "idp",
+        "fileshare",
+        "db",
+        "siem",
+    )
     assert len(candidate.world.workflows) == 1
     assert len(candidate.world.users) == 4
     assert all(weak.family == "code_web" for weak in candidate.world.weaknesses)
@@ -54,18 +61,24 @@ def test_build_config_threads_through_build_and_admission(tmp_path: Path):
     assert 1 <= len(runtime_snapshot.reference_bundle.reference_defense_traces) <= 2
 
 
-def test_build_config_can_filter_services_without_touching_manifest_schema(tmp_path: Path):
+def test_build_config_can_filter_services_without_touching_manifest_schema(
+    tmp_path: Path,
+):
     pipeline = BuildPipeline(store=FileSnapshotStore(tmp_path / "snapshots"))
     candidate = pipeline.build(
         _manifest_payload(),
         tmp_path / "rendered-filtered",
-        BuildConfig(services_enabled=("web_app", "idp", "siem"), validation_profile="graph_only"),
+        BuildConfig(
+            services_enabled=("web_app", "idp", "siem"), validation_profile="graph_only"
+        ),
     )
 
     assert candidate.world.allowed_service_kinds == ("web_app", "idp", "siem")
 
 
-def test_manifest_accepts_standard_attack_objectives_and_rejects_unknown_predicates() -> None:
+def test_manifest_accepts_standard_attack_objectives_and_rejects_unknown_predicates() -> (
+    None
+):
     payload = _manifest_payload()
     payload["objectives"]["red"] = [
         {"predicate": "db_access(payroll_db)"},
@@ -74,7 +87,9 @@ def test_manifest_accepts_standard_attack_objectives_and_rejects_unknown_predica
     manifest = validate_manifest(payload)
 
     assert manifest.objectives.red[0].predicate == "db_access(payroll_db)"
-    assert manifest.objectives.red[1].predicate == "privilege_escalation(idp_admin_cred)"
+    assert (
+        manifest.objectives.red[1].predicate == "privilege_escalation(idp_admin_cred)"
+    )
 
     payload["objectives"]["red"] = [{"predicate": "made_up_objective(finance_docs)"}]
     with pytest.raises(Exception) as exc:

--- a/tests/test_curriculum.py
+++ b/tests/test_curriculum.py
@@ -4,7 +4,11 @@ from pathlib import Path
 
 from open_range._runtime_store import load_world_ir
 from open_range.compiler import EnterpriseSaaSManifestCompiler
-from open_range.curriculum import FrontierMutationPolicy, PopulationStats, propose_mutations
+from open_range.curriculum import (
+    FrontierMutationPolicy,
+    PopulationStats,
+    propose_mutations,
+)
 from open_range.pipeline import BuildPipeline
 from open_range.store import FileSnapshotStore
 from open_range.weaknesses import CatalogWeaknessSeeder
@@ -89,9 +93,15 @@ def test_policy_mutate_is_deterministic_and_tracks_lineage():
     assert child_a.lineage.parent_world_id == world.world_id
     assert child_a.seed == 2026
     assert len(child_a.hosts) <= len(world.hosts) + world.mutation_bounds.max_new_hosts
-    assert len(child_a.services) <= len(world.services) + world.mutation_bounds.max_new_services
+    assert (
+        len(child_a.services)
+        <= len(world.services) + world.mutation_bounds.max_new_services
+    )
     assert len(child_a.users) <= len(world.users) + world.mutation_bounds.max_new_users
-    assert len(child_a.weaknesses) <= len(world.weaknesses) + world.mutation_bounds.max_new_weaknesses
+    assert (
+        len(child_a.weaknesses)
+        <= len(world.weaknesses) + world.mutation_bounds.max_new_weaknesses
+    )
     assert child_a.lineage.mutation_ops != world.lineage.mutation_ops
     assert all(weak.realization for weak in child_a.weaknesses)
     assert all(weak.remediation_kind == "shell" for weak in child_a.weaknesses)
@@ -101,7 +111,9 @@ def test_policy_mutate_is_deterministic_and_tracks_lineage():
 def test_mutated_child_is_admitted_and_can_live_in_eval_pool(tmp_path: Path):
     store = FileSnapshotStore(tmp_path / "snapshots")
     pipeline = BuildPipeline(store=store)
-    parent_candidate = pipeline.build(_manifest_payload(), tmp_path / "parent-render", OFFLINE_BUILD_CONFIG)
+    parent_candidate = pipeline.build(
+        _manifest_payload(), tmp_path / "parent-render", OFFLINE_BUILD_CONFIG
+    )
     parent_snapshot = pipeline.admit(parent_candidate, split="train")
     parent_world = load_world_ir(store, parent_snapshot.snapshot_id)
 
@@ -121,13 +133,21 @@ def test_mutated_child_is_admitted_and_can_live_in_eval_pool(tmp_path: Path):
         ),
         child_seed=3030,
     )
-    child_snapshot = pipeline.admit_child(child_world, tmp_path / "child-render", split="eval", build_config=OFFLINE_BUILD_CONFIG)
+    child_snapshot = pipeline.admit_child(
+        child_world,
+        tmp_path / "child-render",
+        split="eval",
+        build_config=OFFLINE_BUILD_CONFIG,
+    )
 
     assert child_snapshot.parent_world_id == parent_world.world_id
     assert child_snapshot.validator_report.admitted is True
     assert len(store.list(split="train")) == 1
     assert len(store.list(split="eval")) == 1
-    assert store.sample(split="eval", strategy="latest").snapshot_id == child_snapshot.snapshot_id
+    assert (
+        store.sample(split="eval", strategy="latest").snapshot_id
+        == child_snapshot.snapshot_id
+    )
 
 
 def test_propose_mutations_loads_best_parent_from_store(tmp_path: Path):
@@ -179,7 +199,10 @@ def test_mutation_added_weakness_carries_target_metadata():
         child_seed=4040,
     )
 
-    assert any(weak.target_kind in {"service", "workflow", "asset", "telemetry"} for weak in child.weaknesses)
+    assert any(
+        weak.target_kind in {"service", "workflow", "asset", "telemetry"}
+        for weak in child.weaknesses
+    )
     assert all(weak.target_ref for weak in child.weaknesses)
 
 
@@ -203,7 +226,9 @@ def test_mutation_can_persistently_patch_parent_weakness_and_replace_it():
         child_seed=5050,
     )
 
-    assert any(token.startswith("patch_weakness") for token in child.lineage.mutation_ops)
+    assert any(
+        token.startswith("patch_weakness") for token in child.lineage.mutation_ops
+    )
     assert parent_ids - {weak.id for weak in child.weaknesses}
     assert child.weaknesses
 
@@ -227,6 +252,15 @@ def test_mutation_can_harden_direct_route_and_expose_alternate_one():
         child_seed=6060,
     )
 
-    assert any(token.startswith("harden_route_expose_alternate") for token in child.lineage.mutation_ops)
-    assert not any(edge.source == "svc-web" and edge.target == "svc-fileshare" for edge in child.network_edges)
-    assert any(edge.source == "svc-email" and edge.target.startswith("svc-fileshare") for edge in child.network_edges)
+    assert any(
+        token.startswith("harden_route_expose_alternate")
+        for token in child.lineage.mutation_ops
+    )
+    assert not any(
+        edge.source == "svc-web" and edge.target == "svc-fileshare"
+        for edge in child.network_edges
+    )
+    assert any(
+        edge.source == "svc-email" and edge.target.startswith("svc-fileshare")
+        for edge in child.network_edges
+    )

--- a/tests/test_determinism.py
+++ b/tests/test_determinism.py
@@ -19,18 +19,27 @@ def test_build_pipeline_is_repeatable_for_same_manifest(tmp_path: Path):
 
     assert candidate_a.world == candidate_b.world
     assert candidate_a.artifacts.chart_values == candidate_b.artifacts.chart_values
-    assert candidate_a.artifacts.pinned_image_digests == candidate_b.artifacts.pinned_image_digests
+    assert (
+        candidate_a.artifacts.pinned_image_digests
+        == candidate_b.artifacts.pinned_image_digests
+    )
 
 
 def test_admission_is_repeatable_for_same_world(tmp_path: Path):
     pipeline = BuildPipeline()
-    candidate = pipeline.build(_manifest_payload(), tmp_path / "render", OFFLINE_BUILD_CONFIG)
+    candidate = pipeline.build(
+        _manifest_payload(), tmp_path / "render", OFFLINE_BUILD_CONFIG
+    )
     admission = LocalAdmissionController(mode="fail_fast")
 
-    bundle_a, report_a = admission.admit(candidate.world, candidate.artifacts, OFFLINE_BUILD_CONFIG)
-    bundle_b, report_b = admission.admit(candidate.world, candidate.artifacts, OFFLINE_BUILD_CONFIG)
+    bundle_a, report_a = admission.admit(
+        candidate.world, candidate.artifacts, OFFLINE_BUILD_CONFIG
+    )
+    bundle_b, report_b = admission.admit(
+        candidate.world, candidate.artifacts, OFFLINE_BUILD_CONFIG
+    )
 
     assert bundle_a == bundle_b
-    assert report_a.model_dump(exclude={"build_logs", "health_info"}) == report_b.model_dump(
+    assert report_a.model_dump(
         exclude={"build_logs", "health_info"}
-    )
+    ) == report_b.model_dump(exclude={"build_logs", "health_info"})

--- a/tests/test_driver.py
+++ b/tests/test_driver.py
@@ -21,12 +21,18 @@ def _manifest_payload() -> dict:
 
 
 def _snapshot(tmp_path: Path):
-    world = CatalogWeaknessSeeder().apply(EnterpriseSaaSManifestCompiler().compile(_manifest_payload()))
+    world = CatalogWeaknessSeeder().apply(
+        EnterpriseSaaSManifestCompiler().compile(_manifest_payload())
+    )
     synth = EnterpriseSaaSWorldSynthesizer().synthesize(world, tmp_path / "synth")
     artifacts = EnterpriseSaaSKindRenderer().render(world, synth, tmp_path / "rendered")
-    reference_bundle, report = LocalAdmissionController(mode="fail_fast").admit(world, artifacts, OFFLINE_BUILD_CONFIG)
+    reference_bundle, report = LocalAdmissionController(mode="fail_fast").admit(
+        world, artifacts, OFFLINE_BUILD_CONFIG
+    )
     store = FileSnapshotStore(tmp_path / "snapshots")
-    return hydrate_runtime_snapshot(store, store.create(world, artifacts, reference_bundle, report, synth=synth))
+    return hydrate_runtime_snapshot(
+        store, store.create(world, artifacts, reference_bundle, report, synth=synth)
+    )
 
 
 def test_tandem_driver_runs_joint_pool_episode(tmp_path: Path):
@@ -49,8 +55,18 @@ def test_tandem_driver_runs_joint_pool_episode(tmp_path: Path):
     )
     blue_agent = ScriptedRuntimeAgent(
         [
-            Action(actor_id="blue", role="blue", kind="submit_finding", payload={"event_type": "InitialAccess", "target": red_trace[0].target}),
-            Action(actor_id="blue", role="blue", kind="control", payload={"target": blue_target, "action": "contain"}),
+            Action(
+                actor_id="blue",
+                role="blue",
+                kind="submit_finding",
+                payload={"event_type": "InitialAccess", "target": red_trace[0].target},
+            ),
+            Action(
+                actor_id="blue",
+                role="blue",
+                kind="control",
+                payload={"target": blue_target, "action": "contain"},
+            ),
         ]
     )
 
@@ -73,15 +89,27 @@ def test_driver_can_run_blue_only_prefix_episode(tmp_path: Path):
     driver = TandemEpisodeDriver(runtime)
 
     red_trace = snapshot.reference_bundle.reference_attack_traces[0].steps
-    red_agent = ScriptedRuntimeAgent([Action(actor_id="red", role="red", kind="sleep", payload={})])
+    red_agent = ScriptedRuntimeAgent(
+        [Action(actor_id="red", role="red", kind="sleep", payload={})]
+    )
     blue_agent = ScriptedRuntimeAgent(
         [
-            Action(actor_id="blue", role="blue", kind="submit_finding", payload={"event_type": "InitialAccess", "target": red_trace[0].target}),
+            Action(
+                actor_id="blue",
+                role="blue",
+                kind="submit_finding",
+                payload={"event_type": "InitialAccess", "target": red_trace[0].target},
+            ),
             Action(
                 actor_id="blue",
                 role="blue",
                 kind="control",
-                payload={"target": snapshot.reference_bundle.reference_defense_traces[0].steps[2].target, "action": "contain"},
+                payload={
+                    "target": snapshot.reference_bundle.reference_defense_traces[0]
+                    .steps[2]
+                    .target,
+                    "action": "contain",
+                },
             ),
         ]
     )
@@ -90,7 +118,11 @@ def test_driver_can_run_blue_only_prefix_episode(tmp_path: Path):
         snapshot,
         red_agent=red_agent,
         blue_agent=blue_agent,
-        episode_config=EpisodeConfig(mode="blue_only_from_prefix", start_state="prefix_foothold", green_enabled=False),
+        episode_config=EpisodeConfig(
+            mode="blue_only_from_prefix",
+            start_state="prefix_foothold",
+            green_enabled=False,
+        ),
     )
 
     assert episode.done is True

--- a/tests/test_eval_rollouts.py
+++ b/tests/test_eval_rollouts.py
@@ -19,5 +19,7 @@ def test_evaluate_rollouts_builds_mutations_and_reports_modes() -> None:
 
     assert report["snapshot_count"] == 2
     assert len(report["snapshots"]) == 2
-    assert {"joint_pool", "red_only", "blue_only_live", "blue_only_from_prefix"} <= set(report["aggregate"])
+    assert {"joint_pool", "red_only", "blue_only_live", "blue_only_from_prefix"} <= set(
+        report["aggregate"]
+    )
     assert report["snapshots"][0]["validator"]["admitted"] is True

--- a/tests/test_integration.py
+++ b/tests/test_integration.py
@@ -21,26 +21,36 @@ def _manifest_payload() -> dict:
     return manifest_payload()
 
 
-def _code_web_response(world, cmd: str, patched_services: set[str]) -> ExecResult | None:
-    weakness = next((weak for weak in world.weaknesses if weak.family == "code_web"), None)
+def _code_web_response(
+    world, cmd: str, patched_services: set[str]
+) -> ExecResult | None:
+    weakness = next(
+        (weak for weak in world.weaknesses if weak.family == "code_web"), None
+    )
     if weakness is None or weakness.target in patched_services:
         return None
     payload = code_web_payload(world, weakness)
     path = str(payload.get("path", ""))
     if "http://svc-web:80" not in cmd or path not in cmd:
         return None
-    return ExecResult(stdout=str(payload.get("expect_contains", "")), stderr="", exit_code=0)
+    return ExecResult(
+        stdout=str(payload.get("expect_contains", "")), stderr="", exit_code=0
+    )
 
 
 def test_end_to_end_pipeline_store_reset_and_tandem_episode(tmp_path: Path):
     store = FileSnapshotStore(tmp_path / "snapshots")
     pipeline = BuildPipeline(store=store)
 
-    candidate = pipeline.build(_manifest_payload(), tmp_path / "rendered", OFFLINE_BUILD_CONFIG)
+    candidate = pipeline.build(
+        _manifest_payload(), tmp_path / "rendered", OFFLINE_BUILD_CONFIG
+    )
     snapshot = hydrate_runtime_snapshot(store, pipeline.admit(candidate, split="train"))
 
     runtime_service = OpenRange(store=store)
-    runtime_service.reset(snapshot.snapshot_id, EpisodeConfig(mode="joint_pool", green_enabled=True))
+    runtime_service.reset(
+        snapshot.snapshot_id, EpisodeConfig(mode="joint_pool", green_enabled=True)
+    )
     runtime_service.close()
 
     red_steps = snapshot.reference_bundle.reference_attack_traces[0].steps
@@ -90,7 +100,9 @@ def test_end_to_end_pipeline_store_reset_and_tandem_episode(tmp_path: Path):
     assert score.winner == "blue"
     assert any(turn.role == "red" for turn in episode.turns)
     assert any(turn.role == "blue" for turn in episode.turns)
-    assert any(event.actor == "green" for event in runtime_service.runtime.export_events())
+    assert any(
+        event.actor == "green" for event in runtime_service.runtime.export_events()
+    )
 
 
 def test_live_backend_integration_carries_logs_from_runtime_events(tmp_path: Path):
@@ -112,7 +124,9 @@ def test_live_backend_integration_carries_logs_from_runtime_events(tmp_path: Pat
         async def is_healthy(self, service: str) -> bool:
             return service in self.pod_ids
 
-        async def exec(self, service: str, cmd: str, timeout: float = 30.0) -> ExecResult:
+        async def exec(
+            self, service: str, cmd: str, timeout: float = 30.0
+        ) -> ExecResult:
             del timeout
             if cmd == "touch /tmp/openrange-contained":
                 self.contained.add(service)
@@ -134,13 +148,25 @@ def test_live_backend_integration_carries_logs_from_runtime_events(tmp_path: Pat
                 self.web_guards.discard(service)
                 return ExecResult(stdout="unguarded", stderr="", exit_code=0)
             if cmd == "test ! -f /tmp/openrange-contained":
-                return ExecResult(stdout="", stderr="", exit_code=1 if service in self.contained else 0)
+                return ExecResult(
+                    stdout="",
+                    stderr="",
+                    exit_code=1 if service in self.contained else 0,
+                )
             if cmd == "test ! -f /tmp/openrange-patched":
-                return ExecResult(stdout="", stderr="", exit_code=1 if service in self.patched else 0)
+                return ExecResult(
+                    stdout="", stderr="", exit_code=1 if service in self.patched else 0
+                )
             if "test ! -f /var/www/html/.openrange/guards/" in cmd:
-                return ExecResult(stdout="", stderr="", exit_code=1 if service in self.web_guards else 0)
+                return ExecResult(
+                    stdout="",
+                    stderr="",
+                    exit_code=1 if service in self.web_guards else 0,
+                )
             if ">> /srv/http/siem/all.log" in cmd:
-                line = cmd.split("printf '%s\\n' ", 1)[1].split(" >> /srv/http/siem/all.log", 1)[0]
+                line = cmd.split("printf '%s\\n' ", 1)[1].split(
+                    " >> /srv/http/siem/all.log", 1
+                )[0]
                 self.logs.append(line.strip("'"))
                 return ExecResult(stdout="", stderr="", exit_code=0)
             if "grep -q 'InitialAccess' /srv/http/siem/all.log" in cmd:
@@ -150,9 +176,14 @@ def test_live_backend_integration_carries_logs_from_runtime_events(tmp_path: Pat
                 seeded = _code_web_response(self.world, cmd, self.web_guards)
                 if seeded is not None:
                     return seeded
-            if service == "sandbox-red" and any(target in cmd for target in ("svc-fileshare", "svc-db", "svc-idp")):
+            if service == "sandbox-red" and any(
+                target in cmd for target in ("svc-fileshare", "svc-db", "svc-idp")
+            ):
                 return ExecResult(stdout="", stderr="blocked", exit_code=1)
-            if service.startswith("sandbox-") and "wget -qO- http://svc-siem:9200/all.log" in cmd:
+            if (
+                service.startswith("sandbox-")
+                and "wget -qO- http://svc-siem:9200/all.log" in cmd
+            ):
                 return ExecResult(stdout="\n".join(self.logs), stderr="", exit_code=0)
             return ExecResult(stdout=f"{service}:{cmd}", stderr="", exit_code=0)
 
@@ -167,10 +198,14 @@ def test_live_backend_integration_carries_logs_from_runtime_events(tmp_path: Pat
             pod_ids["sandbox-red"] = "ns/sandbox-red-pod"
             pod_ids["sandbox-blue"] = "ns/sandbox-blue-pod"
             for persona in world.green_personas:
-                pod_ids[f"sandbox-green-{persona.id.replace('_', '-').lower()}"] = f"ns/{persona.id}-pod"
+                pod_ids[f"sandbox-green-{persona.id.replace('_', '-').lower()}"] = (
+                    f"ns/{persona.id}-pod"
+                )
             pods = FakePods(world, pod_ids)
             pod_registry[snapshot_id] = pods
-            return SimpleNamespace(release_name=f"or-{snapshot_id}", artifacts_dir=artifacts_dir, pods=pods)
+            return SimpleNamespace(
+                release_name=f"or-{snapshot_id}", artifacts_dir=artifacts_dir, pods=pods
+            )
 
         def teardown(self, release) -> None:
             teardowns.append(release.release_name)
@@ -178,19 +213,30 @@ def test_live_backend_integration_carries_logs_from_runtime_events(tmp_path: Pat
     backend = FakeBackend()
     admission = LocalAdmissionController(mode="fail_fast", live_backend=backend)
     pipeline = BuildPipeline(store=store, admission=admission)
-    candidate = pipeline.build(_manifest_payload(), tmp_path / "rendered", BuildConfig(validation_profile="full"))
+    candidate = pipeline.build(
+        _manifest_payload(),
+        tmp_path / "rendered",
+        BuildConfig(validation_profile="full"),
+    )
     built_world = candidate.world
     snapshot = hydrate_runtime_snapshot(store, pipeline.admit(candidate, split="train"))
 
     service = OpenRange(store=store, live_backend=backend)
-    service.reset(snapshot.snapshot_id, EpisodeConfig(mode="joint_pool", green_enabled=False))
+    service.reset(
+        snapshot.snapshot_id, EpisodeConfig(mode="joint_pool", green_enabled=False)
+    )
 
     red_first = snapshot.reference_bundle.reference_attack_traces[0].steps[0]
     decision = service.next_decision()
     assert decision.actor == "red"
     service.act(
         "red",
-        Action(actor_id="red", role="red", kind=red_first.kind, payload={"target": red_first.target, **red_first.payload}),
+        Action(
+            actor_id="red",
+            role="red",
+            kind=red_first.kind,
+            payload={"target": red_first.target, **red_first.payload},
+        ),
     )
 
     live_pods = pod_registry[snapshot.snapshot_id]
@@ -201,18 +247,24 @@ def test_live_backend_integration_carries_logs_from_runtime_events(tmp_path: Pat
     assert teardowns
 
 
-def test_green_reactive_branches_flow_through_runtime_between_external_decisions(tmp_path: Path):
+def test_green_reactive_branches_flow_through_runtime_between_external_decisions(
+    tmp_path: Path,
+):
     store = FileSnapshotStore(tmp_path / "snapshots")
     pipeline = BuildPipeline(store=store)
     snapshot = hydrate_runtime_snapshot(
         store,
         pipeline.admit(
-            pipeline.build(_manifest_payload(), tmp_path / "rendered", OFFLINE_BUILD_CONFIG),
+            pipeline.build(
+                _manifest_payload(), tmp_path / "rendered", OFFLINE_BUILD_CONFIG
+            ),
             split="train",
-        )
+        ),
     )
     service = OpenRange(store=store)
-    service.reset(snapshot.snapshot_id, EpisodeConfig(mode="joint_pool", green_enabled=True))
+    service.reset(
+        snapshot.snapshot_id, EpisodeConfig(mode="joint_pool", green_enabled=True)
+    )
 
     red_steps = snapshot.reference_bundle.reference_attack_traces[0].steps
     credential_index = next(
@@ -226,11 +278,18 @@ def test_green_reactive_branches_flow_through_runtime_between_external_decisions
         assert decision.actor == "red"
         service.act(
             "red",
-            Action(actor_id="red", role="red", kind=step.kind, payload={"target": step.target, **step.payload}),
+            Action(
+                actor_id="red",
+                role="red",
+                kind=step.kind,
+                payload={"target": step.target, **step.payload},
+            ),
         )
         decision = service.next_decision()
         assert decision.actor == "blue"
-        service.act("blue", Action(actor_id="blue", role="blue", kind="sleep", payload={}))
+        service.act(
+            "blue", Action(actor_id="blue", role="blue", kind="sleep", payload={})
+        )
 
     decision = service.next_decision()
     assert decision.actor == "red"
@@ -249,10 +308,18 @@ def test_green_reactive_branches_flow_through_runtime_between_external_decisions
         ):
             break
         decision = service.next_decision()
-        service.act(decision.actor, Action(actor_id=decision.actor, role=decision.actor, kind="sleep", payload={}))
+        service.act(
+            decision.actor,
+            Action(
+                actor_id=decision.actor, role=decision.actor, kind="sleep", payload={}
+            ),
+        )
 
     events = service.runtime.export_events()
-    assert any(event.actor == "green" and event.event_type == "DetectionAlertRaised" for event in events)
+    assert any(
+        event.actor == "green" and event.event_type == "DetectionAlertRaised"
+        for event in events
+    )
     assert any(
         event.actor == "green"
         and event.event_type == "RecoveryCompleted"

--- a/tests/test_model_rollouts.py
+++ b/tests/test_model_rollouts.py
@@ -43,19 +43,30 @@ def _snapshot(tmp_path: Path):
         "max_new_weaknesses": 1,
         "allow_patch_old_weaknesses": True,
     }
-    world = CatalogWeaknessSeeder().apply(EnterpriseSaaSManifestCompiler().compile(manifest))
+    world = CatalogWeaknessSeeder().apply(
+        EnterpriseSaaSManifestCompiler().compile(manifest)
+    )
     synth = EnterpriseSaaSWorldSynthesizer().synthesize(world, tmp_path / "synth")
     artifacts = EnterpriseSaaSKindRenderer().render(world, synth, tmp_path / "rendered")
-    reference_bundle, report = LocalAdmissionController(mode="fail_fast").admit(world, artifacts, OFFLINE_BUILD_CONFIG)
+    reference_bundle, report = LocalAdmissionController(mode="fail_fast").admit(
+        world, artifacts, OFFLINE_BUILD_CONFIG
+    )
     store = FileSnapshotStore(tmp_path / "snapshots")
-    return hydrate_runtime_snapshot(store, store.create(world, artifacts, reference_bundle, report, synth=synth))
+    return hydrate_runtime_snapshot(
+        store, store.create(world, artifacts, reference_bundle, report, synth=synth)
+    )
 
 
 def test_model_rollout_helpers_build_prompt_and_candidates(tmp_path: Path) -> None:
     mod = _load_module("eval_model_rollouts", "scripts/eval_model_rollouts.py")
     snapshot = _snapshot(tmp_path)
     runtime = mod.ReferenceDrivenRuntime()
-    runtime.reset(snapshot, mod.EpisodeConfig(mode="red_only", scheduler_mode="strict_turns", opponent_blue="scripted"))
+    runtime.reset(
+        snapshot,
+        mod.EpisodeConfig(
+            mode="red_only", scheduler_mode="strict_turns", opponent_blue="scripted"
+        ),
+    )
     decision = runtime.next_decision()
 
     candidates = mod.red_candidates(runtime, snapshot, decision.obs)

--- a/tests/test_objectives.py
+++ b/tests/test_objectives.py
@@ -22,13 +22,19 @@ def test_predicate_engine_builds_service_native_graders_for_red_objectives() -> 
     world = EnterpriseSaaSManifestCompiler().compile(_manifest_payload())
     predicates = PredicateEngine(world)
 
-    graders = {objective.predicate: predicates.objective_grader(objective.predicate) for objective in world.red_objectives}
+    graders = {
+        objective.predicate: predicates.objective_grader(objective.predicate)
+        for objective in world.red_objectives
+    }
 
     assert graders["asset_read(finance_docs)"] is not None
     assert graders["asset_read(finance_docs)"].grader_kind == "file_exists"
     assert graders["credential_obtained(idp_admin_cred)"] is not None
     assert graders["credential_obtained(idp_admin_cred)"].grader_kind == "event_present"
-    assert graders["credential_obtained(idp_admin_cred)"].objective_tag == "privilege_escalation"
+    assert (
+        graders["credential_obtained(idp_admin_cred)"].objective_tag
+        == "privilege_escalation"
+    )
 
 
 def test_live_event_backed_admin_grader_still_requires_the_event() -> None:
@@ -40,7 +46,9 @@ def test_live_event_backed_admin_grader_still_requires_the_event() -> None:
             "target": "service:svc-idp",
         }
     ]
-    world = CatalogWeaknessSeeder().apply(EnterpriseSaaSManifestCompiler().compile(payload))
+    world = CatalogWeaknessSeeder().apply(
+        EnterpriseSaaSManifestCompiler().compile(payload)
+    )
     predicates = PredicateEngine(world)
     grader = predicates.objective_grader("unauthorized_admin_login(svc-idp)")
     assert grader is not None
@@ -48,35 +56,45 @@ def test_live_event_backed_admin_grader_still_requires_the_event() -> None:
     class _Pods:
         async def exec(self, service: str, cmd: str, timeout: float = 10.0):
             del service, cmd, timeout
-            return SimpleNamespace(ok=True, stdout="target_ref=svc-idp\nadmin_surface_public=true\n", stderr="")
+            return SimpleNamespace(
+                ok=True,
+                stdout="target_ref=svc-idp\nadmin_surface_public=true\n",
+                stderr="",
+            )
 
     snapshot = SimpleNamespace(world=world, file_assets={}, db_seed_state={})
 
-    assert evaluate_objective_grader_live(
-        "unauthorized_admin_login(svc-idp)",
-        grader,
-        snapshot=snapshot,
-        pods=_Pods(),
-        events=(),
-        service_health={"svc-idp": 1.0},
-        outputs=("admin_surface public",),
-    ) is False
+    assert (
+        evaluate_objective_grader_live(
+            "unauthorized_admin_login(svc-idp)",
+            grader,
+            snapshot=snapshot,
+            pods=_Pods(),
+            events=(),
+            service_health={"svc-idp": 1.0},
+            outputs=("admin_surface public",),
+        )
+        is False
+    )
 
-    assert evaluate_objective_grader_live(
-        "unauthorized_admin_login(svc-idp)",
-        grader,
-        snapshot=snapshot,
-        pods=_Pods(),
-        events=(
-            SimpleNamespace(
-                event_type="UnauthorizedCredentialUse",
-                target_entity="svc-idp",
-                linked_objective_predicates=("unauthorized_admin_login(svc-idp)",),
+    assert (
+        evaluate_objective_grader_live(
+            "unauthorized_admin_login(svc-idp)",
+            grader,
+            snapshot=snapshot,
+            pods=_Pods(),
+            events=(
+                SimpleNamespace(
+                    event_type="UnauthorizedCredentialUse",
+                    target_entity="svc-idp",
+                    linked_objective_predicates=("unauthorized_admin_login(svc-idp)",),
+                ),
             ),
-        ),
-        service_health={"svc-idp": 1.0},
-        outputs=("admin_surface public",),
-    ) is True
+            service_health={"svc-idp": 1.0},
+            outputs=("admin_surface public",),
+        )
+        is True
+    )
 
 
 def test_live_admin_grader_requires_probe_when_realized_effect_exists() -> None:
@@ -88,7 +106,9 @@ def test_live_admin_grader_requires_probe_when_realized_effect_exists() -> None:
             "target": "service:svc-idp",
         }
     ]
-    world = CatalogWeaknessSeeder().apply(EnterpriseSaaSManifestCompiler().compile(payload))
+    world = CatalogWeaknessSeeder().apply(
+        EnterpriseSaaSManifestCompiler().compile(payload)
+    )
     predicates = PredicateEngine(world)
     grader = predicates.objective_grader("unauthorized_admin_login(svc-idp)")
     assert grader is not None
@@ -99,21 +119,24 @@ def test_live_admin_grader_requires_probe_when_realized_effect_exists() -> None:
             return SimpleNamespace(ok=False, stdout="", stderr="miss")
 
     snapshot = SimpleNamespace(world=world, file_assets={}, db_seed_state={})
-    assert evaluate_objective_grader_live(
-        "unauthorized_admin_login(svc-idp)",
-        grader,
-        snapshot=snapshot,
-        pods=_Pods(),
-        events=(
-            SimpleNamespace(
-                event_type="UnauthorizedCredentialUse",
-                target_entity="svc-idp",
-                linked_objective_predicates=("unauthorized_admin_login(svc-idp)",),
+    assert (
+        evaluate_objective_grader_live(
+            "unauthorized_admin_login(svc-idp)",
+            grader,
+            snapshot=snapshot,
+            pods=_Pods(),
+            events=(
+                SimpleNamespace(
+                    event_type="UnauthorizedCredentialUse",
+                    target_entity="svc-idp",
+                    linked_objective_predicates=("unauthorized_admin_login(svc-idp)",),
+                ),
             ),
-        ),
-        service_health={"svc-idp": 1.0},
-        outputs=("admin_surface_public=true",),
-    ) is False
+            service_health={"svc-idp": 1.0},
+            outputs=("admin_surface_public=true",),
+        )
+        is False
+    )
 
 
 def test_live_privilege_grader_probes_realized_config_without_output_tokens() -> None:
@@ -125,7 +148,9 @@ def test_live_privilege_grader_probes_realized_config_without_output_tokens() ->
             "target": "service:svc-idp",
         }
     ]
-    world = CatalogWeaknessSeeder().apply(EnterpriseSaaSManifestCompiler().compile(payload))
+    world = CatalogWeaknessSeeder().apply(
+        EnterpriseSaaSManifestCompiler().compile(payload)
+    )
     predicates = PredicateEngine(world)
     grader = predicates.objective_grader("privilege_escalation(svc-idp)")
     assert grader is not None
@@ -133,27 +158,35 @@ def test_live_privilege_grader_probes_realized_config_without_output_tokens() ->
     class _Pods:
         async def exec(self, service: str, cmd: str, timeout: float = 10.0):
             del timeout
-            if service == "svc-idp" and "service_account_scope" in cmd and "svc-db" in cmd and "svc-idp" in cmd:
+            if (
+                service == "svc-idp"
+                and "service_account_scope" in cmd
+                and "svc-db" in cmd
+                and "svc-idp" in cmd
+            ):
                 return SimpleNamespace(ok=True, stdout="", stderr="")
             return SimpleNamespace(ok=False, stdout="", stderr="miss")
 
     snapshot = SimpleNamespace(world=world, file_assets={}, db_seed_state={})
 
-    assert evaluate_objective_grader_live(
-        "privilege_escalation(svc-idp)",
-        grader,
-        snapshot=snapshot,
-        pods=_Pods(),
-        events=(
-            SimpleNamespace(
-                event_type="PrivilegeEscalation",
-                target_entity="svc-idp",
-                linked_objective_predicates=("privilege_escalation(svc-idp)",),
+    assert (
+        evaluate_objective_grader_live(
+            "privilege_escalation(svc-idp)",
+            grader,
+            snapshot=snapshot,
+            pods=_Pods(),
+            events=(
+                SimpleNamespace(
+                    event_type="PrivilegeEscalation",
+                    target_entity="svc-idp",
+                    linked_objective_predicates=("privilege_escalation(svc-idp)",),
+                ),
             ),
-        ),
-        service_health={"svc-idp": 1.0},
-        outputs=("",),
-    ) is True
+            service_health={"svc-idp": 1.0},
+            outputs=("",),
+        )
+        is True
+    )
 
 
 def test_live_outbound_grader_probes_ssrf_realizations_without_output_tokens() -> None:
@@ -166,7 +199,9 @@ def test_live_outbound_grader_probes_ssrf_realizations_without_output_tokens() -
             "target": "service:svc-web",
         }
     ]
-    world = CatalogWeaknessSeeder().apply(EnterpriseSaaSManifestCompiler().compile(payload))
+    world = CatalogWeaknessSeeder().apply(
+        EnterpriseSaaSManifestCompiler().compile(payload)
+    )
     predicates = PredicateEngine(world)
     grader = predicates.objective_grader("outbound_service(svc-web)")
     assert grader is not None
@@ -174,27 +209,34 @@ def test_live_outbound_grader_probes_ssrf_realizations_without_output_tokens() -
     class _Pods:
         async def exec(self, service: str, cmd: str, timeout: float = 10.0):
             del timeout
-            if service == "svc-siem" and "egress-canary" in cmd and world.weaknesses[0].id in cmd:
+            if (
+                service == "svc-siem"
+                and "egress-canary" in cmd
+                and world.weaknesses[0].id in cmd
+            ):
                 return SimpleNamespace(ok=True, stdout="", stderr="")
             return SimpleNamespace(ok=False, stdout="", stderr="miss")
 
     snapshot = SimpleNamespace(world=world, file_assets={}, db_seed_state={})
 
-    assert evaluate_objective_grader_live(
-        "outbound_service(svc-web)",
-        grader,
-        snapshot=snapshot,
-        pods=_Pods(),
-        events=(
-            SimpleNamespace(
-                event_type="PersistenceEstablished",
-                target_entity="svc-web",
-                linked_objective_predicates=("outbound_service(svc-web)",),
+    assert (
+        evaluate_objective_grader_live(
+            "outbound_service(svc-web)",
+            grader,
+            snapshot=snapshot,
+            pods=_Pods(),
+            events=(
+                SimpleNamespace(
+                    event_type="PersistenceEstablished",
+                    target_entity="svc-web",
+                    linked_objective_predicates=("outbound_service(svc-web)",),
+                ),
             ),
-        ),
-        service_health={"svc-web": 1.0},
-        outputs=("",),
-    ) is True
+            service_health={"svc-web": 1.0},
+            outputs=("",),
+        )
+        is True
+    )
 
 
 def test_live_outbound_grader_requires_probe_when_ssrf_realization_exists() -> None:
@@ -207,7 +249,9 @@ def test_live_outbound_grader_requires_probe_when_ssrf_realization_exists() -> N
             "target": "service:svc-web",
         }
     ]
-    world = CatalogWeaknessSeeder().apply(EnterpriseSaaSManifestCompiler().compile(payload))
+    world = CatalogWeaknessSeeder().apply(
+        EnterpriseSaaSManifestCompiler().compile(payload)
+    )
     predicates = PredicateEngine(world)
     grader = predicates.objective_grader("outbound_service(svc-web)")
     assert grader is not None
@@ -218,18 +262,21 @@ def test_live_outbound_grader_requires_probe_when_ssrf_realization_exists() -> N
             return SimpleNamespace(ok=False, stdout="", stderr="miss")
 
     snapshot = SimpleNamespace(world=world, file_assets={}, db_seed_state={})
-    assert evaluate_objective_grader_live(
-        "outbound_service(svc-web)",
-        grader,
-        snapshot=snapshot,
-        pods=_Pods(),
-        events=(
-            SimpleNamespace(
-                event_type="PersistenceEstablished",
-                target_entity="svc-web",
-                linked_objective_predicates=("outbound_service(svc-web)",),
+    assert (
+        evaluate_objective_grader_live(
+            "outbound_service(svc-web)",
+            grader,
+            snapshot=snapshot,
+            pods=_Pods(),
+            events=(
+                SimpleNamespace(
+                    event_type="PersistenceEstablished",
+                    target_entity="svc-web",
+                    linked_objective_predicates=("outbound_service(svc-web)",),
+                ),
             ),
-        ),
-        service_health={"svc-web": 1.0},
-        outputs=("http://127.0.0.1/internal",),
-    ) is False
+            service_health={"svc-web": 1.0},
+            outputs=("http://127.0.0.1/internal",),
+        )
+        is False
+    )

--- a/tests/test_package_resources.py
+++ b/tests/test_package_resources.py
@@ -22,8 +22,14 @@ def test_bundled_resource_tree_exists():
 
 def test_bundled_schemas_match_checked_in_schemas():
     repo_dir = Path("schemas")
-    for name in ("manifest.schema.json", "validator_report.schema.json", "reference_bundle.schema.json"):
-        assert (bundled_schema_dir() / name).read_text(encoding="utf-8") == (repo_dir / name).read_text(encoding="utf-8")
+    for name in (
+        "manifest.schema.json",
+        "validator_report.schema.json",
+        "reference_bundle.schema.json",
+    ):
+        assert (bundled_schema_dir() / name).read_text(encoding="utf-8") == (
+            repo_dir / name
+        ).read_text(encoding="utf-8")
         assert isinstance(load_bundled_schema(name), dict)
 
 

--- a/tests/test_render_admission.py
+++ b/tests/test_render_admission.py
@@ -13,7 +13,11 @@ from open_range.render import EnterpriseSaaSKindRenderer
 from open_range.store import FileSnapshotStore
 from open_range.synth import EnterpriseSaaSWorldSynthesizer
 from open_range.weaknesses import CatalogWeaknessSeeder
-from tests.support import OFFLINE_BUILD_CONFIG, OFFLINE_REFERENCE_BUILD_CONFIG, manifest_payload
+from tests.support import (
+    OFFLINE_BUILD_CONFIG,
+    OFFLINE_REFERENCE_BUILD_CONFIG,
+    manifest_payload,
+)
 
 
 def _manifest_payload() -> dict:
@@ -34,15 +38,21 @@ def _synth(world, tmp_path: Path):
     return EnterpriseSaaSWorldSynthesizer().synthesize(world, tmp_path / "synth")
 
 
-def _code_web_response(world, cmd: str, patched_services: set[str]) -> ExecResult | None:
-    weakness = next((weak for weak in world.weaknesses if weak.family == "code_web"), None)
+def _code_web_response(
+    world, cmd: str, patched_services: set[str]
+) -> ExecResult | None:
+    weakness = next(
+        (weak for weak in world.weaknesses if weak.family == "code_web"), None
+    )
     if weakness is None or weakness.target in patched_services:
         return None
     payload = code_web_payload(world, weakness)
     path = str(payload.get("path", ""))
     if "http://svc-web:80" not in cmd or path not in cmd:
         return None
-    return ExecResult(stdout=str(payload.get("expect_contains", "")), stderr="", exit_code=0)
+    return ExecResult(
+        stdout=str(payload.get("expect_contains", "")), stderr="", exit_code=0
+    )
 
 
 def test_weakness_seeder_is_deterministic():
@@ -51,7 +61,9 @@ def test_weakness_seeder_is_deterministic():
 
     assert world_a.weaknesses == world_b.weaknesses
     assert len(world_a.weaknesses) == 2
-    assert any(weak.objective_tags for weak in world_a.weaknesses if weak.family == "code_web")
+    assert any(
+        weak.objective_tags for weak in world_a.weaknesses if weak.family == "code_web"
+    )
 
 
 def test_weakness_seeder_respects_allowed_families():
@@ -75,33 +87,56 @@ def test_kind_renderer_emits_expected_files(tmp_path: Path):
     assert Path(synth.summary_path).exists()
     assert "svc-web" in artifacts.chart_values["services"]
     assert artifacts.chart_values["services"]["svc-web"]["enabled"] is True
-    assert artifacts.chart_values["services"]["svc-web"]["payloads"][0]["mountPath"] == "/var/www/html/index.html"
-    assert artifacts.chart_values["global"]["namePrefix"].startswith("enterprise-saas-v1-")
+    assert (
+        artifacts.chart_values["services"]["svc-web"]["payloads"][0]["mountPath"]
+        == "/var/www/html/index.html"
+    )
+    assert artifacts.chart_values["global"]["namePrefix"].startswith(
+        "enterprise-saas-v1-"
+    )
     assert "sandbox-red" in artifacts.chart_values["sandboxes"]
-    assert artifacts.chart_values["services"]["svc-db"]["payloads"][0]["mountPath"] == "/docker-entrypoint-initdb.d/01-init.sql"
+    assert (
+        artifacts.chart_values["services"]["svc-db"]["payloads"][0]["mountPath"]
+        == "/docker-entrypoint-initdb.d/01-init.sql"
+    )
     siem_command = artifacts.chart_values["services"]["svc-siem"]["command"][-1]
     assert "busybox nc -lp 9201" in siem_command
     assert "busybox httpd -f -p 9200 -h /srv/http/siem" in siem_command
-    assert any(rule["fromZone"] == "external" and rule["toZone"] == "dmz" for rule in artifacts.chart_values["firewallRules"])
-    assert artifacts.pinned_image_digests["svc-web"].startswith("php:8.1-apache@sha256:")
+    assert any(
+        rule["fromZone"] == "external" and rule["toZone"] == "dmz"
+        for rule in artifacts.chart_values["firewallRules"]
+    )
+    assert artifacts.pinned_image_digests["svc-web"].startswith(
+        "php:8.1-apache@sha256:"
+    )
 
 
 def test_admission_controller_admits_seeded_world(tmp_path: Path):
     world = _build_seeded_world()
-    artifacts = EnterpriseSaaSKindRenderer().render(world, _synth(world, tmp_path), tmp_path / "rendered")
+    artifacts = EnterpriseSaaSKindRenderer().render(
+        world, _synth(world, tmp_path), tmp_path / "rendered"
+    )
 
-    reference_bundle, report = LocalAdmissionController(mode="fail_fast").admit(world, artifacts, OFFLINE_REFERENCE_BUILD_CONFIG)
+    reference_bundle, report = LocalAdmissionController(mode="fail_fast").admit(
+        world, artifacts, OFFLINE_REFERENCE_BUILD_CONFIG
+    )
 
     assert report.admitted is True
     assert report.graph_ok is True
     assert report.reference_attack_ok is True
-    assert report.blue_signal_points == len({edge.source for edge in world.telemetry_edges})
+    assert report.blue_signal_points == len(
+        {edge.source for edge in world.telemetry_edges}
+    )
     assert report.benchmark_tags_covered
     assert report.stages[-1].name == "determinism"
-    objective_grounding = next(stage for stage in report.stages if stage.name == "static").checks[3]
+    objective_grounding = next(
+        stage for stage in report.stages if stage.name == "static"
+    ).checks[3]
     assert objective_grounding.name == "objective_grounding"
     assert objective_grounding.details["graders"]
-    red_reference = next(stage for stage in report.stages if stage.name == "red_reference").checks[0]
+    red_reference = next(
+        stage for stage in report.stages if stage.name == "red_reference"
+    ).checks[0]
     assert sorted(red_reference.details["satisfied_predicates"]) == sorted(
         objective.predicate for objective in world.red_objectives if objective.terminal
     )
@@ -109,21 +144,35 @@ def test_admission_controller_admits_seeded_world(tmp_path: Path):
     assert reference_bundle.reference_defense_traces
 
 
-def test_admission_controller_offline_witness_can_ground_pinned_non_code_weakness(tmp_path: Path):
+def test_admission_controller_offline_witness_can_ground_pinned_non_code_weakness(
+    tmp_path: Path,
+):
     payload = _manifest_payload()
     payload["security"]["allowed_weakness_families"] = ["secret_exposure"]
     payload["security"]["pinned_weaknesses"] = [
-        {"family": "secret_exposure", "kind": "credential_in_share", "target": "asset:idp_admin_cred"},
+        {
+            "family": "secret_exposure",
+            "kind": "credential_in_share",
+            "target": "asset:idp_admin_cred",
+        },
     ]
-    world = CatalogWeaknessSeeder().apply(EnterpriseSaaSManifestCompiler().compile(payload))
-    artifacts = EnterpriseSaaSKindRenderer().render(world, _synth(world, tmp_path), tmp_path / "rendered-non-code")
+    world = CatalogWeaknessSeeder().apply(
+        EnterpriseSaaSManifestCompiler().compile(payload)
+    )
+    artifacts = EnterpriseSaaSKindRenderer().render(
+        world, _synth(world, tmp_path), tmp_path / "rendered-non-code"
+    )
 
-    reference_bundle, report = LocalAdmissionController(mode="fail_fast").admit(world, artifacts, OFFLINE_REFERENCE_BUILD_CONFIG)
+    reference_bundle, report = LocalAdmissionController(mode="fail_fast").admit(
+        world, artifacts, OFFLINE_REFERENCE_BUILD_CONFIG
+    )
 
     assert report.admitted is True
 
 
-def test_mutated_world_blue_reference_skips_blindspot_only_detection_targets(tmp_path: Path) -> None:
+def test_mutated_world_blue_reference_skips_blindspot_only_detection_targets(
+    tmp_path: Path,
+) -> None:
     base_world = _build_seeded_world()
     mutation = FrontierMutationPolicy().mutate(
         base_world,
@@ -141,13 +190,19 @@ def test_mutated_world_blue_reference_skips_blindspot_only_detection_targets(tmp
         ),
         child_seed=1102,
     )
-    artifacts = EnterpriseSaaSKindRenderer().render(mutation, _synth(mutation, tmp_path), tmp_path / "rendered-mutation")
+    artifacts = EnterpriseSaaSKindRenderer().render(
+        mutation, _synth(mutation, tmp_path), tmp_path / "rendered-mutation"
+    )
 
-    reference_bundle, report = LocalAdmissionController(mode="fail_fast").admit(mutation, artifacts, OFFLINE_REFERENCE_BUILD_CONFIG)
+    reference_bundle, report = LocalAdmissionController(mode="fail_fast").admit(
+        mutation, artifacts, OFFLINE_REFERENCE_BUILD_CONFIG
+    )
 
     assert report.admitted is True
     defense_trace = reference_bundle.reference_defense_traces[0]
-    finding_step = next(step for step in defense_trace.steps if step.kind == "submit_finding")
+    finding_step = next(
+        step for step in defense_trace.steps if step.kind == "submit_finding"
+    )
     assert finding_step.target != "svc-email"
     assert report.reference_attack_ok is True
     assert report.necessity_ok is True
@@ -155,7 +210,9 @@ def test_mutated_world_blue_reference_skips_blindspot_only_detection_targets(tmp
 
 def test_admission_controller_can_run_optional_live_backend(tmp_path: Path):
     world = _build_seeded_world()
-    artifacts = EnterpriseSaaSKindRenderer().render(world, _synth(world, tmp_path), tmp_path / "rendered")
+    artifacts = EnterpriseSaaSKindRenderer().render(
+        world, _synth(world, tmp_path), tmp_path / "rendered"
+    )
     calls: list[str] = []
 
     class FakePods:
@@ -169,7 +226,9 @@ def test_admission_controller_can_run_optional_live_backend(tmp_path: Path):
         async def is_healthy(self, service: str) -> bool:
             return service in self.pod_ids
 
-        async def exec(self, service: str, cmd: str, timeout: float = 30.0) -> ExecResult:
+        async def exec(
+            self, service: str, cmd: str, timeout: float = 30.0
+        ) -> ExecResult:
             del timeout
             if cmd == "touch /tmp/openrange-contained":
                 self.contained.add(service)
@@ -191,25 +250,41 @@ def test_admission_controller_can_run_optional_live_backend(tmp_path: Path):
                 self.web_guards.discard(service)
                 return ExecResult(stdout="unguarded", stderr="", exit_code=0)
             if cmd == "test ! -f /tmp/openrange-contained":
-                return ExecResult(stdout="", stderr="", exit_code=1 if service in self.contained else 0)
+                return ExecResult(
+                    stdout="",
+                    stderr="",
+                    exit_code=1 if service in self.contained else 0,
+                )
             if cmd == "test ! -f /tmp/openrange-patched":
-                return ExecResult(stdout="", stderr="", exit_code=1 if service in self.patched else 0)
+                return ExecResult(
+                    stdout="", stderr="", exit_code=1 if service in self.patched else 0
+                )
             if "test ! -f /var/www/html/.openrange/guards/" in cmd:
-                return ExecResult(stdout="", stderr="", exit_code=1 if service in self.web_guards else 0)
+                return ExecResult(
+                    stdout="",
+                    stderr="",
+                    exit_code=1 if service in self.web_guards else 0,
+                )
             if ">> /srv/http/siem/all.log" in cmd:
-                line = cmd.split("printf '%s\\n' ", 1)[1].split(" >> /srv/http/siem/all.log", 1)[0]
+                line = cmd.split("printf '%s\\n' ", 1)[1].split(
+                    " >> /srv/http/siem/all.log", 1
+                )[0]
                 self.logs.append(line.strip("'"))
                 return ExecResult(stdout="", stderr="", exit_code=0)
             if "grep -q 'InitialAccess' /srv/http/siem/all.log" in cmd:
                 present = any("InitialAccess" in line for line in self.logs)
                 return ExecResult(stdout="", stderr="", exit_code=0 if present else 1)
-            if service.startswith("sandbox-") and ("wget -qO- http://svc-siem:9200/all.log" in cmd):
+            if service.startswith("sandbox-") and (
+                "wget -qO- http://svc-siem:9200/all.log" in cmd
+            ):
                 return ExecResult(stdout="\n".join(self.logs), stderr="", exit_code=0)
             if service == "sandbox-red":
                 seeded = _code_web_response(world, cmd, self.web_guards)
                 if seeded is not None:
                     return seeded
-            if service == "sandbox-red" and any(target in cmd for target in ("svc-fileshare", "svc-db", "svc-idp")):
+            if service == "sandbox-red" and any(
+                target in cmd for target in ("svc-fileshare", "svc-db", "svc-idp")
+            ):
                 return ExecResult(stdout="", stderr="blocked", exit_code=1)
             return ExecResult(stdout=f"{service}:{cmd}", stderr="", exit_code=0)
 
@@ -220,7 +295,9 @@ def test_admission_controller_can_run_optional_live_backend(tmp_path: Path):
             pod_ids["sandbox-red"] = "ns/sandbox-red-pod"
             pod_ids["sandbox-blue"] = "ns/sandbox-blue-pod"
             for persona in world.green_personas:
-                pod_ids[f"sandbox-green-{persona.id.replace('_', '-').lower()}"] = f"ns/{persona.id}-pod"
+                pod_ids[f"sandbox-green-{persona.id.replace('_', '-').lower()}"] = (
+                    f"ns/{persona.id}-pod"
+                )
             return SimpleNamespace(
                 release_name=f"or-{snapshot_id}",
                 artifacts_dir=artifacts_dir,
@@ -245,9 +322,13 @@ def test_admission_controller_can_run_optional_live_backend(tmp_path: Path):
 def test_admission_controller_rejects_world_without_telemetry(tmp_path: Path):
     world = _build_seeded_world()
     broken = world.replace_edges(telemetry=())
-    artifacts = EnterpriseSaaSKindRenderer().render(broken, _synth(broken, tmp_path), tmp_path / "rendered")
+    artifacts = EnterpriseSaaSKindRenderer().render(
+        broken, _synth(broken, tmp_path), tmp_path / "rendered"
+    )
 
-    _bundle, report = LocalAdmissionController(mode="analysis").admit(broken, artifacts, OFFLINE_REFERENCE_BUILD_CONFIG)
+    _bundle, report = LocalAdmissionController(mode="analysis").admit(
+        broken, artifacts, OFFLINE_REFERENCE_BUILD_CONFIG
+    )
 
     assert report.admitted is False
     failed = {
@@ -262,14 +343,21 @@ def test_admission_controller_rejects_world_without_telemetry(tmp_path: Path):
 def test_admission_controller_rejects_public_secret_leak_in_artifacts(tmp_path: Path):
     world = _build_seeded_world()
     synth = _synth(world, tmp_path)
-    leak_path = next(file for file in synth.generated_files if "/svc-web/" in file and file.endswith("index.html"))
+    leak_path = next(
+        file
+        for file in synth.generated_files
+        if "/svc-web/" in file and file.endswith("index.html")
+    )
     Path(leak_path).write_text(
-        Path(leak_path).read_text(encoding="utf-8") + "\nseeded-sensitive-idp_admin_cred\n",
+        Path(leak_path).read_text(encoding="utf-8")
+        + "\nseeded-sensitive-idp_admin_cred\n",
         encoding="utf-8",
     )
     artifacts = EnterpriseSaaSKindRenderer().render(world, synth, tmp_path / "rendered")
 
-    _bundle, report = LocalAdmissionController(mode="analysis").admit(world, artifacts, OFFLINE_REFERENCE_BUILD_CONFIG)
+    _bundle, report = LocalAdmissionController(mode="analysis").admit(
+        world, artifacts, OFFLINE_REFERENCE_BUILD_CONFIG
+    )
 
     assert report.admitted is False
     failed = {
@@ -286,13 +374,19 @@ def test_admission_controller_rejects_unlogged_critical_action_targets(tmp_path:
     weakened_services = []
     for service in world.services:
         if service.id == "svc-web":
-            weakened_services.append(service.model_copy(update={"telemetry_surfaces": ()}))
+            weakened_services.append(
+                service.model_copy(update={"telemetry_surfaces": ()})
+            )
         else:
             weakened_services.append(service)
     broken = world.model_copy(update={"services": tuple(weakened_services)})
-    artifacts = EnterpriseSaaSKindRenderer().render(broken, _synth(broken, tmp_path), tmp_path / "rendered")
+    artifacts = EnterpriseSaaSKindRenderer().render(
+        broken, _synth(broken, tmp_path), tmp_path / "rendered"
+    )
 
-    _bundle, report = LocalAdmissionController(mode="analysis").admit(broken, artifacts, OFFLINE_REFERENCE_BUILD_CONFIG)
+    _bundle, report = LocalAdmissionController(mode="analysis").admit(
+        broken, artifacts, OFFLINE_REFERENCE_BUILD_CONFIG
+    )
 
     assert report.admitted is False
     failed = {
@@ -308,7 +402,9 @@ def test_snapshot_store_persists_v1_snapshot(tmp_path: Path):
     world = _build_seeded_world()
     synth = _synth(world, tmp_path)
     artifacts = EnterpriseSaaSKindRenderer().render(world, synth, tmp_path / "rendered")
-    reference_bundle, report = LocalAdmissionController(mode="fail_fast").admit(world, artifacts, OFFLINE_BUILD_CONFIG)
+    reference_bundle, report = LocalAdmissionController(mode="fail_fast").admit(
+        world, artifacts, OFFLINE_BUILD_CONFIG
+    )
     store = FileSnapshotStore(tmp_path / "snapshots")
 
     snapshot = store.create(world, artifacts, reference_bundle, report, synth=synth)

--- a/tests/test_repo_manifests.py
+++ b/tests/test_repo_manifests.py
@@ -28,7 +28,9 @@ def test_checked_in_manifests_validate_and_compile(tmp_path: Path):
 
 
 def test_manifest_registry_points_to_existing_examples():
-    payload = yaml.safe_load(Path("manifests/registry.yaml").read_text(encoding="utf-8"))
+    payload = yaml.safe_load(
+        Path("manifests/registry.yaml").read_text(encoding="utf-8")
+    )
 
     manifests_dir = Path("manifests")
     families = payload["families"]
@@ -39,7 +41,10 @@ def test_manifest_registry_points_to_existing_examples():
 
 
 def test_bundled_manifests_match_repo_examples():
-    repo_manifests = {path.name: path.read_text(encoding="utf-8") for path in Path("manifests").glob("tier*.yaml")}
+    repo_manifests = {
+        path.name: path.read_text(encoding="utf-8")
+        for path in Path("manifests").glob("tier*.yaml")
+    }
 
     assert tuple(sorted(repo_manifests)) == bundled_manifest_names()
     for name, content in repo_manifests.items():
@@ -48,5 +53,7 @@ def test_bundled_manifests_match_repo_examples():
 
 
 def test_bundled_registry_matches_repo_registry():
-    repo_registry = yaml.safe_load(Path("manifests/registry.yaml").read_text(encoding="utf-8"))
+    repo_registry = yaml.safe_load(
+        Path("manifests/registry.yaml").read_text(encoding="utf-8")
+    )
     assert load_bundled_manifest_registry() == repo_registry

--- a/tests/test_rewards.py
+++ b/tests/test_rewards.py
@@ -8,7 +8,9 @@ from open_range.rewards import RewardEngine
 
 def test_red_reward_keeps_tick_cost_and_milestone_bonus():
     engine = RewardEngine()
-    action = Action(actor_id="red", role="red", kind="api", payload={"target": "svc-web"})
+    action = Action(
+        actor_id="red", role="red", kind="api", payload={"target": "svc-web"}
+    )
     event = SimpleNamespace(
         event_type="InitialAccess",
         linked_objective_predicates=(),

--- a/tests/test_runtime.py
+++ b/tests/test_runtime.py
@@ -26,23 +26,35 @@ def _manifest_payload() -> dict:
 
 
 def _snapshot(tmp_path: Path):
-    world = CatalogWeaknessSeeder().apply(EnterpriseSaaSManifestCompiler().compile(_manifest_payload()))
+    world = CatalogWeaknessSeeder().apply(
+        EnterpriseSaaSManifestCompiler().compile(_manifest_payload())
+    )
     synth = EnterpriseSaaSWorldSynthesizer().synthesize(world, tmp_path / "synth")
     artifacts = EnterpriseSaaSKindRenderer().render(world, synth, tmp_path / "rendered")
-    reference_bundle, report = LocalAdmissionController(mode="fail_fast").admit(world, artifacts, OFFLINE_BUILD_CONFIG)
+    reference_bundle, report = LocalAdmissionController(mode="fail_fast").admit(
+        world, artifacts, OFFLINE_BUILD_CONFIG
+    )
     store = FileSnapshotStore(tmp_path / "snapshots")
-    return hydrate_runtime_snapshot(store, store.create(world, artifacts, reference_bundle, report, synth=synth))
+    return hydrate_runtime_snapshot(
+        store, store.create(world, artifacts, reference_bundle, report, synth=synth)
+    )
 
 
-def _code_web_response(snapshot, cmd: str, patched_services: set[str]) -> ExecResult | None:
-    weakness = next((weak for weak in snapshot.world.weaknesses if weak.family == "code_web"), None)
+def _code_web_response(
+    snapshot, cmd: str, patched_services: set[str]
+) -> ExecResult | None:
+    weakness = next(
+        (weak for weak in snapshot.world.weaknesses if weak.family == "code_web"), None
+    )
     if weakness is None or weakness.target in patched_services:
         return None
     payload = code_web_payload(snapshot.world, weakness)
     path = str(payload.get("path", ""))
     if "http://svc-web:80" not in cmd or path not in cmd:
         return None
-    return ExecResult(stdout=str(payload.get("expect_contains", "")), stderr="", exit_code=0)
+    return ExecResult(
+        stdout=str(payload.get("expect_contains", "")), stderr="", exit_code=0
+    )
 
 
 def test_joint_pool_next_decision_returns_actor_specific_observations(tmp_path: Path):
@@ -67,7 +79,12 @@ def test_joint_pool_next_decision_returns_actor_specific_observations(tmp_path: 
 
     runtime.act(
         "red",
-        Action(actor_id="red", role="red", kind=first_red.kind, payload={"target": first_red.target, **first_red.payload}),
+        Action(
+            actor_id="red",
+            role="red",
+            kind=first_red.kind,
+            payload={"target": first_red.target, **first_red.payload},
+        ),
     )
 
     blue_decision = runtime.next_decision()
@@ -75,7 +92,9 @@ def test_joint_pool_next_decision_returns_actor_specific_observations(tmp_path: 
     assert blue_decision.obs.actor_id == "blue"
     assert blue_decision.obs.sim_time >= 0.5
     assert any(event.malicious for event in blue_decision.obs.visible_events)
-    assert any(event.event_type == "InitialAccess" for event in blue_decision.obs.alerts_delta)
+    assert any(
+        event.event_type == "InitialAccess" for event in blue_decision.obs.alerts_delta
+    )
 
 
 def test_runtime_keeps_green_internal_and_never_exposes_green_decisions(tmp_path: Path):
@@ -91,7 +110,12 @@ def test_runtime_keeps_green_internal_and_never_exposes_green_decisions(tmp_path
     assert decision.actor == "red"
     runtime.act(
         "red",
-        Action(actor_id="red", role="red", kind=red_step.kind, payload={"target": red_step.target, **red_step.payload}),
+        Action(
+            actor_id="red",
+            role="red",
+            kind=red_step.kind,
+            payload={"target": red_step.target, **red_step.payload},
+        ),
     )
     decision = runtime.next_decision()
     assert decision.actor == "blue"
@@ -131,10 +155,14 @@ def test_blue_only_from_prefix_starts_blue_after_compromise_prefix(tmp_path: Pat
     assert state.controls_blue is True
     decision = runtime.next_decision()
     assert decision.actor == "blue"
-    assert any(event.event_type == "InitialAccess" for event in decision.obs.visible_events)
+    assert any(
+        event.event_type == "InitialAccess" for event in decision.obs.visible_events
+    )
 
 
-def test_blue_only_from_prefix_delivery_and_click_do_not_collapse_without_matching_reference_steps(tmp_path: Path):
+def test_blue_only_from_prefix_delivery_and_click_do_not_collapse_without_matching_reference_steps(
+    tmp_path: Path,
+):
     snapshot = _snapshot(tmp_path)
 
     delivery_runtime = ReferenceDrivenRuntime()
@@ -148,7 +176,10 @@ def test_blue_only_from_prefix_delivery_and_click_do_not_collapse_without_matchi
     )
     delivery_decision = delivery_runtime.next_decision()
     assert delivery_decision.actor == "blue"
-    assert not any(event.event_type == "InitialAccess" for event in delivery_decision.obs.visible_events)
+    assert not any(
+        event.event_type == "InitialAccess"
+        for event in delivery_decision.obs.visible_events
+    )
 
     click_runtime = ReferenceDrivenRuntime()
     click_runtime.reset(
@@ -161,7 +192,10 @@ def test_blue_only_from_prefix_delivery_and_click_do_not_collapse_without_matchi
     )
     click_decision = click_runtime.next_decision()
     assert click_decision.actor == "blue"
-    assert not any(event.event_type == "InitialAccess" for event in click_decision.obs.visible_events)
+    assert not any(
+        event.event_type == "InitialAccess"
+        for event in click_decision.obs.visible_events
+    )
 
 
 def test_blue_only_live_can_win_by_detect_and_contain(tmp_path: Path):
@@ -183,7 +217,10 @@ def test_blue_only_live_can_win_by_detect_and_contain(tmp_path: Path):
             actor_id="blue",
             role="blue",
             kind=detect_step.kind,
-            payload={"event_type": str(detect_step.payload["event"]), "target": detect_step.target},
+            payload={
+                "event_type": str(detect_step.payload["event"]),
+                "target": detect_step.target,
+            },
         ),
     )
     assert "validated finding" in detect.stdout
@@ -209,11 +246,15 @@ def test_runtime_hard_done_rejects_more_decisions_and_actions(tmp_path: Path):
     runtime = ReferenceDrivenRuntime()
     runtime.reset(
         snapshot,
-        EpisodeConfig(mode="joint_pool", green_enabled=False, episode_horizon_minutes=0.1),
+        EpisodeConfig(
+            mode="joint_pool", green_enabled=False, episode_horizon_minutes=0.1
+        ),
     )
 
     decision = runtime.next_decision()
-    runtime.act(decision.actor, Action(actor_id="red", role="red", kind="sleep", payload={}))
+    runtime.act(
+        decision.actor, Action(actor_id="red", role="red", kind="sleep", payload={})
+    )
 
     with pytest.raises(RuntimeError):
         runtime.next_decision()
@@ -222,8 +263,15 @@ def test_runtime_hard_done_rejects_more_decisions_and_actions(tmp_path: Path):
 
 
 def test_runtime_matching_rejects_extra_api_path_when_reference_has_no_path() -> None:
-    expected = SimpleNamespace(kind="api", target="svc-web", payload={"action": "traverse"})
-    action = Action(actor_id="red", role="red", kind="api", payload={"target": "svc-web", "path": "/"})
+    expected = SimpleNamespace(
+        kind="api", target="svc-web", payload={"action": "traverse"}
+    )
+    action = Action(
+        actor_id="red",
+        role="red",
+        kind="api",
+        payload={"target": "svc-web", "path": "/"},
+    )
 
     assert ReferenceDrivenRuntime._matches_step(action, expected, "ok") is False
 
@@ -237,7 +285,9 @@ def test_runtime_live_containment_blocks_future_red_step(tmp_path: Path):
             self.contained: set[str] = set()
             self.patched: set[str] = set()
 
-        async def exec(self, service: str, cmd: str, timeout: float = 30.0) -> ExecResult:
+        async def exec(
+            self, service: str, cmd: str, timeout: float = 30.0
+        ) -> ExecResult:
             del timeout
             if cmd == "touch /tmp/openrange-contained":
                 self.contained.add(service)
@@ -253,22 +303,34 @@ def test_runtime_live_containment_blocks_future_red_step(tmp_path: Path):
                 self.patched.discard(service)
                 return ExecResult(stdout="recovered", stderr="", exit_code=0)
             if cmd == "test ! -f /tmp/openrange-contained":
-                return ExecResult(stdout="", stderr="", exit_code=1 if service in self.contained else 0)
+                return ExecResult(
+                    stdout="",
+                    stderr="",
+                    exit_code=1 if service in self.contained else 0,
+                )
             if cmd == "test ! -f /tmp/openrange-patched":
-                return ExecResult(stdout="", stderr="", exit_code=1 if service in self.patched else 0)
+                return ExecResult(
+                    stdout="", stderr="", exit_code=1 if service in self.patched else 0
+                )
             return ExecResult(stdout=f"{service}:{cmd}", stderr="", exit_code=0)
 
         async def is_healthy(self, service: str) -> bool:
             return service in self.pod_ids
 
-    pod_ids = {service.id: f"ns/{service.id}-pod" for service in snapshot.world.services}
+    pod_ids = {
+        service.id: f"ns/{service.id}-pod" for service in snapshot.world.services
+    }
     pod_ids["sandbox-red"] = "ns/sandbox-red-pod"
     pod_ids["sandbox-blue"] = "ns/sandbox-blue-pod"
     for persona in snapshot.world.green_personas:
-        pod_ids[f"sandbox-green-{persona.id.replace('_', '-').lower()}"] = f"ns/{persona.id}-pod"
+        pod_ids[f"sandbox-green-{persona.id.replace('_', '-').lower()}"] = (
+            f"ns/{persona.id}-pod"
+        )
 
     backend = PodActionBackend()
-    backend.bind(snapshot, SimpleNamespace(release_name="or-test", pods=FakePods(pod_ids)))
+    backend.bind(
+        snapshot, SimpleNamespace(release_name="or-test", pods=FakePods(pod_ids))
+    )
     runtime = ReferenceDrivenRuntime(action_backend=backend)
     runtime.reset(
         snapshot,
@@ -282,26 +344,43 @@ def test_runtime_live_containment_blocks_future_red_step(tmp_path: Path):
     assert red_decision.actor == "red"
     runtime.act(
         "red",
-        Action(actor_id="red", role="red", kind=first_step.kind, payload={"target": first_step.target, **first_step.payload}),
+        Action(
+            actor_id="red",
+            role="red",
+            kind=first_step.kind,
+            payload={"target": first_step.target, **first_step.payload},
+        ),
     )
 
     blue_decision = runtime.next_decision()
     assert blue_decision.actor == "blue"
     runtime.act(
         "blue",
-        Action(actor_id="blue", role="blue", kind="control", payload={"target": second_step.target, "action": "contain"}),
+        Action(
+            actor_id="blue",
+            role="blue",
+            kind="control",
+            payload={"target": second_step.target, "action": "contain"},
+        ),
     )
 
     red_decision = runtime.next_decision()
     blocked = runtime.act(
         "red",
-        Action(actor_id="red", role="red", kind=second_step.kind, payload={"target": second_step.target}),
+        Action(
+            actor_id="red",
+            role="red",
+            kind=second_step.kind,
+            payload={"target": second_step.target},
+        ),
     )
 
     assert "contained" in blocked.stderr
 
 
-def test_runtime_live_patch_blocks_future_red_step_and_emits_patch_event(tmp_path: Path):
+def test_runtime_live_patch_blocks_future_red_step_and_emits_patch_event(
+    tmp_path: Path,
+):
     snapshot = _snapshot(tmp_path)
 
     class FakePods:
@@ -310,7 +389,9 @@ def test_runtime_live_patch_blocks_future_red_step_and_emits_patch_event(tmp_pat
             self.contained: set[str] = set()
             self.patched: set[str] = set()
 
-        async def exec(self, service: str, cmd: str, timeout: float = 30.0) -> ExecResult:
+        async def exec(
+            self, service: str, cmd: str, timeout: float = 30.0
+        ) -> ExecResult:
             del timeout
             if cmd == "touch /tmp/openrange-contained":
                 self.contained.add(service)
@@ -323,22 +404,34 @@ def test_runtime_live_patch_blocks_future_red_step_and_emits_patch_event(tmp_pat
                 self.patched.discard(service)
                 return ExecResult(stdout="recovered", stderr="", exit_code=0)
             if cmd == "test ! -f /tmp/openrange-contained":
-                return ExecResult(stdout="", stderr="", exit_code=1 if service in self.contained else 0)
+                return ExecResult(
+                    stdout="",
+                    stderr="",
+                    exit_code=1 if service in self.contained else 0,
+                )
             if cmd == "test ! -f /tmp/openrange-patched":
-                return ExecResult(stdout="", stderr="", exit_code=1 if service in self.patched else 0)
+                return ExecResult(
+                    stdout="", stderr="", exit_code=1 if service in self.patched else 0
+                )
             return ExecResult(stdout=f"{service}:{cmd}", stderr="", exit_code=0)
 
         async def is_healthy(self, service: str) -> bool:
             return service in self.pod_ids
 
-    pod_ids = {service.id: f"ns/{service.id}-pod" for service in snapshot.world.services}
+    pod_ids = {
+        service.id: f"ns/{service.id}-pod" for service in snapshot.world.services
+    }
     pod_ids["sandbox-red"] = "ns/sandbox-red-pod"
     pod_ids["sandbox-blue"] = "ns/sandbox-blue-pod"
     for persona in snapshot.world.green_personas:
-        pod_ids[f"sandbox-green-{persona.id.replace('_', '-').lower()}"] = f"ns/{persona.id}-pod"
+        pod_ids[f"sandbox-green-{persona.id.replace('_', '-').lower()}"] = (
+            f"ns/{persona.id}-pod"
+        )
 
     backend = PodActionBackend()
-    backend.bind(snapshot, SimpleNamespace(release_name="or-test", pods=FakePods(pod_ids)))
+    backend.bind(
+        snapshot, SimpleNamespace(release_name="or-test", pods=FakePods(pod_ids))
+    )
     runtime = ReferenceDrivenRuntime(action_backend=backend)
     runtime.reset(
         snapshot,
@@ -351,14 +444,24 @@ def test_runtime_live_patch_blocks_future_red_step_and_emits_patch_event(tmp_pat
     assert runtime.next_decision().actor == "red"
     runtime.act(
         "red",
-        Action(actor_id="red", role="red", kind=first_step.kind, payload={"target": first_step.target, **first_step.payload}),
+        Action(
+            actor_id="red",
+            role="red",
+            kind=first_step.kind,
+            payload={"target": first_step.target, **first_step.payload},
+        ),
     )
 
     patch_decision = runtime.next_decision()
     assert patch_decision.actor == "blue"
     patched = runtime.act(
         "blue",
-        Action(actor_id="blue", role="blue", kind="control", payload={"target": second_step.target, "action": "patch"}),
+        Action(
+            actor_id="blue",
+            role="blue",
+            kind="control",
+            payload={"target": second_step.target, "action": "patch"},
+        ),
     )
 
     assert "patch applied" in patched.stdout
@@ -367,7 +470,12 @@ def test_runtime_live_patch_blocks_future_red_step_and_emits_patch_event(tmp_pat
     assert runtime.next_decision().actor == "red"
     blocked = runtime.act(
         "red",
-        Action(actor_id="red", role="red", kind=second_step.kind, payload={"target": second_step.target}),
+        Action(
+            actor_id="red",
+            role="red",
+            kind=second_step.kind,
+            payload={"target": second_step.target},
+        ),
     )
 
     assert "patched" in blocked.stderr
@@ -383,7 +491,9 @@ def test_runtime_live_patch_can_disable_exact_web_handler(tmp_path: Path):
             self.patched: set[str] = set()
             self.web_guards: set[str] = set()
 
-        async def exec(self, service: str, cmd: str, timeout: float = 30.0) -> ExecResult:
+        async def exec(
+            self, service: str, cmd: str, timeout: float = 30.0
+        ) -> ExecResult:
             del timeout
             if cmd == "touch /tmp/openrange-contained":
                 self.contained.add(service)
@@ -402,11 +512,21 @@ def test_runtime_live_patch_can_disable_exact_web_handler(tmp_path: Path):
                 self.web_guards.discard(service)
                 return ExecResult(stdout="unguarded", stderr="", exit_code=0)
             if cmd == "test ! -f /tmp/openrange-contained":
-                return ExecResult(stdout="", stderr="", exit_code=1 if service in self.contained else 0)
+                return ExecResult(
+                    stdout="",
+                    stderr="",
+                    exit_code=1 if service in self.contained else 0,
+                )
             if cmd == "test ! -f /tmp/openrange-patched":
-                return ExecResult(stdout="", stderr="", exit_code=1 if service in self.patched else 0)
+                return ExecResult(
+                    stdout="", stderr="", exit_code=1 if service in self.patched else 0
+                )
             if "test ! -f /var/www/html/.openrange/guards/" in cmd:
-                return ExecResult(stdout="", stderr="", exit_code=1 if service in self.web_guards else 0)
+                return ExecResult(
+                    stdout="",
+                    stderr="",
+                    exit_code=1 if service in self.web_guards else 0,
+                )
             if service == "sandbox-red":
                 seeded = _code_web_response(snapshot, cmd, self.web_guards)
                 if seeded is not None:
@@ -416,14 +536,20 @@ def test_runtime_live_patch_can_disable_exact_web_handler(tmp_path: Path):
         async def is_healthy(self, service: str) -> bool:
             return service in self.pod_ids
 
-    pod_ids = {service.id: f"ns/{service.id}-pod" for service in snapshot.world.services}
+    pod_ids = {
+        service.id: f"ns/{service.id}-pod" for service in snapshot.world.services
+    }
     pod_ids["sandbox-red"] = "ns/sandbox-red-pod"
     pod_ids["sandbox-blue"] = "ns/sandbox-blue-pod"
     for persona in snapshot.world.green_personas:
-        pod_ids[f"sandbox-green-{persona.id.replace('_', '-').lower()}"] = f"ns/{persona.id}-pod"
+        pod_ids[f"sandbox-green-{persona.id.replace('_', '-').lower()}"] = (
+            f"ns/{persona.id}-pod"
+        )
 
     backend = PodActionBackend()
-    backend.bind(snapshot, SimpleNamespace(release_name="or-test", pods=FakePods(pod_ids)))
+    backend.bind(
+        snapshot, SimpleNamespace(release_name="or-test", pods=FakePods(pod_ids))
+    )
     runtime = ReferenceDrivenRuntime(action_backend=backend)
     runtime.reset(
         snapshot,
@@ -441,7 +567,12 @@ def test_runtime_live_patch_can_disable_exact_web_handler(tmp_path: Path):
     assert runtime.next_decision().actor == "blue"
     patched = runtime.act(
         "blue",
-        Action(actor_id="blue", role="blue", kind="control", payload={"target": first_step.target, "action": "patch"}),
+        Action(
+            actor_id="blue",
+            role="blue",
+            kind="control",
+            payload={"target": first_step.target, "action": "patch"},
+        ),
     )
     assert "patch applied" in patched.stdout
 
@@ -473,13 +604,23 @@ def test_runtime_accepts_mitigate_as_patch_alias(tmp_path: Path):
     assert runtime.next_decision().actor == "red"
     runtime.act(
         "red",
-        Action(actor_id="red", role="red", kind=first_step.kind, payload={"target": first_step.target, **first_step.payload}),
+        Action(
+            actor_id="red",
+            role="red",
+            kind=first_step.kind,
+            payload={"target": first_step.target, **first_step.payload},
+        ),
     )
 
     assert runtime.next_decision().actor == "blue"
     mitigated = runtime.act(
         "blue",
-        Action(actor_id="blue", role="blue", kind="control", payload={"target": second_step.target, "action": "mitigate"}),
+        Action(
+            actor_id="blue",
+            role="blue",
+            kind="control",
+            payload={"target": second_step.target, "action": "mitigate"},
+        ),
     )
 
     assert "mitigation applied" in mitigated.stdout
@@ -504,7 +645,12 @@ def test_internal_blue_controller_modes_are_not_aliases(tmp_path: Path):
     assert reference_runtime.next_decision().actor == "red"
     reference_runtime.act(
         "red",
-        Action(actor_id="red", role="red", kind=first_step.kind, payload={"target": first_step.target, **first_step.payload}),
+        Action(
+            actor_id="red",
+            role="red",
+            kind=first_step.kind,
+            payload={"target": first_step.target, **first_step.payload},
+        ),
     )
     reference_action = reference_runtime._internal_blue_action()
     assert reference_action.kind == "shell"
@@ -524,7 +670,12 @@ def test_internal_blue_controller_modes_are_not_aliases(tmp_path: Path):
     assert scripted_runtime.next_decision().actor == "red"
     scripted_runtime.act(
         "red",
-        Action(actor_id="red", role="red", kind=first_step.kind, payload={"target": first_step.target, **first_step.payload}),
+        Action(
+            actor_id="red",
+            role="red",
+            kind=first_step.kind,
+            payload={"target": first_step.target, **first_step.payload},
+        ),
     )
     scripted_action = scripted_runtime._internal_blue_action()
     assert scripted_action.kind == "submit_finding"
@@ -568,12 +719,21 @@ def test_green_branch_backends_are_not_aliases(tmp_path: Path):
     assert scripted_runtime.next_decision().actor == "red"
     scripted_runtime.act(
         "red",
-        Action(actor_id="red", role="red", kind=first_step.kind, payload={"target": first_step.target, **first_step.payload}),
+        Action(
+            actor_id="red",
+            role="red",
+            kind=first_step.kind,
+            payload={"target": first_step.target, **first_step.payload},
+        ),
     )
     assert scripted_runtime.next_decision().actor == "blue"
-    scripted_runtime.act("blue", Action(actor_id="blue", role="blue", kind="sleep", payload={}))
+    scripted_runtime.act(
+        "blue", Action(actor_id="blue", role="blue", kind="sleep", payload={})
+    )
     assert scripted_runtime.next_decision().actor == "red"
-    scripted_green_events = [event for event in scripted_runtime.export_events() if event.actor == "green"]
+    scripted_green_events = [
+        event for event in scripted_runtime.export_events() if event.actor == "green"
+    ]
 
     orchestrated_runtime = ReferenceDrivenRuntime()
     orchestrated_runtime.reset(
@@ -588,12 +748,25 @@ def test_green_branch_backends_are_not_aliases(tmp_path: Path):
     assert orchestrated_runtime.next_decision().actor == "red"
     orchestrated_runtime.act(
         "red",
-        Action(actor_id="red", role="red", kind=first_step.kind, payload={"target": first_step.target, **first_step.payload}),
+        Action(
+            actor_id="red",
+            role="red",
+            kind=first_step.kind,
+            payload={"target": first_step.target, **first_step.payload},
+        ),
     )
     assert orchestrated_runtime.next_decision().actor == "blue"
-    orchestrated_runtime.act("blue", Action(actor_id="blue", role="blue", kind="sleep", payload={}))
+    orchestrated_runtime.act(
+        "blue", Action(actor_id="blue", role="blue", kind="sleep", payload={})
+    )
     assert orchestrated_runtime.next_decision().actor == "red"
-    orchestrated_green_events = [event for event in orchestrated_runtime.export_events() if event.actor == "green"]
+    orchestrated_green_events = [
+        event
+        for event in orchestrated_runtime.export_events()
+        if event.actor == "green"
+    ]
 
     assert len(orchestrated_green_events) > len(scripted_green_events)
-    assert any(event.event_type == "RecoveryCompleted" for event in orchestrated_green_events)
+    assert any(
+        event.event_type == "RecoveryCompleted" for event in orchestrated_green_events
+    )

--- a/tests/test_schemas.py
+++ b/tests/test_schemas.py
@@ -70,8 +70,16 @@ def test_manifest_rejects_unknown_fields():
 def test_manifest_accepts_pinned_weaknesses():
     payload = _manifest_payload()
     payload["security"]["pinned_weaknesses"] = [
-        {"family": "secret_exposure", "kind": "credential_in_share", "target": "asset:finance_docs"},
-        {"family": "workflow_abuse", "kind": "helpdesk_reset_bypass", "target": "workflow:helpdesk_ticketing"},
+        {
+            "family": "secret_exposure",
+            "kind": "credential_in_share",
+            "target": "asset:finance_docs",
+        },
+        {
+            "family": "workflow_abuse",
+            "kind": "helpdesk_reset_bypass",
+            "target": "workflow:helpdesk_ticketing",
+        },
     ]
 
     manifest = validate_manifest(payload)
@@ -82,13 +90,19 @@ def test_manifest_accepts_pinned_weaknesses():
         "auth_bypass",
     )
     assert manifest.security.pinned_weaknesses[0].kind == "credential_in_share"
-    assert manifest.security.pinned_weaknesses[1].target == "workflow:helpdesk_ticketing"
+    assert (
+        manifest.security.pinned_weaknesses[1].target == "workflow:helpdesk_ticketing"
+    )
 
 
 def test_manifest_rejects_pinned_kind_from_wrong_family():
     payload = _manifest_payload()
     payload["security"]["pinned_weaknesses"] = [
-        {"family": "secret_exposure", "kind": "sql_injection", "target": "asset:finance_docs"},
+        {
+            "family": "secret_exposure",
+            "kind": "sql_injection",
+            "target": "asset:finance_docs",
+        },
     ]
 
     try:
@@ -96,7 +110,9 @@ def test_manifest_rejects_pinned_kind_from_wrong_family():
     except Exception as exc:  # noqa: BLE001
         assert "unsupported kind" in str(exc)
     else:
-        raise AssertionError("manifest unexpectedly accepted mismatched pinned weakness kind")
+        raise AssertionError(
+            "manifest unexpectedly accepted mismatched pinned weakness kind"
+        )
 
 
 def test_world_ir_serializes_minimal_core_objects():
@@ -121,11 +137,23 @@ def test_world_ir_serializes_minimal_core_objects():
         workflows=(),
         edges=(),
         weaknesses=(),
-        red_objectives=(ObjectiveSpec(id="o-red", owner="red", predicate="asset_read(finance_docs)"),),
-        blue_objectives=(ObjectiveSpec(id="o-blue", owner="blue", predicate="intrusion_detected(initial_access)"),),
+        red_objectives=(
+            ObjectiveSpec(
+                id="o-red", owner="red", predicate="asset_read(finance_docs)"
+            ),
+        ),
+        blue_objectives=(
+            ObjectiveSpec(
+                id="o-blue",
+                owner="blue",
+                predicate="intrusion_detected(initial_access)",
+            ),
+        ),
         green_personas=(),
         green_workload=GreenWorkloadSpec(noise_density="medium"),
-        mutation_bounds=MutationBoundsSpec(max_new_hosts=1, max_new_services=1, max_new_users=1, max_new_weaknesses=1),
+        mutation_bounds=MutationBoundsSpec(
+            max_new_hosts=1, max_new_services=1, max_new_users=1, max_new_weaknesses=1
+        ),
         lineage=LineageSpec(seed=1337),
     )
 
@@ -172,9 +200,15 @@ def test_validator_report_and_reference_bundle_round_trip():
 
 def test_generated_schema_files_exist_and_match_titles():
     root = Path(__file__).resolve().parent.parent
-    manifest_schema = json.loads((root / "schemas" / "manifest.schema.json").read_text(encoding="utf-8"))
-    report_schema = json.loads((root / "schemas" / "validator_report.schema.json").read_text(encoding="utf-8"))
-    bundle_schema = json.loads((root / "schemas" / "reference_bundle.schema.json").read_text(encoding="utf-8"))
+    manifest_schema = json.loads(
+        (root / "schemas" / "manifest.schema.json").read_text(encoding="utf-8")
+    )
+    report_schema = json.loads(
+        (root / "schemas" / "validator_report.schema.json").read_text(encoding="utf-8")
+    )
+    bundle_schema = json.loads(
+        (root / "schemas" / "reference_bundle.schema.json").read_text(encoding="utf-8")
+    )
 
     assert manifest_schema["title"] == "EnterpriseSaaSManifest"
     assert report_schema["title"] == "ValidatorReport"

--- a/tests/test_service.py
+++ b/tests/test_service.py
@@ -23,9 +23,11 @@ def _service_and_snapshots(tmp_path: Path):
     train_snapshot = hydrate_runtime_snapshot(
         store,
         pipeline.admit(
-            pipeline.build(_manifest_payload(), tmp_path / "train-render", OFFLINE_BUILD_CONFIG),
+            pipeline.build(
+                _manifest_payload(), tmp_path / "train-render", OFFLINE_BUILD_CONFIG
+            ),
             split="train",
-        )
+        ),
     )
 
     eval_payload = _manifest_payload()
@@ -33,9 +35,11 @@ def _service_and_snapshots(tmp_path: Path):
     eval_snapshot = hydrate_runtime_snapshot(
         store,
         pipeline.admit(
-            pipeline.build(eval_payload, tmp_path / "eval-render", OFFLINE_BUILD_CONFIG),
+            pipeline.build(
+                eval_payload, tmp_path / "eval-render", OFFLINE_BUILD_CONFIG
+            ),
             split="eval",
-        )
+        ),
     )
     return OpenRange(store=store), train_snapshot, eval_snapshot
 
@@ -43,7 +47,10 @@ def _service_and_snapshots(tmp_path: Path):
 def test_service_reset_loads_snapshot_and_primes_first_decision(tmp_path: Path):
     service, train_snapshot, _eval_snapshot = _service_and_snapshots(tmp_path)
 
-    state = service.reset(train_snapshot.snapshot_id, EpisodeConfig(mode="joint_pool", green_enabled=False))
+    state = service.reset(
+        train_snapshot.snapshot_id,
+        EpisodeConfig(mode="joint_pool", green_enabled=False),
+    )
 
     assert state.snapshot_id == train_snapshot.snapshot_id
     assert service.active_snapshot_id == train_snapshot.snapshot_id
@@ -69,13 +76,21 @@ def test_service_can_sample_held_out_eval_pool(tmp_path: Path):
 
 def test_service_proxies_runtime_decisions_and_actions(tmp_path: Path):
     service, train_snapshot, _eval_snapshot = _service_and_snapshots(tmp_path)
-    service.reset(train_snapshot.snapshot_id, EpisodeConfig(mode="joint_pool", green_enabled=False))
+    service.reset(
+        train_snapshot.snapshot_id,
+        EpisodeConfig(mode="joint_pool", green_enabled=False),
+    )
 
     decision = service.next_decision()
     red_step = train_snapshot.reference_bundle.reference_attack_traces[0].steps[0]
     result = service.act(
         "red",
-        Action(actor_id="red", role="red", kind=red_step.kind, payload={"target": red_step.target, **red_step.payload}),
+        Action(
+            actor_id="red",
+            role="red",
+            kind=red_step.kind,
+            payload={"target": red_step.target, **red_step.payload},
+        ),
     )
 
     assert decision.actor == "red"
@@ -90,9 +105,11 @@ def test_service_boots_and_tears_down_live_release(tmp_path: Path):
     snapshot = hydrate_runtime_snapshot(
         store,
         pipeline.admit(
-            pipeline.build(_manifest_payload(), tmp_path / "rendered", OFFLINE_BUILD_CONFIG),
+            pipeline.build(
+                _manifest_payload(), tmp_path / "rendered", OFFLINE_BUILD_CONFIG
+            ),
             split="train",
-        )
+        ),
     )
     calls: list[str] = []
 
@@ -103,25 +120,36 @@ def test_service_boots_and_tears_down_live_release(tmp_path: Path):
         async def is_healthy(self, service: str) -> bool:
             return service in self.pod_ids
 
-        async def exec(self, service: str, cmd: str, timeout: float = 30.0) -> ExecResult:
+        async def exec(
+            self, service: str, cmd: str, timeout: float = 30.0
+        ) -> ExecResult:
             del timeout
             return ExecResult(stdout=f"{service}:{cmd}", stderr="", exit_code=0)
 
     class FakeBackend:
         def boot(self, *, snapshot_id: str, artifacts_dir: Path):
             calls.append(f"boot:{snapshot_id}:{artifacts_dir.name}")
-            pod_ids = {service.id: f"ns/{service.id}-pod" for service in snapshot.world.services}
+            pod_ids = {
+                service.id: f"ns/{service.id}-pod"
+                for service in snapshot.world.services
+            }
             pod_ids["sandbox-red"] = "ns/sandbox-red-pod"
             pod_ids["sandbox-blue"] = "ns/sandbox-blue-pod"
             for persona in snapshot.world.green_personas:
-                pod_ids[f"sandbox-green-{persona.id.replace('_', '-').lower()}"] = f"ns/{persona.id}-pod"
-            return SimpleNamespace(release_name=f"or-{snapshot_id}", pods=FakePods(pod_ids))
+                pod_ids[f"sandbox-green-{persona.id.replace('_', '-').lower()}"] = (
+                    f"ns/{persona.id}-pod"
+                )
+            return SimpleNamespace(
+                release_name=f"or-{snapshot_id}", pods=FakePods(pod_ids)
+            )
 
         def teardown(self, release) -> None:
             calls.append(f"down:{release.release_name}")
 
     service = OpenRange(store=store, live_backend=FakeBackend())
-    service.reset(snapshot.snapshot_id, EpisodeConfig(mode="joint_pool", green_enabled=False))
+    service.reset(
+        snapshot.snapshot_id, EpisodeConfig(mode="joint_pool", green_enabled=False)
+    )
     assert service.live_release is not None
     service.close()
 

--- a/tests/test_sim.py
+++ b/tests/test_sim.py
@@ -18,12 +18,18 @@ def _manifest_payload() -> dict:
 
 
 def _snapshot(tmp_path: Path):
-    world = CatalogWeaknessSeeder().apply(EnterpriseSaaSManifestCompiler().compile(_manifest_payload()))
+    world = CatalogWeaknessSeeder().apply(
+        EnterpriseSaaSManifestCompiler().compile(_manifest_payload())
+    )
     synth = EnterpriseSaaSWorldSynthesizer().synthesize(world, tmp_path / "synth")
     artifacts = EnterpriseSaaSKindRenderer().render(world, synth, tmp_path / "rendered")
-    reference_bundle, report = LocalAdmissionController(mode="fail_fast").admit(world, artifacts, OFFLINE_BUILD_CONFIG)
+    reference_bundle, report = LocalAdmissionController(mode="fail_fast").admit(
+        world, artifacts, OFFLINE_BUILD_CONFIG
+    )
     store = FileSnapshotStore(tmp_path / "snapshots")
-    return hydrate_runtime_snapshot(store, store.create(world, artifacts, reference_bundle, report, synth=synth))
+    return hydrate_runtime_snapshot(
+        store, store.create(world, artifacts, reference_bundle, report, synth=synth)
+    )
 
 
 def test_reference_sim_plane_generates_deterministic_bootstrap_trace(tmp_path: Path):

--- a/tests/test_synth.py
+++ b/tests/test_synth.py
@@ -22,43 +22,75 @@ def _manifest_payload() -> dict:
 
 
 def test_synthesizer_generates_bounded_seed_artifacts(tmp_path: Path):
-    world = CatalogWeaknessSeeder().apply(EnterpriseSaaSManifestCompiler().compile(_manifest_payload()))
+    world = CatalogWeaknessSeeder().apply(
+        EnterpriseSaaSManifestCompiler().compile(_manifest_payload())
+    )
 
     synth = EnterpriseSaaSWorldSynthesizer().synthesize(world, tmp_path / "synth")
 
     assert Path(synth.summary_path).exists()
     assert "svc-web" in synth.service_payloads
-    assert any(file.mount_path == "/var/www/html/index.html" for file in synth.service_payloads["svc-web"])
-    assert any(file.mount_path == "/docker-entrypoint-initdb.d/01-init.sql" for file in synth.service_payloads["svc-db"])
+    assert any(
+        file.mount_path == "/var/www/html/index.html"
+        for file in synth.service_payloads["svc-web"]
+    )
+    assert any(
+        file.mount_path == "/docker-entrypoint-initdb.d/01-init.sql"
+        for file in synth.service_payloads["svc-db"]
+    )
     assert synth.mailboxes
     realized = [
         file.mount_path
         for files in synth.service_payloads.values()
         for file in files
-        if ".openrange/" in file.mount_path or "/opt/openrange/" in file.mount_path or "openrange/exposed-" in file.mount_path
+        if ".openrange/" in file.mount_path
+        or "/opt/openrange/" in file.mount_path
+        or "openrange/exposed-" in file.mount_path
     ]
     assert realized
 
 
-def test_synthesizer_realizes_pinned_weaknesses_and_can_disable_phishing_surface(tmp_path: Path):
+def test_synthesizer_realizes_pinned_weaknesses_and_can_disable_phishing_surface(
+    tmp_path: Path,
+):
     payload = _manifest_payload()
     payload["security"]["phishing_surface_enabled"] = False
     payload["security"]["pinned_weaknesses"] = [
-        {"family": "secret_exposure", "kind": "credential_in_share", "target": "asset:finance_docs"},
-        {"family": "workflow_abuse", "kind": "helpdesk_reset_bypass", "target": "workflow:helpdesk_ticketing"},
+        {
+            "family": "secret_exposure",
+            "kind": "credential_in_share",
+            "target": "asset:finance_docs",
+        },
+        {
+            "family": "workflow_abuse",
+            "kind": "helpdesk_reset_bypass",
+            "target": "workflow:helpdesk_ticketing",
+        },
     ]
-    world = CatalogWeaknessSeeder().apply(EnterpriseSaaSManifestCompiler().compile(payload))
+    world = CatalogWeaknessSeeder().apply(
+        EnterpriseSaaSManifestCompiler().compile(payload)
+    )
 
     synth = EnterpriseSaaSWorldSynthesizer().synthesize(world, tmp_path / "synth")
 
     fileshare_payloads = synth.service_payloads["svc-fileshare"]
     web_payloads = synth.service_payloads["svc-web"]
-    assert any(file.mount_path.endswith("exposed-finance_docs.txt") for file in fileshare_payloads)
-    assert any(file.mount_path.endswith("helpdesk_reset_bypass.json") for file in web_payloads)
-    assert all("Password reset review" not in "\n".join(messages) for messages in synth.mailboxes.values())
+    assert any(
+        file.mount_path.endswith("exposed-finance_docs.txt")
+        for file in fileshare_payloads
+    )
+    assert any(
+        file.mount_path.endswith("helpdesk_reset_bypass.json") for file in web_payloads
+    )
+    assert all(
+        "Password reset review" not in "\n".join(messages)
+        for messages in synth.mailboxes.values()
+    )
 
 
-def test_synthesizer_realizes_exact_code_web_templates_and_witness_routes(tmp_path: Path):
+def test_synthesizer_realizes_exact_code_web_templates_and_witness_routes(
+    tmp_path: Path,
+):
     expected_routes = {
         "sql_injection": "/var/www/html/search.php",
         "broken_authorization": "/var/www/html/records.php",
@@ -74,12 +106,21 @@ def test_synthesizer_realizes_exact_code_web_templates_and_witness_routes(tmp_pa
         payload["security"]["pinned_weaknesses"] = [
             {"family": "code_web", "kind": kind, "target": "service:web_app"},
         ]
-        world = CatalogWeaknessSeeder().apply(EnterpriseSaaSManifestCompiler().compile(payload))
+        world = CatalogWeaknessSeeder().apply(
+            EnterpriseSaaSManifestCompiler().compile(payload)
+        )
         synth = EnterpriseSaaSWorldSynthesizer().synthesize(world, tmp_path / kind)
         web_payloads = synth.service_payloads["svc-web"]
-        assert any(file.mount_path == route and file.content.startswith("<?php") for file in web_payloads)
-        artifacts = EnterpriseSaaSKindRenderer().render(world, synth, tmp_path / f"{kind}-render")
-        reference_bundle, report = LocalAdmissionController(mode="fail_fast").admit(world, artifacts, OFFLINE_BUILD_CONFIG)
+        assert any(
+            file.mount_path == route and file.content.startswith("<?php")
+            for file in web_payloads
+        )
+        artifacts = EnterpriseSaaSKindRenderer().render(
+            world, synth, tmp_path / f"{kind}-render"
+        )
+        reference_bundle, report = LocalAdmissionController(mode="fail_fast").admit(
+            world, artifacts, OFFLINE_BUILD_CONFIG
+        )
         assert report.admitted is True
         first_step = reference_bundle.reference_attack_traces[0].steps[0]
         assert first_step.payload["path"] == route.removeprefix("/var/www/html")
@@ -87,7 +128,9 @@ def test_synthesizer_realizes_exact_code_web_templates_and_witness_routes(tmp_pa
         if kind in {"auth_bypass", "ssrf", "command_injection"}:
             assert first_step.payload["expect_contains"].startswith("OPENRANGE-EFFECT:")
         else:
-            assert first_step.payload["expect_contains"].startswith("OPENRANGE-FOOTHOLD:")
+            assert first_step.payload["expect_contains"].startswith(
+                "OPENRANGE-FOOTHOLD:"
+            )
         assert not any(
             file.mount_path.startswith("/var/www/html/openrange-foothold-")
             for file in web_payloads
@@ -96,32 +139,157 @@ def test_synthesizer_realizes_exact_code_web_templates_and_witness_routes(tmp_pa
 
 def test_synthesizer_realizes_required_non_code_catalog(tmp_path: Path):
     cases = (
-        ("config_identity", "weak_password", "credential:it_admin-01", "svc-idp", "/etc/openrange/password-policy.json", "min_password_length"),
-        ("config_identity", "default_credential", "service:idp", "svc-idp", "/etc/openrange/default-credential.json", "default_password"),
-        ("config_identity", "overbroad_service_account", "service:idp", "svc-idp", "/etc/openrange/service-account-policy.json", "service_account_scope"),
-        ("config_identity", "admin_surface_exposed", "service:idp", "svc-idp", "/etc/openrange/admin-surface.json", "admin_surface_public"),
-        ("config_identity", "trust_edge_misconfig", "service:idp", "svc-idp", "/etc/openrange/trust-edge.json", "trust_scope"),
-        ("secret_exposure", "env_file_leak", "service:web_app", "svc-web", "/var/www/html/.env", "OPENRANGE_APP_SECRET"),
-        ("secret_exposure", "credential_in_share", "asset:finance_docs", "svc-fileshare", "/srv/shared/.openrange/exposed-finance_docs.txt", "secret_material="),
-        ("secret_exposure", "backup_leak", "asset:payroll_db", "svc-fileshare", "/srv/shared/.openrange/backup-payroll_db.sql", "INSERT INTO leaked_credentials"),
-        ("secret_exposure", "hardcoded_app_secret", "service:web_app", "svc-web", "/var/www/html/.openrange/app-secret.php", "OPENRANGE_APP_SECRET"),
-        ("workflow_abuse", "helpdesk_reset_bypass", "workflow:helpdesk_ticketing", "svc-web", "/var/www/html/.openrange/weaknesses/helpdesk_reset_bypass.json", "identity_verification"),
-        ("workflow_abuse", "approval_chain_bypass", "workflow:payroll_approval", "svc-web", "/var/www/html/.openrange/weaknesses/approval_chain_bypass.json", "secondary_approval_skipped"),
-        ("workflow_abuse", "document_share_abuse", "workflow:document_sharing", "svc-fileshare", "/srv/shared/.openrange/workflows/document_share_abuse.json", "share_visibility"),
-        ("telemetry_blindspot", "missing_web_logs", "service:web_app", "svc-web", "/etc/openrange/missing_web_logs.json", "access_logs_enabled"),
-        ("telemetry_blindspot", "missing_idp_logs", "service:idp", "svc-idp", "/etc/openrange/missing_idp_logs.json", "auth_logs_enabled"),
-        ("telemetry_blindspot", "delayed_siem_ingest", "service:email", "svc-email", "/etc/openrange/delayed_siem_ingest.json", "delay_seconds"),
-        ("telemetry_blindspot", "unmonitored_admin_action", "service:idp", "svc-idp", "/etc/openrange/unmonitored_admin_action.json", "admin_actions_logged"),
-        ("telemetry_blindspot", "silent_mail_rule", "service:email", "svc-email", "/etc/openrange/silent_mail_rule.json", "mail_rule_logging"),
+        (
+            "config_identity",
+            "weak_password",
+            "credential:it_admin-01",
+            "svc-idp",
+            "/etc/openrange/password-policy.json",
+            "min_password_length",
+        ),
+        (
+            "config_identity",
+            "default_credential",
+            "service:idp",
+            "svc-idp",
+            "/etc/openrange/default-credential.json",
+            "default_password",
+        ),
+        (
+            "config_identity",
+            "overbroad_service_account",
+            "service:idp",
+            "svc-idp",
+            "/etc/openrange/service-account-policy.json",
+            "service_account_scope",
+        ),
+        (
+            "config_identity",
+            "admin_surface_exposed",
+            "service:idp",
+            "svc-idp",
+            "/etc/openrange/admin-surface.json",
+            "admin_surface_public",
+        ),
+        (
+            "config_identity",
+            "trust_edge_misconfig",
+            "service:idp",
+            "svc-idp",
+            "/etc/openrange/trust-edge.json",
+            "trust_scope",
+        ),
+        (
+            "secret_exposure",
+            "env_file_leak",
+            "service:web_app",
+            "svc-web",
+            "/var/www/html/.env",
+            "OPENRANGE_APP_SECRET",
+        ),
+        (
+            "secret_exposure",
+            "credential_in_share",
+            "asset:finance_docs",
+            "svc-fileshare",
+            "/srv/shared/.openrange/exposed-finance_docs.txt",
+            "secret_material=",
+        ),
+        (
+            "secret_exposure",
+            "backup_leak",
+            "asset:payroll_db",
+            "svc-fileshare",
+            "/srv/shared/.openrange/backup-payroll_db.sql",
+            "INSERT INTO leaked_credentials",
+        ),
+        (
+            "secret_exposure",
+            "hardcoded_app_secret",
+            "service:web_app",
+            "svc-web",
+            "/var/www/html/.openrange/app-secret.php",
+            "OPENRANGE_APP_SECRET",
+        ),
+        (
+            "workflow_abuse",
+            "helpdesk_reset_bypass",
+            "workflow:helpdesk_ticketing",
+            "svc-web",
+            "/var/www/html/.openrange/weaknesses/helpdesk_reset_bypass.json",
+            "identity_verification",
+        ),
+        (
+            "workflow_abuse",
+            "approval_chain_bypass",
+            "workflow:payroll_approval",
+            "svc-web",
+            "/var/www/html/.openrange/weaknesses/approval_chain_bypass.json",
+            "secondary_approval_skipped",
+        ),
+        (
+            "workflow_abuse",
+            "document_share_abuse",
+            "workflow:document_sharing",
+            "svc-fileshare",
+            "/srv/shared/.openrange/workflows/document_share_abuse.json",
+            "share_visibility",
+        ),
+        (
+            "telemetry_blindspot",
+            "missing_web_logs",
+            "service:web_app",
+            "svc-web",
+            "/etc/openrange/missing_web_logs.json",
+            "access_logs_enabled",
+        ),
+        (
+            "telemetry_blindspot",
+            "missing_idp_logs",
+            "service:idp",
+            "svc-idp",
+            "/etc/openrange/missing_idp_logs.json",
+            "auth_logs_enabled",
+        ),
+        (
+            "telemetry_blindspot",
+            "delayed_siem_ingest",
+            "service:email",
+            "svc-email",
+            "/etc/openrange/delayed_siem_ingest.json",
+            "delay_seconds",
+        ),
+        (
+            "telemetry_blindspot",
+            "unmonitored_admin_action",
+            "service:idp",
+            "svc-idp",
+            "/etc/openrange/unmonitored_admin_action.json",
+            "admin_actions_logged",
+        ),
+        (
+            "telemetry_blindspot",
+            "silent_mail_rule",
+            "service:email",
+            "svc-email",
+            "/etc/openrange/silent_mail_rule.json",
+            "mail_rule_logging",
+        ),
     )
 
     for family, kind, target, service_id, mount_path, snippet in cases:
         payload = _manifest_payload()
-        payload["security"]["pinned_weaknesses"] = [{"family": family, "kind": kind, "target": target}]
-        world = CatalogWeaknessSeeder().apply(EnterpriseSaaSManifestCompiler().compile(payload))
+        payload["security"]["pinned_weaknesses"] = [
+            {"family": family, "kind": kind, "target": target}
+        ]
+        world = CatalogWeaknessSeeder().apply(
+            EnterpriseSaaSManifestCompiler().compile(payload)
+        )
         synth = EnterpriseSaaSWorldSynthesizer().synthesize(world, tmp_path / kind)
         service_payloads = synth.service_payloads[service_id]
-        file = next((item for item in service_payloads if item.mount_path == mount_path), None)
+        file = next(
+            (item for item in service_payloads if item.mount_path == mount_path), None
+        )
         assert file is not None, f"missing realization for {family}:{kind}"
         assert snippet in file.content
         assert world.weaknesses[0].kind == kind
@@ -130,16 +298,37 @@ def test_synthesizer_realizes_required_non_code_catalog(tmp_path: Path):
 
 def test_synthesizer_seeds_mailbox_realizations_for_email_borne_kinds(tmp_path: Path):
     cases = (
-        ("secret_exposure", "token_in_email", "asset:idp_admin_cred", "token-idp_admin_cred.eml"),
-        ("workflow_abuse", "phishing_credential_capture", "workflow:internal_email", "phishing_credential_capture.eml"),
-        ("workflow_abuse", "internal_request_impersonation", "workflow:internal_email", "internal_request_impersonation.eml"),
+        (
+            "secret_exposure",
+            "token_in_email",
+            "asset:idp_admin_cred",
+            "token-idp_admin_cred.eml",
+        ),
+        (
+            "workflow_abuse",
+            "phishing_credential_capture",
+            "workflow:internal_email",
+            "phishing_credential_capture.eml",
+        ),
+        (
+            "workflow_abuse",
+            "internal_request_impersonation",
+            "workflow:internal_email",
+            "internal_request_impersonation.eml",
+        ),
     )
 
     for family, kind, target, suffix in cases:
         payload = _manifest_payload()
-        payload["security"]["pinned_weaknesses"] = [{"family": family, "kind": kind, "target": target}]
-        world = CatalogWeaknessSeeder().apply(EnterpriseSaaSManifestCompiler().compile(payload))
-        synth = EnterpriseSaaSWorldSynthesizer().synthesize(world, tmp_path / f"mail-{kind}")
+        payload["security"]["pinned_weaknesses"] = [
+            {"family": family, "kind": kind, "target": target}
+        ]
+        world = CatalogWeaknessSeeder().apply(
+            EnterpriseSaaSManifestCompiler().compile(payload)
+        )
+        synth = EnterpriseSaaSWorldSynthesizer().synthesize(
+            world, tmp_path / f"mail-{kind}"
+        )
         email_payloads = synth.service_payloads["svc-email"]
         assert any(file.mount_path.endswith(suffix) for file in email_payloads)
         assert any(kind in "\n".join(messages) for messages in synth.mailboxes.values())

--- a/tests/test_tracegen.py
+++ b/tests/test_tracegen.py
@@ -8,7 +8,11 @@ from open_range.tracegen import generate_trace_dataset
 
 
 def _read_jsonl(path: Path) -> list[dict]:
-    return [json.loads(line) for line in path.read_text(encoding="utf-8").splitlines() if line.strip()]
+    return [
+        json.loads(line)
+        for line in path.read_text(encoding="utf-8").splitlines()
+        if line.strip()
+    ]
 
 
 def test_generate_trace_dataset_writes_raw_and_decision_views(tmp_path: Path) -> None:
@@ -29,10 +33,18 @@ def test_generate_trace_dataset_writes_raw_and_decision_views(tmp_path: Path) ->
     assert len(sft_rows) == report.rows
     assert {"runtime", "sim"} <= {row["trace_source"] for row in raw_rows}
     assert {"red", "blue"} <= {row["role"] for row in raw_rows}
-    assert {"red_only", "blue_only_live", "blue_only_from_prefix", "joint_pool"} <= {row["mode"] for row in raw_rows}
-    assert all("candidate_actions" in row and row["candidate_actions"] for row in raw_rows)
-    assert all("grounded_effects" in row and "mitigation_effects" in row for row in raw_rows)
-    assert all("service_command" not in row["chosen_action"]["payload"] for row in raw_rows)
+    assert {"red_only", "blue_only_live", "blue_only_from_prefix", "joint_pool"} <= {
+        row["mode"] for row in raw_rows
+    }
+    assert all(
+        "candidate_actions" in row and row["candidate_actions"] for row in raw_rows
+    )
+    assert all(
+        "grounded_effects" in row and "mitigation_effects" in row for row in raw_rows
+    )
+    assert all(
+        "service_command" not in row["chosen_action"]["payload"] for row in raw_rows
+    )
     assert all(len(entry["messages"]) == 3 for entry in sft_rows)
     assert all(entry["lineage_root_world_id"] for entry in sft_rows)
     assert all(entry["split"] in {"train", "val", "test"} for entry in sft_rows)
@@ -44,7 +56,9 @@ def test_generate_trace_dataset_writes_raw_and_decision_views(tmp_path: Path) ->
     assert Path(report.shard_paths["raw.red.all"]).exists()
 
 
-def test_generate_trace_dataset_handles_multi_mutation_joint_pool(tmp_path: Path) -> None:
+def test_generate_trace_dataset_handles_multi_mutation_joint_pool(
+    tmp_path: Path,
+) -> None:
     report = generate_trace_dataset(
         load_bundled_manifest("tier1_basic.yaml"),
         tmp_path / "traces-multi",

--- a/tests/test_training_data.py
+++ b/tests/test_training_data.py
@@ -16,8 +16,19 @@ from open_range.runtime_types import RuntimeEvent
 
 
 def test_decision_prompt_and_completion_are_structured() -> None:
-    action = Action(actor_id="red", role="red", kind="api", payload={"target": "svc-web", "path": "/search", "query": {"q": "admin"}})
-    candidate = TraceCandidate(label="teacher", action=action, text=render_action_text(action), selected=True, counterfactual_label="teacher")
+    action = Action(
+        actor_id="red",
+        role="red",
+        kind="api",
+        payload={"target": "svc-web", "path": "/search", "query": {"q": "admin"}},
+    )
+    candidate = TraceCandidate(
+        label="teacher",
+        action=action,
+        text=render_action_text(action),
+        selected=True,
+        counterfactual_label="teacher",
+    )
     prompt = build_decision_prompt(
         snapshot_id="snap-1",
         world_id="world-1",
@@ -50,8 +61,19 @@ def test_decision_prompt_and_completion_are_structured() -> None:
 
 
 def test_decision_prompt_can_optionally_include_hidden_context() -> None:
-    action = Action(actor_id="red", role="red", kind="api", payload={"target": "svc-web", "path": "/search"})
-    candidate = TraceCandidate(label="teacher", action=action, text=render_action_text(action), selected=True, counterfactual_label="teacher")
+    action = Action(
+        actor_id="red",
+        role="red",
+        kind="api",
+        payload={"target": "svc-web", "path": "/search"},
+    )
+    candidate = TraceCandidate(
+        label="teacher",
+        action=action,
+        text=render_action_text(action),
+        selected=True,
+        counterfactual_label="teacher",
+    )
     prompt = build_decision_prompt(
         snapshot_id="snap-1",
         world_id="world-1",
@@ -81,7 +103,11 @@ def test_public_trace_action_strips_internal_execution_payload() -> None:
         actor_id="red",
         role="red",
         kind="shell",
-        payload={"target": "svc-idp", "command": "cat /etc/openrange/admin-surface.json", "service_command": "grep -Fq admin /etc/openrange/admin-surface.json"},
+        payload={
+            "target": "svc-idp",
+            "command": "cat /etc/openrange/admin-surface.json",
+            "service_command": "grep -Fq admin /etc/openrange/admin-surface.json",
+        },
     )
 
     public = public_trace_action(action)
@@ -112,9 +138,16 @@ def test_grounded_and_mitigation_effect_helpers_extract_runtime_signals() -> Non
         ),
     )
 
-    grounded = grounded_effects_for_result(stdout="OPENRANGE-EFFECT:privilege:wk-1:svc-idp", emitted_events=events)
+    grounded = grounded_effects_for_result(
+        stdout="OPENRANGE-EFFECT:privilege:wk-1:svc-idp", emitted_events=events
+    )
     mitigations = mitigation_effects_for_result(
-        action=Action(actor_id="blue", role="blue", kind="control", payload={"target": "svc-idp", "action": "mitigate"}),
+        action=Action(
+            actor_id="blue",
+            role="blue",
+            kind="control",
+            payload={"target": "svc-idp", "action": "mitigate"},
+        ),
         stdout="mitigation applied to svc-idp",
         emitted_events=events,
     )

--- a/tests/test_training_scripts.py
+++ b/tests/test_training_scripts.py
@@ -24,7 +24,9 @@ def test_tiny_sft_helpers_are_deterministic() -> None:
         limit=12,
         seed=7,
     )
-    train_rows, eval_rows = module.split_examples(rows, eval_ratio=0.25, min_eval_rows=3)
+    train_rows, eval_rows = module.split_examples(
+        rows, eval_ratio=0.25, min_eval_rows=3
+    )
 
     assert len(rows) == 12
     assert len(train_rows) >= 3

--- a/uv.lock
+++ b/uv.lock
@@ -208,6 +208,15 @@ wheels = [
 ]
 
 [[package]]
+name = "cfgv"
+version = "3.5.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/4e/b5/721b8799b04bf9afe054a3899c6cf4e880fcf8563cc71c15610242490a0c/cfgv-3.5.0.tar.gz", hash = "sha256:d5b1034354820651caa73ede66a6294d6e95c1b00acc5e9b098e917404669132", size = 7334, upload-time = "2025-11-19T20:55:51.612Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/db/3c/33bac158f8ab7f89b2e59426d5fe2e4f63f7ed25df84c036890172b412b5/cfgv-3.5.0-py2.py3-none-any.whl", hash = "sha256:a8dc6b26ad22ff227d2634a65cb388215ce6cc96bbcc5cfde7641ae87e8dacc0", size = 7445, upload-time = "2025-11-19T20:55:50.744Z" },
+]
+
+[[package]]
 name = "charset-normalizer"
 version = "3.4.5"
 source = { registry = "https://pypi.org/simple" }
@@ -357,6 +366,15 @@ source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/12/80/630b4b88364e9a8c8c5797f4602d0f76ef820909ee32f0bacb9f90654042/dill-0.4.0.tar.gz", hash = "sha256:0633f1d2df477324f53a895b02c901fb961bdbf65a17122586ea7019292cbcf0", size = 186976, upload-time = "2025-04-16T00:41:48.867Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/50/3d/9373ad9c56321fdab5b41197068e1d8c25883b3fea29dd361f9b55116869/dill-0.4.0-py3-none-any.whl", hash = "sha256:44f54bf6412c2c8464c14e8243eb163690a9800dbe2c367330883b19c7561049", size = 119668, upload-time = "2025-04-16T00:41:47.671Z" },
+]
+
+[[package]]
+name = "distlib"
+version = "0.4.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/96/8e/709914eb2b5749865801041647dc7f4e6d00b549cfe88b65ca192995f07c/distlib-0.4.0.tar.gz", hash = "sha256:feec40075be03a04501a973d81f633735b4b69f98b05450592310c0f401a4e0d", size = 614605, upload-time = "2025-07-17T16:52:00.465Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/33/6b/e0547afaf41bf2c42e52430072fa5658766e3d65bd4b03a563d1b6336f57/distlib-0.4.0-py2.py3-none-any.whl", hash = "sha256:9659f7d87e46584a30b5780e43ac7a2143098441670ff0a49d5f9034c54a6c16", size = 469047, upload-time = "2025-07-17T16:51:58.613Z" },
 ]
 
 [[package]]
@@ -574,6 +592,15 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/d5/7a/304cec37112382c4fe29a43bcb0d5891f922785d18745883d2aa4eb74e4b/huggingface_hub-1.6.0.tar.gz", hash = "sha256:d931ddad8ba8dfc1e816bf254810eb6f38e5c32f60d4184b5885662a3b167325", size = 717071, upload-time = "2026-03-06T14:19:18.524Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/92/e3/e3a44f54c8e2f28983fcf07f13d4260b37bd6a0d3a081041bc60b91d230e/huggingface_hub-1.6.0-py3-none-any.whl", hash = "sha256:ef40e2d5cb85e48b2c067020fa5142168342d5108a1b267478ed384ecbf18961", size = 612874, upload-time = "2026-03-06T14:19:16.844Z" },
+]
+
+[[package]]
+name = "identify"
+version = "2.6.18"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/46/c4/7fb4db12296cdb11893d61c92048fe617ee853f8523b9b296ac03b43757e/identify-2.6.18.tar.gz", hash = "sha256:873ac56a5e3fd63e7438a7ecbc4d91aca692eb3fefa4534db2b7913f3fc352fd", size = 99580, upload-time = "2026-03-15T18:39:50.319Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/46/33/92ef41c6fad0233e41d3d84ba8e8ad18d1780f1e5d99b3c683e6d7f98b63/identify-2.6.18-py2.py3-none-any.whl", hash = "sha256:8db9d3c8ea9079db92cafb0ebf97abdc09d52e97f4dcf773a2e694048b7cd737", size = 99394, upload-time = "2026-03-15T18:39:48.915Z" },
 ]
 
 [[package]]
@@ -853,6 +880,15 @@ wheels = [
 ]
 
 [[package]]
+name = "nodeenv"
+version = "1.10.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/24/bf/d1bda4f6168e0b2e9e5958945e01910052158313224ada5ce1fb2e1113b8/nodeenv-1.10.0.tar.gz", hash = "sha256:996c191ad80897d076bdfba80a41994c2b47c68e224c542b48feba42ba00f8bb", size = 55611, upload-time = "2025-12-20T14:08:54.006Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/88/b2/d0896bdcdc8d28a7fc5717c305f1a861c26e18c05047949fb371034d98bd/nodeenv-1.10.0-py2.py3-none-any.whl", hash = "sha256:5bb13e3eed2923615535339b3c620e76779af4cb4c6a90deccc9e36b274d3827", size = 23438, upload-time = "2025-12-20T14:08:52.782Z" },
+]
+
+[[package]]
 name = "numpy"
 version = "2.4.2"
 source = { registry = "https://pypi.org/simple" }
@@ -1076,9 +1112,6 @@ dependencies = [
 ]
 
 [package.optional-dependencies]
-dev = [
-    { name = "pytest" },
-]
 training = [
     { name = "accelerate" },
     { name = "datasets" },
@@ -1088,6 +1121,22 @@ training = [
     { name = "trl" },
 ]
 
+[package.dev-dependencies]
+dev = [
+    { name = "pre-commit" },
+    { name = "pytest" },
+    { name = "ruff" },
+]
+hooks = [
+    { name = "pre-commit" },
+]
+lint = [
+    { name = "ruff" },
+]
+test = [
+    { name = "pytest" },
+]
+
 [package.metadata]
 requires-dist = [
     { name = "accelerate", marker = "extra == 'training'", specifier = ">=1.13" },
@@ -1095,13 +1144,22 @@ requires-dist = [
     { name = "datasets", marker = "extra == 'training'", specifier = ">=4.3" },
     { name = "peft", marker = "extra == 'training'", specifier = ">=0.18" },
     { name = "pydantic", specifier = ">=2.0.0" },
-    { name = "pytest", marker = "extra == 'dev'", specifier = ">=8.0" },
     { name = "pyyaml", specifier = ">=6.0" },
     { name = "torch", marker = "extra == 'training'", specifier = ">=2.10" },
     { name = "transformers", marker = "extra == 'training'", specifier = ">=5.2" },
     { name = "trl", marker = "extra == 'training'", specifier = ">=0.24" },
 ]
-provides-extras = ["dev", "training"]
+provides-extras = ["training"]
+
+[package.metadata.requires-dev]
+dev = [
+    { name = "pre-commit", specifier = ">=4.5" },
+    { name = "pytest", specifier = ">=8.0" },
+    { name = "ruff", specifier = ">=0.15.6" },
+]
+hooks = [{ name = "pre-commit", specifier = ">=4.5" }]
+lint = [{ name = "ruff", specifier = ">=0.15.6" }]
+test = [{ name = "pytest", specifier = ">=8.0" }]
 
 [[package]]
 name = "packaging"
@@ -1194,12 +1252,37 @@ wheels = [
 ]
 
 [[package]]
+name = "platformdirs"
+version = "4.9.4"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/19/56/8d4c30c8a1d07013911a8fdbd8f89440ef9f08d07a1b50ab8ca8be5a20f9/platformdirs-4.9.4.tar.gz", hash = "sha256:1ec356301b7dc906d83f371c8f487070e99d3ccf9e501686456394622a01a934", size = 28737, upload-time = "2026-03-05T18:34:13.271Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/63/d7/97f7e3a6abb67d8080dd406fd4df842c2be0efaf712d1c899c32a075027c/platformdirs-4.9.4-py3-none-any.whl", hash = "sha256:68a9a4619a666ea6439f2ff250c12a853cd1cbd5158d258bd824a7df6be2f868", size = 21216, upload-time = "2026-03-05T18:34:12.172Z" },
+]
+
+[[package]]
 name = "pluggy"
 version = "1.6.0"
 source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/f9/e2/3e91f31a7d2b083fe6ef3fa267035b518369d9511ffab804f839851d2779/pluggy-1.6.0.tar.gz", hash = "sha256:7dcc130b76258d33b90f61b658791dede3486c3e6bfb003ee5c9bfb396dd22f3", size = 69412, upload-time = "2025-05-15T12:30:07.975Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/54/20/4d324d65cc6d9205fabedc306948156824eb9f0ee1633355a8f7ec5c66bf/pluggy-1.6.0-py3-none-any.whl", hash = "sha256:e920276dd6813095e9377c0bc5566d94c932c33b27a3e3945d8389c374dd4746", size = 20538, upload-time = "2025-05-15T12:30:06.134Z" },
+]
+
+[[package]]
+name = "pre-commit"
+version = "4.5.1"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "cfgv" },
+    { name = "identify" },
+    { name = "nodeenv" },
+    { name = "pyyaml" },
+    { name = "virtualenv" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/40/f1/6d86a29246dfd2e9b6237f0b5823717f60cad94d47ddc26afa916d21f525/pre_commit-4.5.1.tar.gz", hash = "sha256:eb545fcff725875197837263e977ea257a402056661f09dae08e4b149b030a61", size = 198232, upload-time = "2025-12-16T21:14:33.552Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/5d/19/fd3ef348460c80af7bb4669ea7926651d1f95c23ff2df18b9d24bab4f3fa/pre_commit-4.5.1-py2.py3-none-any.whl", hash = "sha256:3b3afd891e97337708c1674210f8eba659b52a38ea5f822ff142d10786221f77", size = 226437, upload-time = "2025-12-16T21:14:32.409Z" },
 ]
 
 [[package]]
@@ -1529,6 +1612,19 @@ wheels = [
 ]
 
 [[package]]
+name = "python-discovery"
+version = "1.1.3"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "filelock" },
+    { name = "platformdirs" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/d7/7e/9f3b0dd3a074a6c3e1e79f35e465b1f2ee4b262d619de00cfce523cc9b24/python_discovery-1.1.3.tar.gz", hash = "sha256:7acca36e818cd88e9b2ba03e045ad7e93e1713e29c6bbfba5d90202310b7baa5", size = 56945, upload-time = "2026-03-10T15:08:15.038Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/e7/80/73211fc5bfbfc562369b4aa61dc1e4bf07dc7b34df7b317e4539316b809c/python_discovery-1.1.3-py3-none-any.whl", hash = "sha256:90e795f0121bc84572e737c9aa9966311b9fde44ffb88a5953b3ec9b31c6945e", size = 31485, upload-time = "2026-03-10T15:08:13.06Z" },
+]
+
+[[package]]
 name = "pyyaml"
 version = "6.0.3"
 source = { registry = "https://pypi.org/simple" }
@@ -1713,6 +1809,31 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/b3/c6/f3b320c27991c46f43ee9d856302c70dc2d0fb2dba4842ff739d5f46b393/rich-14.3.3.tar.gz", hash = "sha256:b8daa0b9e4eef54dd8cf7c86c03713f53241884e814f4e2f5fb342fe520f639b", size = 230582, upload-time = "2026-02-19T17:23:12.474Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/14/25/b208c5683343959b670dc001595f2f3737e051da617f66c31f7c4fa93abc/rich-14.3.3-py3-none-any.whl", hash = "sha256:793431c1f8619afa7d3b52b2cdec859562b950ea0d4b6b505397612db8d5362d", size = 310458, upload-time = "2026-02-19T17:23:13.732Z" },
+]
+
+[[package]]
+name = "ruff"
+version = "0.15.6"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/51/df/f8629c19c5318601d3121e230f74cbee7a3732339c52b21daa2b82ef9c7d/ruff-0.15.6.tar.gz", hash = "sha256:8394c7bb153a4e3811a4ecdacd4a8e6a4fa8097028119160dffecdcdf9b56ae4", size = 4597916, upload-time = "2026-03-12T23:05:47.51Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/9e/2f/4e03a7e5ce99b517e98d3b4951f411de2b0fa8348d39cf446671adcce9a2/ruff-0.15.6-py3-none-linux_armv6l.whl", hash = "sha256:7c98c3b16407b2cf3d0f2b80c80187384bc92c6774d85fefa913ecd941256fff", size = 10508953, upload-time = "2026-03-12T23:05:17.246Z" },
+    { url = "https://files.pythonhosted.org/packages/70/60/55bcdc3e9f80bcf39edf0cd272da6fa511a3d94d5a0dd9e0adf76ceebdb4/ruff-0.15.6-py3-none-macosx_10_12_x86_64.whl", hash = "sha256:ee7dcfaad8b282a284df4aa6ddc2741b3f4a18b0555d626805555a820ea181c3", size = 10942257, upload-time = "2026-03-12T23:05:23.076Z" },
+    { url = "https://files.pythonhosted.org/packages/e7/f9/005c29bd1726c0f492bfa215e95154cf480574140cb5f867c797c18c790b/ruff-0.15.6-py3-none-macosx_11_0_arm64.whl", hash = "sha256:3bd9967851a25f038fc8b9ae88a7fbd1b609f30349231dffaa37b6804923c4bb", size = 10322683, upload-time = "2026-03-12T23:05:33.738Z" },
+    { url = "https://files.pythonhosted.org/packages/5f/74/2f861f5fd7cbb2146bddb5501450300ce41562da36d21868c69b7a828169/ruff-0.15.6-py3-none-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:13f4594b04e42cd24a41da653886b04d2ff87adbf57497ed4f728b0e8a4866f8", size = 10660986, upload-time = "2026-03-12T23:05:53.245Z" },
+    { url = "https://files.pythonhosted.org/packages/c1/a1/309f2364a424eccb763cdafc49df843c282609f47fe53aa83f38272389e0/ruff-0.15.6-py3-none-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:e2ed8aea2f3fe57886d3f00ea5b8aae5bf68d5e195f487f037a955ff9fbaac9e", size = 10332177, upload-time = "2026-03-12T23:05:56.145Z" },
+    { url = "https://files.pythonhosted.org/packages/30/41/7ebf1d32658b4bab20f8ac80972fb19cd4e2c6b78552be263a680edc55ac/ruff-0.15.6-py3-none-manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:70789d3e7830b848b548aae96766431c0dc01a6c78c13381f423bf7076c66d15", size = 11170783, upload-time = "2026-03-12T23:06:01.742Z" },
+    { url = "https://files.pythonhosted.org/packages/76/be/6d488f6adca047df82cd62c304638bcb00821c36bd4881cfca221561fdfc/ruff-0.15.6-py3-none-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:542aaf1de3154cea088ced5a819ce872611256ffe2498e750bbae5247a8114e9", size = 12044201, upload-time = "2026-03-12T23:05:28.697Z" },
+    { url = "https://files.pythonhosted.org/packages/71/68/e6f125df4af7e6d0b498f8d373274794bc5156b324e8ab4bf5c1b4fc0ec7/ruff-0.15.6-py3-none-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:1c22e6f02c16cfac3888aa636e9eba857254d15bbacc9906c9689fdecb1953ab", size = 11421561, upload-time = "2026-03-12T23:05:31.236Z" },
+    { url = "https://files.pythonhosted.org/packages/f1/9f/f85ef5fd01a52e0b472b26dc1b4bd228b8f6f0435975442ffa4741278703/ruff-0.15.6-py3-none-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:98893c4c0aadc8e448cfa315bd0cc343a5323d740fe5f28ef8a3f9e21b381f7e", size = 11310928, upload-time = "2026-03-12T23:05:45.288Z" },
+    { url = "https://files.pythonhosted.org/packages/8c/26/b75f8c421f5654304b89471ed384ae8c7f42b4dff58fa6ce1626d7f2b59a/ruff-0.15.6-py3-none-manylinux_2_31_riscv64.whl", hash = "sha256:70d263770d234912374493e8cc1e7385c5d49376e41dfa51c5c3453169dc581c", size = 11235186, upload-time = "2026-03-12T23:05:50.677Z" },
+    { url = "https://files.pythonhosted.org/packages/fc/d4/d5a6d065962ff7a68a86c9b4f5500f7d101a0792078de636526c0edd40da/ruff-0.15.6-py3-none-musllinux_1_2_aarch64.whl", hash = "sha256:55a1ad63c5a6e54b1f21b7514dfadc0c7fb40093fa22e95143cf3f64ebdcd512", size = 10635231, upload-time = "2026-03-12T23:05:37.044Z" },
+    { url = "https://files.pythonhosted.org/packages/d6/56/7c3acf3d50910375349016cf33de24be021532042afbed87942858992491/ruff-0.15.6-py3-none-musllinux_1_2_armv7l.whl", hash = "sha256:8dc473ba093c5ec238bb1e7429ee676dca24643c471e11fbaa8a857925b061c0", size = 10340357, upload-time = "2026-03-12T23:06:04.748Z" },
+    { url = "https://files.pythonhosted.org/packages/06/54/6faa39e9c1033ff6a3b6e76b5df536931cd30caf64988e112bbf91ef5ce5/ruff-0.15.6-py3-none-musllinux_1_2_i686.whl", hash = "sha256:85b042377c2a5561131767974617006f99f7e13c63c111b998f29fc1e58a4cfb", size = 10860583, upload-time = "2026-03-12T23:05:58.978Z" },
+    { url = "https://files.pythonhosted.org/packages/cb/1e/509a201b843b4dfb0b32acdedf68d951d3377988cae43949ba4c4133a96a/ruff-0.15.6-py3-none-musllinux_1_2_x86_64.whl", hash = "sha256:cef49e30bc5a86a6a92098a7fbf6e467a234d90b63305d6f3ec01225a9d092e0", size = 11410976, upload-time = "2026-03-12T23:05:39.955Z" },
+    { url = "https://files.pythonhosted.org/packages/6c/25/3fc9114abf979a41673ce877c08016f8e660ad6cf508c3957f537d2e9fa9/ruff-0.15.6-py3-none-win32.whl", hash = "sha256:bbf67d39832404812a2d23020dda68fee7f18ce15654e96fb1d3ad21a5fe436c", size = 10616872, upload-time = "2026-03-12T23:05:42.451Z" },
+    { url = "https://files.pythonhosted.org/packages/89/7a/09ece68445ceac348df06e08bf75db72d0e8427765b96c9c0ffabc1be1d9/ruff-0.15.6-py3-none-win_amd64.whl", hash = "sha256:aee25bc84c2f1007ecb5037dff75cef00414fdf17c23f07dc13e577883dca406", size = 11787271, upload-time = "2026-03-12T23:05:20.168Z" },
+    { url = "https://files.pythonhosted.org/packages/7f/d0/578c47dd68152ddddddf31cd7fc67dc30b7cdf639a86275fda821b0d9d98/ruff-0.15.6-py3-none-win_arm64.whl", hash = "sha256:c34de3dd0b0ba203be50ae70f5910b17188556630e2178fd7d79fc030eb0d837", size = 11060497, upload-time = "2026-03-12T23:05:25.968Z" },
 ]
 
 [[package]]
@@ -1991,6 +2112,21 @@ source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/c7/24/5f1b3bdffd70275f6661c76461e25f024d5a38a46f04aaca912426a2b1d3/urllib3-2.6.3.tar.gz", hash = "sha256:1b62b6884944a57dbe321509ab94fd4d3b307075e0c2eae991ac71ee15ad38ed", size = 435556, upload-time = "2026-01-07T16:24:43.925Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/39/08/aaaad47bc4e9dc8c725e68f9d04865dbcb2052843ff09c97b08904852d84/urllib3-2.6.3-py3-none-any.whl", hash = "sha256:bf272323e553dfb2e87d9bfd225ca7b0f467b919d7bbd355436d3fd37cb0acd4", size = 131584, upload-time = "2026-01-07T16:24:42.685Z" },
+]
+
+[[package]]
+name = "virtualenv"
+version = "21.2.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "distlib" },
+    { name = "filelock" },
+    { name = "platformdirs" },
+    { name = "python-discovery" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/aa/92/58199fe10049f9703c2666e809c4f686c54ef0a68b0f6afccf518c0b1eb9/virtualenv-21.2.0.tar.gz", hash = "sha256:1720dc3a62ef5b443092e3f499228599045d7fea4c79199770499df8becf9098", size = 5840618, upload-time = "2026-03-09T17:24:38.013Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/c6/59/7d02447a55b2e55755011a647479041bc92a82e143f96a8195cb33bd0a1c/virtualenv-21.2.0-py3-none-any.whl", hash = "sha256:1bd755b504931164a5a496d217c014d098426cddc79363ad66ac78125f9d908f", size = 5825084, upload-time = "2026-03-09T17:24:35.378Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
## Summary
- add Ruff and pre-commit to the uv-managed developer workflow
- enforce Ruff formatting and linting in GitHub Actions for both `main` and `v1`, while fixing stale CI paths
- apply a repo-wide Ruff baseline and the small follow-up fixes needed for a clean pass on current `v1`

## Testing
- `uv run pre-commit run --all-files`
- `uv sync --locked --no-default-groups --group lint`
- `uv run ruff format --check .`
- `uv run ruff check .`
- `uv sync --locked --no-default-groups --group test`
- `uv run pytest tests/ -v --tb=short`

## Notes
- branched from the latest `origin/v1` before making these changes
- the second commit is mostly mechanical formatter churn so reviewers can isolate the setup commit from the baseline pass