### PR TITLE
Fix live Kind and tiny training smoke blockers

### DIFF
--- a/scripts/train_tiny_sft.py
+++ b/scripts/train_tiny_sft.py
@@ -160,22 +160,22 @@ def tokenize_rows(
     *,
     max_length: int,
 ) -> Any:
-    from datasets import Dataset
-
-    texts = [example_to_text(row) for row in rows]
-    ds = Dataset.from_dict({"text": texts})
-
-    def _map(batch: dict[str, list[str]]) -> dict[str, Any]:
+    items: list[dict[str, list[int]]] = []
+    for row in rows:
         encoded = tokenizer(
-            batch["text"],
+            example_to_text(row),
             truncation=True,
             max_length=max_length,
             padding=False,
         )
-        encoded["labels"] = [ids[:] for ids in encoded["input_ids"]]
-        return encoded
-
-    return ds.map(_map, batched=True, remove_columns=["text"])
+        items.append(
+            {
+                "input_ids": list(encoded["input_ids"]),
+                "attention_mask": list(encoded["attention_mask"]),
+                "labels": list(encoded["input_ids"]),
+            }
+        )
+    return items
 
 
 class CausalCollator:

--- a/src/open_range/admit.py
+++ b/src/open_range/admit.py
@@ -5,6 +5,7 @@ from __future__ import annotations
 import json
 import shutil
 import subprocess
+import time
 from pathlib import Path
 from typing import Callable, Protocol
 from urllib.parse import urlencode
@@ -268,7 +269,7 @@ class LocalAdmissionController:
     def _auto_live_backend(self, build_config: BuildConfig) -> LiveBackend | None:
         if not self.auto_live:
             return None
-        if build_config.validation_profile == "graph_only":
+        if not profile_requires_live(build_config):
             return None
         if not shutil.which("helm"):
             return None
@@ -848,31 +849,69 @@ def _ephemeral_snapshot(
 
 
 def _live_service_smoke_check(world: WorldIR, release) -> ValidatorCheckReport:
-    commands = {
-        "svc-web": ("sandbox-red", "wget -qO- http://svc-web:80/ | grep -q OpenRange"),
-        "svc-email": ("sandbox-red", "nc -z -w 3 svc-email 25"),
-        "svc-idp": ("sandbox-blue", "nc -z -w 3 svc-idp 389"),
-        "svc-fileshare": ("sandbox-blue", "nc -z -w 3 svc-fileshare 445"),
-        "svc-db": ("sandbox-blue", "nc -z -w 3 svc-db 3306"),
-        "svc-siem": (
-            "sandbox-blue",
-            "wget -qO- http://svc-siem:9200/all.log >/dev/null",
-        ),
-    }
     failures: list[str] = []
     for service in world.services:
-        runner, cmd = commands.get(service.id, ("sandbox-blue", "true"))
-        result = run_async(release.pods.exec(runner, cmd, timeout=10.0))
-        if not result.ok:
-            failures.append(
-                f"{service.id}:{result.stderr or result.stdout or 'smoke failed'}"
-            )
+        runner = _smoke_runner_for_service(world, service.id)
+        cmd = _smoke_probe_command(service)
+        last_error = "smoke failed"
+        ok = False
+        attempts = 10 if service.kind == "db" else 3
+        retry_delay_s = 2.0 if service.kind == "db" else 1.0
+        for attempt in range(attempts):
+            result = run_async(release.pods.exec(runner, cmd, timeout=10.0))
+            if result.ok:
+                ok = True
+                break
+            last_error = result.stderr or result.stdout or "smoke failed"
+            if attempt + 1 < attempts:
+                time.sleep(retry_delay_s)
+        if not ok:
+            failures.append(f"{service.id}:{last_error}")
     return ValidatorCheckReport(
         name="live_service_smoke",
         passed=not failures,
         details={"failures": failures},
         error="; ".join(failures),
     )
+
+
+def _smoke_runner_for_service(world: WorldIR, service_id: str) -> str:
+    service_by_id = {service.id: service for service in world.services}
+    host_zone_by_id = {host.id: host.zone for host in world.hosts}
+    service = service_by_id[service_id]
+    zone = host_zone_by_id.get(service.host, "")
+    if zone in {"dmz", "external"}:
+        return "sandbox-red"
+    if zone == "management":
+        return "sandbox-blue"
+    if zone in {"corp", "data"}:
+        runner = _first_green_sandbox_in_zones(world, ("dmz", "corp", zone))
+        if runner:
+            return runner
+    runner = _first_green_sandbox_in_zones(world, (zone,))
+    if runner:
+        return runner
+    return "sandbox-blue" if zone == "management" else "sandbox-red"
+
+
+def _first_green_sandbox_in_zones(world: WorldIR, zones: tuple[str, ...]) -> str:
+    host_zone_by_id = {host.id: host.zone for host in world.hosts}
+    allowed = set(zones)
+    for persona in world.green_personas:
+        zone = host_zone_by_id.get(persona.home_host, "")
+        if zone in allowed:
+            safe = "".join(ch.lower() if ch.isalnum() else "-" for ch in persona.id)
+            return f"sandbox-green-{safe.strip('-')}"
+    return ""
+
+
+def _smoke_probe_command(service: ServiceSpec) -> str:
+    port = service.ports[0] if service.ports else 80
+    if service.id == "svc-web":
+        return f"wget -qO- http://{service.id}:{port}/ | grep -q OpenRange"
+    if service.id == "svc-siem":
+        return "wget -qO- http://svc-siem:9200/all.log >/dev/null"
+    return f"nc -z -w 3 {service.id} {port}"
 
 
 def _live_red_reference_check(

--- a/src/open_range/chart/templates/configmaps.yaml
+++ b/src/open_range/chart/templates/configmaps.yaml
@@ -10,7 +10,7 @@ metadata:
     {{- include "openrange.labels" $ | nindent 4 }}
 data:
   {{- range $svc.payloads }}
-  {{ .key }}: |
+  {{ .key | quote }}: |2
 {{ .content | indent 4 }}
   {{- end }}
 ---

--- a/src/open_range/cluster.py
+++ b/src/open_range/cluster.py
@@ -347,7 +347,7 @@ class KindBackend:
                 "-l",
                 f"app.kubernetes.io/instance={release_name}",
                 "-o",
-                "jsonpath={range .items[*]}{.metadata.namespace}{'/'}{.metadata.name}{'|'}{.metadata.labels.openrange\\.service}{'\\n'}{end}",
+                "jsonpath={range .items[*]}{.metadata.namespace}{'/'}{.metadata.name}{'|'}{.metadata.labels['openrange/service']}{'\\n'}{end}",
             ],
             timeout=30.0,
         )

--- a/src/open_range/compiler.py
+++ b/src/open_range/compiler.py
@@ -516,13 +516,13 @@ class EnterpriseSaaSManifestCompiler:
             location = f"svc-db://main/{asset.id}"
         elif any(token in asset_id for token in ("doc", "file", "share")):
             service = "svc-fileshare"
-            location = f"svc-fileshare:/srv/{asset.id}"
+            location = f"svc-fileshare:/srv/shared/{asset.id}.txt"
         elif any(token in asset_id for token in ("cred", "password", "token", "key")):
             service = "svc-idp"
             location = f"svc-idp://secrets/{asset.id}"
         else:
             service = "svc-web"
-            location = f"svc-web://content/{asset.id}"
+            location = f"svc-web:/var/www/html/content/{asset.id}.txt"
 
         confidentiality = {
             "crown_jewel": "critical",

--- a/src/open_range/execution.py
+++ b/src/open_range/execution.py
@@ -46,6 +46,8 @@ class PodActionBackend:
         self._snapshot: RuntimeSnapshot | None = None
         self._release: BootedRelease | None = None
         self._service_by_id: dict[str, ServiceSpec] = {}
+        self._service_zone_by_id: dict[str, str] = {}
+        self._green_runner_by_zone: dict[str, str] = {}
 
     def bind(self, snapshot: RuntimeSnapshot, release: BootedRelease) -> None:
         self._snapshot = snapshot
@@ -53,11 +55,23 @@ class PodActionBackend:
         self._service_by_id = {
             service.id: service for service in snapshot.world.services
         }
+        host_zone_by_id = {host.id: host.zone for host in snapshot.world.hosts}
+        self._service_zone_by_id = {
+            service.id: host_zone_by_id.get(service.host, "")
+            for service in snapshot.world.services
+        }
+        self._green_runner_by_zone = {}
+        for persona in snapshot.world.green_personas:
+            zone = host_zone_by_id.get(persona.home_host, "")
+            if zone and zone not in self._green_runner_by_zone:
+                self._green_runner_by_zone[zone] = _green_sandbox_name(persona.id)
 
     def clear(self) -> None:
         self._snapshot = None
         self._release = None
         self._service_by_id = {}
+        self._service_zone_by_id = {}
+        self._green_runner_by_zone = {}
 
     def record_event(self, event: Any) -> None:
         if self._release is None or "svc-siem" not in self._service_by_id:
@@ -209,14 +223,25 @@ class PodActionBackend:
         if action.role == "red":
             origin = action.payload.get("origin")
             if isinstance(origin, str) and origin:
-                if origin in self._service_by_id or origin.startswith("sandbox-"):
+                if origin.startswith("sandbox-"):
                     return origin
+                if origin in self._service_by_id:
+                    return self._tool_runner_for_service(origin)
             return "sandbox-red"
         if action.role == "blue":
             return "sandbox-blue"
         if action.role == "green":
             return _green_sandbox_name(action.actor_id)
         raise ValueError(f"unsupported runner role: {action.role}")
+
+    def _tool_runner_for_service(self, service_id: str) -> str:
+        zone = self._service_zone_by_id.get(service_id, "")
+        if zone == "management":
+            return self._green_runner_by_zone.get(zone, "sandbox-blue")
+        green_runner = self._green_runner_by_zone.get(zone)
+        if green_runner:
+            return green_runner
+        return service_id
 
     def _api_command(self, action: Action) -> str:
         target = action_target(action)

--- a/src/open_range/objectives.py
+++ b/src/open_range/objectives.py
@@ -177,7 +177,7 @@ def objective_grader_for_predicate(
             grader_kind="file_exists",
             service_id=service_id,
             target_id=resolved_target,
-            path=asset_location,
+            path=_live_asset_probe_path(asset_location),
             expected_ref=resolved_target,
         )
     if tag == "file_creation":
@@ -186,7 +186,7 @@ def objective_grader_for_predicate(
             grader_kind="file_exists",
             service_id=service_id,
             target_id=resolved_target,
-            path=asset_location,
+            path=_live_asset_probe_path(asset_location),
             expected_ref=resolved_target,
         )
     if tag == "db_access":
@@ -226,6 +226,17 @@ def objective_grader_for_predicate(
         event_type=event_type,
         expected_ref=resolved_target,
     )
+
+
+def _live_asset_probe_path(asset_location: str) -> str:
+    if not asset_location:
+        return ""
+    if asset_location.startswith("/") or "://" in asset_location:
+        return asset_location if asset_location.startswith("/") else ""
+    prefix, sep, suffix = asset_location.partition(":")
+    if prefix and sep and suffix.startswith("/"):
+        return suffix
+    return asset_location
 
 
 def evaluate_objective_grader(

--- a/src/open_range/render.py
+++ b/src/open_range/render.py
@@ -26,9 +26,11 @@ _IMAGE_BY_KIND = {
     "siem": "busybox:1.36",
 }
 
+_DEFAULT_SANDBOX_MULTITOOL_IMAGE = "wbitt/network-multitool:alpine-extra"
+
 _SANDBOX_IMAGE_BY_ROLE = {
-    "red": "ghcr.io/wbitt/network-multitool:alpine-extra",
-    "blue": "ghcr.io/wbitt/network-multitool:alpine-extra",
+    "red": _DEFAULT_SANDBOX_MULTITOOL_IMAGE,
+    "blue": _DEFAULT_SANDBOX_MULTITOOL_IMAGE,
     "green": "busybox:1.36",
 }
 

--- a/src/open_range/runtime.py
+++ b/src/open_range/runtime.py
@@ -63,6 +63,7 @@ class ReferenceDrivenRuntime:
         self._red_objectives_satisfied: set[str] = set()
         self._blue_objectives_satisfied: set[str] = set()
         self._detected_event_ids: set[str] = set()
+        self._red_footholds: set[str] = set()
         self._last_red_target = ""
         self._event_seq = 0
         self._decision_seq = 0
@@ -100,6 +101,7 @@ class ReferenceDrivenRuntime:
         self._red_objectives_satisfied = set()
         self._blue_objectives_satisfied = set()
         self._detected_event_ids = set()
+        self._red_footholds = set()
         self._last_red_target = ""
         self._event_seq = 0
         self._decision_seq = 0
@@ -447,7 +449,7 @@ class ReferenceDrivenRuntime:
         exec_action = action
         if self.action_backend is not None:
             payload = dict(action.payload)
-            payload.setdefault("origin", self._last_red_target or "sandbox-red")
+            payload.setdefault("origin", self._live_red_origin(target))
             if target:
                 payload.setdefault("target", target)
             exec_action = action.model_copy(update={"payload": payload})
@@ -480,6 +482,8 @@ class ReferenceDrivenRuntime:
             emitted = list(batch.events)
             self._red_objectives_satisfied.update(batch.satisfied_objectives)
             self._last_red_target = batch.last_red_target
+            if batch.last_red_target:
+                self._red_footholds.add(batch.last_red_target)
         else:
             stdout = live.stdout or f"red executed on {target or 'unknown target'}"
 
@@ -694,6 +698,60 @@ class ReferenceDrivenRuntime:
         if self._red_progress >= len(trace.steps):
             return None
         return trace.steps[self._red_progress]
+
+    def _live_red_origin(self, target: str) -> str:
+        if not target or self._snapshot is None or self._predicates is None:
+            return self._last_red_target or "sandbox-red"
+        service_ids = {service.id for service in self._snapshot.world.services}
+        candidate_ids = service_ids & self._red_footholds
+        if self._last_red_target in service_ids:
+            candidate_ids.add(self._last_red_target)
+        reachable = {
+            origin
+            for origin in candidate_ids
+            if self._foothold_can_reach_target(origin, target)
+        }
+        if not reachable:
+            return self._last_red_target or "sandbox-red"
+        return min(
+            reachable,
+            key=lambda origin: (
+                len(self._predicates.shortest_path(origin, target)),
+                origin,
+            ),
+        )
+
+    def _foothold_can_reach_target(self, origin: str, target: str) -> bool:
+        if self._snapshot is None:
+            return False
+        origin_zone = self._service_zone(origin)
+        target_zone = self._service_zone(target)
+        if not origin_zone or not target_zone:
+            return False
+        return self._zone_can_reach(origin_zone, target_zone)
+
+    def _service_zone(self, service_id: str) -> str:
+        snapshot = self._require_snapshot()
+        host_zone_by_id = {host.id: host.zone for host in snapshot.world.hosts}
+        service = next(
+            (item for item in snapshot.world.services if item.id == service_id), None
+        )
+        if service is None:
+            return ""
+        return host_zone_by_id.get(service.host, "")
+
+    def _zone_can_reach(self, from_zone: str, to_zone: str) -> bool:
+        if from_zone == to_zone:
+            return True
+        snapshot = self._require_snapshot()
+        rules = snapshot.artifacts.chart_values.get("firewallRules", ())
+        return any(
+            rule.get("action") == "allow"
+            and rule.get("fromZone") == from_zone
+            and rule.get("toZone") == to_zone
+            for rule in rules
+            if isinstance(rule, dict)
+        )
 
     def _next_blue_step(self):
         if self._snapshot is None:

--- a/src/open_range/synth.py
+++ b/src/open_range/synth.py
@@ -134,9 +134,6 @@ class EnterpriseSaaSWorldSynthesizer:
         if service_id == "svc-siem":
             payloads = [
                 SynthFile(
-                    key="all.log", mount_path="/srv/http/siem/all.log", content=""
-                ),
-                SynthFile(
                     key="index.html",
                     mount_path="/srv/http/siem/index.html",
                     content="OpenRange SIEM log sink\n",

--- a/tests/test_cluster.py
+++ b/tests/test_cluster.py
@@ -1,7 +1,9 @@
 from __future__ import annotations
 
+from subprocess import CompletedProcess
+
 from open_range.async_utils import run_async
-from open_range.cluster import PodSet
+from open_range.cluster import KindBackend, PodSet
 import open_range.cluster as cluster_mod
 
 
@@ -37,3 +39,27 @@ def test_podset_resolve_caches_discovered_refs(monkeypatch) -> None:
 
     assert podset._resolve("svc-web") == ("ns", "svc-web-pod")
     assert podset.pod_ids["svc-web"] == "ns/svc-web-pod"
+
+
+def test_kind_backend_discovers_pods_from_service_label(monkeypatch) -> None:
+    captured: dict[str, object] = {}
+    backend = KindBackend()
+
+    def fake_run(args, *, timeout):
+        captured["args"] = tuple(args)
+        captured["timeout"] = timeout
+        return CompletedProcess(
+            list(args),
+            0,
+            stdout="ns/svc-web-pod|svc-web\nns/sandbox-red-pod|sandbox-red\n",
+            stderr="",
+        )
+
+    monkeypatch.setattr(KindBackend, "_run", staticmethod(fake_run))
+
+    assert backend._discover_pods("or-demo") == {
+        "svc-web": "ns/svc-web-pod",
+        "sandbox-red": "ns/sandbox-red-pod",
+    }
+    assert "labels['openrange/service']" in captured["args"][-1]
+    assert captured["timeout"] == 30.0

--- a/tests/test_execution.py
+++ b/tests/test_execution.py
@@ -59,3 +59,46 @@ def test_execution_helpers_raise_clear_errors_when_unbound() -> None:
         backend._is_contained("svc-web")
     with pytest.raises(RuntimeError, match="no active snapshot is bound"):
         backend._weakness_for("svc-web")
+
+
+def test_runner_for_red_service_origin_uses_zone_tooling_runner() -> None:
+    backend = PodActionBackend()
+    backend._service_by_id = {
+        "svc-web": ServiceSpec(
+            id="svc-web",
+            kind="web_app",
+            host="web-1",
+            ports=(80,),
+            dependencies=(),
+            telemetry_surfaces=(),
+        ),
+        "svc-idp": ServiceSpec(
+            id="svc-idp",
+            kind="idp",
+            host="idp-1",
+            ports=(389,),
+            dependencies=(),
+            telemetry_surfaces=(),
+        ),
+    }
+    backend._service_zone_by_id = {"svc-web": "dmz", "svc-idp": "management"}
+    backend._green_runner_by_zone = {
+        "dmz": "sandbox-green-sales-01",
+        "management": "sandbox-green-it-admin-01",
+    }
+
+    web_origin = Action(
+        actor_id="red",
+        role="red",
+        kind="api",
+        payload={"target": "svc-idp", "origin": "svc-web"},
+    )
+    idp_origin = Action(
+        actor_id="red",
+        role="red",
+        kind="api",
+        payload={"target": "svc-idp", "origin": "svc-idp"},
+    )
+
+    assert backend._runner_for(web_origin) == "sandbox-green-sales-01"
+    assert backend._runner_for(idp_origin) == "sandbox-green-it-admin-01"

--- a/tests/test_render_admission.py
+++ b/tests/test_render_admission.py
@@ -96,6 +96,14 @@ def test_kind_renderer_emits_expected_files(tmp_path: Path):
     )
     assert "sandbox-red" in artifacts.chart_values["sandboxes"]
     assert (
+        artifacts.chart_values["sandboxes"]["sandbox-red"]["image"]
+        == "wbitt/network-multitool:alpine-extra"
+    )
+    assert (
+        artifacts.chart_values["sandboxes"]["sandbox-blue"]["image"]
+        == "wbitt/network-multitool:alpine-extra"
+    )
+    assert (
         artifacts.chart_values["services"]["svc-db"]["payloads"][0]["mountPath"]
         == "/docker-entrypoint-initdb.d/01-init.sql"
     )

--- a/tests/test_render_admission.py
+++ b/tests/test_render_admission.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import importlib
 from pathlib import Path
 from types import SimpleNamespace
 
@@ -9,6 +10,7 @@ from open_range.admit import LocalAdmissionController
 from open_range.code_web import code_web_payload
 from open_range.compiler import EnterpriseSaaSManifestCompiler
 from open_range.curriculum import FrontierMutationPolicy, PopulationStats
+from open_range.predicates import PredicateEngine
 from open_range.render import EnterpriseSaaSKindRenderer
 from open_range.store import FileSnapshotStore
 from open_range.synth import EnterpriseSaaSWorldSynthesizer
@@ -18,6 +20,8 @@ from tests.support import (
     OFFLINE_REFERENCE_BUILD_CONFIG,
     manifest_payload,
 )
+
+admit_mod = importlib.import_module("open_range.admit")
 
 
 def _manifest_payload() -> dict:
@@ -80,6 +84,7 @@ def test_kind_renderer_emits_expected_files(tmp_path: Path):
     world = _build_seeded_world()
     synth = _synth(world, tmp_path)
     artifacts = EnterpriseSaaSKindRenderer().render(world, synth, tmp_path / "rendered")
+    finance_docs = next(asset for asset in world.assets if asset.id == "finance_docs")
 
     assert Path(artifacts.values_path).exists()
     assert Path(artifacts.kind_config_path).exists()
@@ -107,9 +112,18 @@ def test_kind_renderer_emits_expected_files(tmp_path: Path):
         artifacts.chart_values["services"]["svc-db"]["payloads"][0]["mountPath"]
         == "/docker-entrypoint-initdb.d/01-init.sql"
     )
+    assert finance_docs.location == "svc-fileshare:/srv/shared/finance_docs.txt"
+    assert (
+        PredicateEngine(world).objective_grader("asset_read(finance_docs)").path
+        == "/srv/shared/finance_docs.txt"
+    )
     siem_command = artifacts.chart_values["services"]["svc-siem"]["command"][-1]
     assert "busybox nc -lp 9201" in siem_command
     assert "busybox httpd -f -p 9200 -h /srv/http/siem" in siem_command
+    assert all(
+        payload["mountPath"] != "/srv/http/siem/all.log"
+        for payload in artifacts.chart_values["services"]["svc-siem"]["payloads"]
+    )
     assert any(
         rule["fromZone"] == "external" and rule["toZone"] == "dmz"
         for rule in artifacts.chart_values["firewallRules"]
@@ -325,6 +339,66 @@ def test_admission_controller_can_run_optional_live_backend(tmp_path: Path):
     assert any(stage.name == "kind_live" for stage in report.stages)
     assert calls[0].startswith("boot:")
     assert calls[-1].startswith("down:")
+
+
+def test_no_necessity_profile_skips_auto_live_backend_probe(
+    tmp_path: Path, monkeypatch
+) -> None:
+    world = _build_seeded_world()
+    artifacts = EnterpriseSaaSKindRenderer().render(
+        world, _synth(world, tmp_path), tmp_path / "rendered"
+    )
+    which_calls: list[str] = []
+    run_calls: list[tuple[object, ...]] = []
+
+    def fake_which(cmd: str) -> str:
+        which_calls.append(cmd)
+        return f"/usr/bin/{cmd}"
+
+    def fake_run(*args, **kwargs):
+        del kwargs
+        run_calls.append(args)
+        return SimpleNamespace(returncode=0, stdout="openrange\n", stderr="")
+
+    monkeypatch.setattr(admit_mod.shutil, "which", fake_which)
+    monkeypatch.setattr(admit_mod.subprocess, "run", fake_run)
+
+    _bundle, report = LocalAdmissionController(mode="fail_fast").admit(
+        world, artifacts, OFFLINE_REFERENCE_BUILD_CONFIG
+    )
+
+    assert report.admitted is True
+    assert all(stage.name != "kind_live" for stage in report.stages)
+    assert which_calls == []
+    assert run_calls == []
+
+
+def test_live_service_smoke_check_uses_reachable_zone_runners() -> None:
+    world = _build_seeded_world()
+    calls: list[tuple[str, str]] = []
+
+    class FakePods:
+        async def exec(
+            self, service: str, cmd: str, timeout: float = 30.0
+        ) -> ExecResult:
+            del timeout
+            calls.append((service, cmd))
+            return ExecResult(stdout="ok", stderr="", exit_code=0)
+
+    report = admit_mod._live_service_smoke_check(
+        world, SimpleNamespace(pods=FakePods())
+    )
+    calls_by_target = {
+        service.id: runner for service, (runner, _cmd) in zip(world.services, calls)
+    }
+
+    assert report.passed is True
+    assert calls_by_target["svc-web"] == "sandbox-red"
+    assert calls_by_target["svc-email"] == "sandbox-red"
+    assert calls_by_target["svc-idp"] == "sandbox-blue"
+    assert calls_by_target["svc-siem"] == "sandbox-blue"
+    assert calls_by_target["svc-fileshare"].startswith("sandbox-green-")
+    assert calls_by_target["svc-db"].startswith("sandbox-green-")
 
 
 def test_admission_controller_rejects_world_without_telemetry(tmp_path: Path):

--- a/tests/test_runtime.py
+++ b/tests/test_runtime.py
@@ -276,6 +276,18 @@ def test_runtime_matching_rejects_extra_api_path_when_reference_has_no_path() ->
     assert ReferenceDrivenRuntime._matches_step(action, expected, "ok") is False
 
 
+def test_runtime_prefers_shortest_live_foothold_for_next_red_origin(
+    tmp_path: Path,
+) -> None:
+    snapshot = _snapshot(tmp_path)
+    runtime = ReferenceDrivenRuntime()
+    runtime.reset(snapshot, EpisodeConfig(mode="red_only", green_enabled=False))
+    runtime._red_footholds = {"svc-web", "svc-idp"}
+    runtime._last_red_target = "svc-idp"
+
+    assert runtime._live_red_origin("svc-fileshare") == "svc-web"
+
+
 def test_runtime_internal_snapshot_helpers_raise_clear_errors_without_reset() -> None:
     runtime = ReferenceDrivenRuntime()
 

--- a/tests/test_training_scripts.py
+++ b/tests/test_training_scripts.py
@@ -65,3 +65,44 @@ def test_tiny_sft_limit_applies_after_role_filtering() -> None:
     assert len(filtered) == 4
     assert len(limited) == 4
     assert {row["role"] for row in limited} == {"red"}
+
+
+def test_tiny_sft_tokenize_rows_returns_trainer_ready_items() -> None:
+    module = _load_module(
+        Path(__file__).resolve().parents[1] / "scripts" / "train_tiny_sft.py",
+        "train_tiny_sft_tokenize_test",
+    )
+
+    class FakeTokenizer:
+        def __call__(
+            self,
+            text: str,
+            *,
+            truncation: bool,
+            max_length: int,
+            padding: bool,
+        ) -> dict[str, list[int]]:
+            assert truncation is True
+            assert padding is False
+            tokens = [ord(char) % 17 for char in text][:max_length]
+            return {
+                "input_ids": tokens,
+                "attention_mask": [1] * len(tokens),
+            }
+
+    rows = [
+        {
+            "messages": [
+                {"role": "system", "content": "sys"},
+                {"role": "user", "content": "hello"},
+                {"role": "assistant", "content": "ok"},
+            ]
+        }
+    ]
+
+    tokenized = module.tokenize_rows(FakeTokenizer(), rows, max_length=8)
+
+    assert len(tokenized) == 1
+    assert tokenized[0]["input_ids"]
+    assert tokenized[0]["attention_mask"]
+    assert tokenized[0]["labels"] == tokenized[0]["input_ids"]


### PR DESCRIPTION
## Summary
- switch red/blue sandbox defaults to the public Docker Hub image
- fix the additional live Kind admission blockers uncovered on a clean run
- fix the tiny SFT smoke path on Python 3.14 so local manifest -> traces -> training -> rollout works again

## Validation
- verified `validation_profile="full"` succeeds locally on a clean Kind cluster
- verified the tiny local trace -> train -> eval -> rollout smoke succeeds on macOS with Python 3.14
