### PR TITLE
Add manifest-defined NPC profiles

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,6 +30,7 @@ The supported surface on this branch is:
 - [Benchmark Offensive Coverage](docs/benchmark-offensive-coverage.md)
 - [Effect Grounding](docs/effect-grounding.md)
 - [Weakness Lifecycle](docs/weakness-lifecycle.md)
+- [NPC Profiles](docs/npc-profiles.md)
 
 ## Package shape
 

--- a/docs/npc-profiles.md
+++ b/docs/npc-profiles.md
@@ -1,0 +1,161 @@
+# NPC Profile Spec
+
+This document defines the public manifest contract for role-level green-user
+behavior in OpenRange V1.
+
+`npc_profiles` is a public business-world input. It shapes generated
+`GreenPersona` objects without exposing private validator references or hidden
+weakness inventory.
+
+## Goals
+
+- Let manifest authors vary role-level NPC behavior without editing Python code.
+- Keep the contract backward compatible with existing manifests.
+- Make the current semantics explicit so newcomers do not need to read the
+  compiler or runtime to use the feature safely.
+
+## Manifest Shape
+
+`npc_profiles` is an optional top-level manifest field.
+
+```yaml
+users:
+  roles:
+    sales: 2
+    engineer: 1
+    it_admin: 1
+
+npc_profiles:
+  sales:
+    awareness: 0.2
+    susceptibility:
+      initial_access: 0.8
+      credential_obtained: 0.7
+    routine:
+      - check_mail
+      - browse_app
+      - access_fileshare
+  it_admin:
+    awareness: 0.9
+    susceptibility:
+      unauthorized_credential_use: 0.2
+    routine:
+      - review_idp
+      - triage_alerts
+      - reset_password
+```
+
+Rules:
+
+- `npc_profiles` is optional. Omitting it preserves current compiler behavior.
+- Keys MUST match names declared in `users.roles`.
+- All fields are optional. Omitted fields fall back to the existing compiler
+  defaults for that role.
+- Profiles apply per role, not per individual user.
+- `awareness` and all `susceptibility` values must be between `0.0` and `1.0`.
+
+## Field Definitions
+
+### `awareness`
+
+`awareness` is a normalized caution score.
+
+- `0.0` means minimally aware.
+- `1.0` means maximally aware.
+
+Current V1 semantics:
+
+- Used by the green scheduler when choosing which persona reacts in the
+  `small_llm` backend.
+- Higher awareness makes a persona more likely to be selected as the reporter.
+- Higher awareness also makes recovery actions more likely once a malicious
+  event has been observed.
+
+### `susceptibility`
+
+`susceptibility` is a map from label to probability-like score.
+
+- `0.0` means minimally susceptible for that label.
+- `1.0` means maximally susceptible for that label.
+- Keys are free-form strings at the schema level.
+
+Recommended stable keys for V1:
+
+- `initial_access`
+- `credential_obtained`
+- `unauthorized_credential_use`
+
+Current V1 semantics:
+
+- The `small_llm` green backend first looks up the event-style key associated
+  with the observed malicious event.
+- If that exact key is missing, it falls back to the maximum value in the map.
+- Other backends currently do not use `susceptibility` directly.
+
+Implication:
+
+- Free-form labels such as `phishing`, `pretexting`, or `spear_phishing` are
+  accepted and preserved in the manifest and `WorldIR`.
+- For predictable runtime behavior today, prefer the event-style keys above.
+
+### `routine`
+
+`routine` is an ordered list of benign activities for that role.
+
+Current V1 semantics:
+
+- The green scheduler cycles through the list over time.
+- Each token is interpreted heuristically into a service target.
+- The order matters because the scheduler advances through the list.
+
+Recommended stable routine tokens for V1:
+
+- `check_mail`
+- `browse_app`
+- `access_fileshare`
+- `open_payroll_dashboard`
+- `review_idp`
+- `triage_alerts`
+- `reset_password`
+
+Current service mapping:
+
+- tokens containing `mail` -> email
+- tokens containing `file` or `share` -> fileshare
+- tokens containing `idp` or `password` -> IDP
+- tokens containing `alert` or `triage` -> SIEM
+- tokens containing `payroll` -> database
+- everything else -> web app
+
+## Compiler Rules
+
+At compile time:
+
+- OpenRange validates that every `npc_profiles` key exists in `users.roles`.
+- A role profile is applied uniformly to all generated users for that role.
+- A profile only overrides fields that are explicitly set.
+- Omitted fields keep the same defaults as before the feature was added.
+
+## What This Covers Today
+
+`npc_profiles` is useful today for:
+
+- coarse role-level benign routine shaping
+- coarse role-level green reaction weighting in the `small_llm` backend
+- reproducible manifest-authored variation across snapshots
+
+## What This Does Not Cover Yet
+
+`npc_profiles` does not yet provide:
+
+- per-individual overrides within a role
+- an explicit click-through model for phishing links or attachments
+- a first-class taxonomy of social-engineering technique keys
+- uniform `susceptibility` semantics across all green backends
+- explicit policies for escalation, ticketing, or reporting thresholds beyond
+  the current scheduler heuristics
+
+If V1 needs "careless reps click every lure" or "admins report every anomaly"
+as first-class scenario semantics, the next step should be a dedicated NPC
+behavior model with explicit pre-compromise and post-compromise controls rather
+than relying only on the current `awareness` and `susceptibility` heuristics.

--- a/docs/npc-profiles.md
+++ b/docs/npc-profiles.md
@@ -1,22 +1,7 @@
 # NPC Profile Spec
 
-This document defines the public manifest contract for role-level green-user
-behavior in OpenRange V1.
-
-`npc_profiles` is a public business-world input. It shapes generated
-`GreenPersona` objects without exposing private validator references or hidden
-weakness inventory.
-
-## Goals
-
-- Let manifest authors vary role-level NPC behavior without editing Python code.
-- Keep the contract backward compatible with existing manifests.
-- Make the current semantics explicit so newcomers do not need to read the
-  compiler or runtime to use the feature safely.
-
-## Manifest Shape
-
-`npc_profiles` is an optional top-level manifest field.
+`npc_profiles` is an optional top-level manifest field for role-level green-user
+behavior.
 
 ```yaml
 users:
@@ -45,70 +30,55 @@ npc_profiles:
       - reset_password
 ```
 
-Rules:
+## Rules
 
-- `npc_profiles` is optional. Omitting it preserves current compiler behavior.
-- Keys MUST match names declared in `users.roles`.
-- All fields are optional. Omitted fields fall back to the existing compiler
-  defaults for that role.
-- Profiles apply per role, not per individual user.
+- `npc_profiles` is optional.
+- Keys must match names declared in `users.roles`.
+- All fields are optional.
+- Omitting `npc_profiles` or setting it to `{}` preserves the pre-existing
+  compiler behavior.
 - `awareness` and all `susceptibility` values must be between `0.0` and `1.0`.
+- Profiles apply per role, not per individual user.
 
-## Field Definitions
+## Fields
 
 ### `awareness`
 
-`awareness` is a normalized caution score.
+Normalized caution score.
 
-- `0.0` means minimally aware.
-- `1.0` means maximally aware.
+- `0.0` = minimally aware
+- `1.0` = maximally aware
 
-Current V1 semantics:
+Current V1 use:
 
-- Used by the green scheduler when choosing which persona reacts in the
-  `small_llm` backend.
-- Higher awareness makes a persona more likely to be selected as the reporter.
-- Higher awareness also makes recovery actions more likely once a malicious
-  event has been observed.
+- Used by the `small_llm` green backend when choosing who reacts to a malicious
+  event.
+- Higher awareness also makes recovery actions more likely after detection.
 
 ### `susceptibility`
 
-`susceptibility` is a map from label to probability-like score.
+Map from label to score.
 
-- `0.0` means minimally susceptible for that label.
-- `1.0` means maximally susceptible for that label.
 - Keys are free-form strings at the schema level.
+- `0.0` = minimally susceptible
+- `1.0` = maximally susceptible
 
-Recommended stable keys for V1:
+Recommended V1 keys:
 
 - `initial_access`
 - `credential_obtained`
 - `unauthorized_credential_use`
 
-Current V1 semantics:
+Current V1 use:
 
-- The `small_llm` green backend first looks up the event-style key associated
-  with the observed malicious event.
-- If that exact key is missing, it falls back to the maximum value in the map.
-- Other backends currently do not use `susceptibility` directly.
-
-Implication:
-
-- Free-form labels such as `phishing`, `pretexting`, or `spear_phishing` are
-  accepted and preserved in the manifest and `WorldIR`.
-- For predictable runtime behavior today, prefer the event-style keys above.
+- The `small_llm` green backend looks up the event-style key first.
+- If that key is missing, it falls back to the maximum value in the map.
 
 ### `routine`
 
-`routine` is an ordered list of benign activities for that role.
+Ordered list of benign activities for the role.
 
-Current V1 semantics:
-
-- The green scheduler cycles through the list over time.
-- Each token is interpreted heuristically into a service target.
-- The order matters because the scheduler advances through the list.
-
-Recommended stable routine tokens for V1:
+Recommended V1 tokens:
 
 - `check_mail`
 - `browse_app`
@@ -127,35 +97,7 @@ Current service mapping:
 - tokens containing `payroll` -> database
 - everything else -> web app
 
-## Compiler Rules
+## Current Scope
 
-At compile time:
-
-- OpenRange validates that every `npc_profiles` key exists in `users.roles`.
-- A role profile is applied uniformly to all generated users for that role.
-- A profile only overrides fields that are explicitly set.
-- Omitted fields keep the same defaults as before the feature was added.
-
-## What This Covers Today
-
-`npc_profiles` is useful today for:
-
-- coarse role-level benign routine shaping
-- coarse role-level green reaction weighting in the `small_llm` backend
-- reproducible manifest-authored variation across snapshots
-
-## What This Does Not Cover Yet
-
-`npc_profiles` does not yet provide:
-
-- per-individual overrides within a role
-- an explicit click-through model for phishing links or attachments
-- a first-class taxonomy of social-engineering technique keys
-- uniform `susceptibility` semantics across all green backends
-- explicit policies for escalation, ticketing, or reporting thresholds beyond
-  the current scheduler heuristics
-
-If V1 needs "careless reps click every lure" or "admins report every anomaly"
-as first-class scenario semantics, the next step should be a dedicated NPC
-behavior model with explicit pre-compromise and post-compromise controls rather
-than relying only on the current `awareness` and `susceptibility` heuristics.
+This feature provides role-level routine and reaction shaping. It does not yet
+add per-user overrides, NPC memory, daily planning, or a richer social model.

--- a/manifests/tier1_basic.yaml
+++ b/manifests/tier1_basic.yaml
@@ -32,6 +32,35 @@ users:
     finance: 1
     it_admin: 1
 
+npc_profiles:
+  sales:
+    awareness: 0.2
+    susceptibility:
+      initial_access: 0.8
+      credential_obtained: 0.7
+    routine:
+      - check_mail
+      - browse_app
+      - access_fileshare
+  engineer:
+    awareness: 0.65
+    susceptibility:
+      initial_access: 0.4
+      credential_obtained: 0.3
+    routine:
+      - browse_app
+      - check_mail
+      - access_fileshare
+  it_admin:
+    awareness: 0.9
+    susceptibility:
+      credential_obtained: 0.2
+      unauthorized_credential_use: 0.1
+    routine:
+      - review_idp
+      - triage_alerts
+      - reset_password
+
 assets:
   - id: finance_docs
     class: crown_jewel

--- a/schemas/manifest.schema.json
+++ b/schemas/manifest.schema.json
@@ -115,6 +115,51 @@
       "title": "MutationBounds",
       "type": "object"
     },
+    "NPCProfileSpec": {
+      "additionalProperties": false,
+      "properties": {
+        "awareness": {
+          "anyOf": [
+            {
+              "maximum": 1.0,
+              "minimum": 0.0,
+              "type": "number"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "title": "Awareness"
+        },
+        "routine": {
+          "anyOf": [
+            {
+              "items": {
+                "type": "string"
+              },
+              "type": "array"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "title": "Routine"
+        },
+        "susceptibility": {
+          "additionalProperties": {
+            "maximum": 1.0,
+            "minimum": 0.0,
+            "type": "number"
+          },
+          "title": "Susceptibility",
+          "type": "object"
+        }
+      },
+      "title": "NPCProfileSpec",
+      "type": "object"
+    },
     "ObjectivePredicate": {
       "additionalProperties": false,
       "properties": {
@@ -353,6 +398,13 @@
     },
     "mutation_bounds": {
       "$ref": "#/$defs/MutationBounds"
+    },
+    "npc_profiles": {
+      "additionalProperties": {
+        "$ref": "#/$defs/NPCProfileSpec"
+      },
+      "title": "Npc Profiles",
+      "type": "object"
     },
     "objectives": {
       "$ref": "#/$defs/ObjectiveSet"

--- a/src/open_range/_resources/docs/npc-profiles.md
+++ b/src/open_range/_resources/docs/npc-profiles.md
@@ -1,0 +1,161 @@
+# NPC Profile Spec
+
+This document defines the public manifest contract for role-level green-user
+behavior in OpenRange V1.
+
+`npc_profiles` is a public business-world input. It shapes generated
+`GreenPersona` objects without exposing private validator references or hidden
+weakness inventory.
+
+## Goals
+
+- Let manifest authors vary role-level NPC behavior without editing Python code.
+- Keep the contract backward compatible with existing manifests.
+- Make the current semantics explicit so newcomers do not need to read the
+  compiler or runtime to use the feature safely.
+
+## Manifest Shape
+
+`npc_profiles` is an optional top-level manifest field.
+
+```yaml
+users:
+  roles:
+    sales: 2
+    engineer: 1
+    it_admin: 1
+
+npc_profiles:
+  sales:
+    awareness: 0.2
+    susceptibility:
+      initial_access: 0.8
+      credential_obtained: 0.7
+    routine:
+      - check_mail
+      - browse_app
+      - access_fileshare
+  it_admin:
+    awareness: 0.9
+    susceptibility:
+      unauthorized_credential_use: 0.2
+    routine:
+      - review_idp
+      - triage_alerts
+      - reset_password
+```
+
+Rules:
+
+- `npc_profiles` is optional. Omitting it preserves current compiler behavior.
+- Keys MUST match names declared in `users.roles`.
+- All fields are optional. Omitted fields fall back to the existing compiler
+  defaults for that role.
+- Profiles apply per role, not per individual user.
+- `awareness` and all `susceptibility` values must be between `0.0` and `1.0`.
+
+## Field Definitions
+
+### `awareness`
+
+`awareness` is a normalized caution score.
+
+- `0.0` means minimally aware.
+- `1.0` means maximally aware.
+
+Current V1 semantics:
+
+- Used by the green scheduler when choosing which persona reacts in the
+  `small_llm` backend.
+- Higher awareness makes a persona more likely to be selected as the reporter.
+- Higher awareness also makes recovery actions more likely once a malicious
+  event has been observed.
+
+### `susceptibility`
+
+`susceptibility` is a map from label to probability-like score.
+
+- `0.0` means minimally susceptible for that label.
+- `1.0` means maximally susceptible for that label.
+- Keys are free-form strings at the schema level.
+
+Recommended stable keys for V1:
+
+- `initial_access`
+- `credential_obtained`
+- `unauthorized_credential_use`
+
+Current V1 semantics:
+
+- The `small_llm` green backend first looks up the event-style key associated
+  with the observed malicious event.
+- If that exact key is missing, it falls back to the maximum value in the map.
+- Other backends currently do not use `susceptibility` directly.
+
+Implication:
+
+- Free-form labels such as `phishing`, `pretexting`, or `spear_phishing` are
+  accepted and preserved in the manifest and `WorldIR`.
+- For predictable runtime behavior today, prefer the event-style keys above.
+
+### `routine`
+
+`routine` is an ordered list of benign activities for that role.
+
+Current V1 semantics:
+
+- The green scheduler cycles through the list over time.
+- Each token is interpreted heuristically into a service target.
+- The order matters because the scheduler advances through the list.
+
+Recommended stable routine tokens for V1:
+
+- `check_mail`
+- `browse_app`
+- `access_fileshare`
+- `open_payroll_dashboard`
+- `review_idp`
+- `triage_alerts`
+- `reset_password`
+
+Current service mapping:
+
+- tokens containing `mail` -> email
+- tokens containing `file` or `share` -> fileshare
+- tokens containing `idp` or `password` -> IDP
+- tokens containing `alert` or `triage` -> SIEM
+- tokens containing `payroll` -> database
+- everything else -> web app
+
+## Compiler Rules
+
+At compile time:
+
+- OpenRange validates that every `npc_profiles` key exists in `users.roles`.
+- A role profile is applied uniformly to all generated users for that role.
+- A profile only overrides fields that are explicitly set.
+- Omitted fields keep the same defaults as before the feature was added.
+
+## What This Covers Today
+
+`npc_profiles` is useful today for:
+
+- coarse role-level benign routine shaping
+- coarse role-level green reaction weighting in the `small_llm` backend
+- reproducible manifest-authored variation across snapshots
+
+## What This Does Not Cover Yet
+
+`npc_profiles` does not yet provide:
+
+- per-individual overrides within a role
+- an explicit click-through model for phishing links or attachments
+- a first-class taxonomy of social-engineering technique keys
+- uniform `susceptibility` semantics across all green backends
+- explicit policies for escalation, ticketing, or reporting thresholds beyond
+  the current scheduler heuristics
+
+If V1 needs "careless reps click every lure" or "admins report every anomaly"
+as first-class scenario semantics, the next step should be a dedicated NPC
+behavior model with explicit pre-compromise and post-compromise controls rather
+than relying only on the current `awareness` and `susceptibility` heuristics.

--- a/src/open_range/_resources/docs/npc-profiles.md
+++ b/src/open_range/_resources/docs/npc-profiles.md
@@ -1,22 +1,7 @@
 # NPC Profile Spec
 
-This document defines the public manifest contract for role-level green-user
-behavior in OpenRange V1.
-
-`npc_profiles` is a public business-world input. It shapes generated
-`GreenPersona` objects without exposing private validator references or hidden
-weakness inventory.
-
-## Goals
-
-- Let manifest authors vary role-level NPC behavior without editing Python code.
-- Keep the contract backward compatible with existing manifests.
-- Make the current semantics explicit so newcomers do not need to read the
-  compiler or runtime to use the feature safely.
-
-## Manifest Shape
-
-`npc_profiles` is an optional top-level manifest field.
+`npc_profiles` is an optional top-level manifest field for role-level green-user
+behavior.
 
 ```yaml
 users:
@@ -45,70 +30,55 @@ npc_profiles:
       - reset_password
 ```
 
-Rules:
+## Rules
 
-- `npc_profiles` is optional. Omitting it preserves current compiler behavior.
-- Keys MUST match names declared in `users.roles`.
-- All fields are optional. Omitted fields fall back to the existing compiler
-  defaults for that role.
-- Profiles apply per role, not per individual user.
+- `npc_profiles` is optional.
+- Keys must match names declared in `users.roles`.
+- All fields are optional.
+- Omitting `npc_profiles` or setting it to `{}` preserves the pre-existing
+  compiler behavior.
 - `awareness` and all `susceptibility` values must be between `0.0` and `1.0`.
+- Profiles apply per role, not per individual user.
 
-## Field Definitions
+## Fields
 
 ### `awareness`
 
-`awareness` is a normalized caution score.
+Normalized caution score.
 
-- `0.0` means minimally aware.
-- `1.0` means maximally aware.
+- `0.0` = minimally aware
+- `1.0` = maximally aware
 
-Current V1 semantics:
+Current V1 use:
 
-- Used by the green scheduler when choosing which persona reacts in the
-  `small_llm` backend.
-- Higher awareness makes a persona more likely to be selected as the reporter.
-- Higher awareness also makes recovery actions more likely once a malicious
-  event has been observed.
+- Used by the `small_llm` green backend when choosing who reacts to a malicious
+  event.
+- Higher awareness also makes recovery actions more likely after detection.
 
 ### `susceptibility`
 
-`susceptibility` is a map from label to probability-like score.
+Map from label to score.
 
-- `0.0` means minimally susceptible for that label.
-- `1.0` means maximally susceptible for that label.
 - Keys are free-form strings at the schema level.
+- `0.0` = minimally susceptible
+- `1.0` = maximally susceptible
 
-Recommended stable keys for V1:
+Recommended V1 keys:
 
 - `initial_access`
 - `credential_obtained`
 - `unauthorized_credential_use`
 
-Current V1 semantics:
+Current V1 use:
 
-- The `small_llm` green backend first looks up the event-style key associated
-  with the observed malicious event.
-- If that exact key is missing, it falls back to the maximum value in the map.
-- Other backends currently do not use `susceptibility` directly.
-
-Implication:
-
-- Free-form labels such as `phishing`, `pretexting`, or `spear_phishing` are
-  accepted and preserved in the manifest and `WorldIR`.
-- For predictable runtime behavior today, prefer the event-style keys above.
+- The `small_llm` green backend looks up the event-style key first.
+- If that key is missing, it falls back to the maximum value in the map.
 
 ### `routine`
 
-`routine` is an ordered list of benign activities for that role.
+Ordered list of benign activities for the role.
 
-Current V1 semantics:
-
-- The green scheduler cycles through the list over time.
-- Each token is interpreted heuristically into a service target.
-- The order matters because the scheduler advances through the list.
-
-Recommended stable routine tokens for V1:
+Recommended V1 tokens:
 
 - `check_mail`
 - `browse_app`
@@ -127,35 +97,7 @@ Current service mapping:
 - tokens containing `payroll` -> database
 - everything else -> web app
 
-## Compiler Rules
+## Current Scope
 
-At compile time:
-
-- OpenRange validates that every `npc_profiles` key exists in `users.roles`.
-- A role profile is applied uniformly to all generated users for that role.
-- A profile only overrides fields that are explicitly set.
-- Omitted fields keep the same defaults as before the feature was added.
-
-## What This Covers Today
-
-`npc_profiles` is useful today for:
-
-- coarse role-level benign routine shaping
-- coarse role-level green reaction weighting in the `small_llm` backend
-- reproducible manifest-authored variation across snapshots
-
-## What This Does Not Cover Yet
-
-`npc_profiles` does not yet provide:
-
-- per-individual overrides within a role
-- an explicit click-through model for phishing links or attachments
-- a first-class taxonomy of social-engineering technique keys
-- uniform `susceptibility` semantics across all green backends
-- explicit policies for escalation, ticketing, or reporting thresholds beyond
-  the current scheduler heuristics
-
-If V1 needs "careless reps click every lure" or "admins report every anomaly"
-as first-class scenario semantics, the next step should be a dedicated NPC
-behavior model with explicit pre-compromise and post-compromise controls rather
-than relying only on the current `awareness` and `susceptibility` heuristics.
+This feature provides role-level routine and reaction shaping. It does not yet
+add per-user overrides, NPC memory, daily planning, or a richer social model.

--- a/src/open_range/_resources/manifests/tier1_basic.yaml
+++ b/src/open_range/_resources/manifests/tier1_basic.yaml
@@ -32,6 +32,35 @@ users:
     finance: 1
     it_admin: 1
 
+npc_profiles:
+  sales:
+    awareness: 0.2
+    susceptibility:
+      initial_access: 0.8
+      credential_obtained: 0.7
+    routine:
+      - check_mail
+      - browse_app
+      - access_fileshare
+  engineer:
+    awareness: 0.65
+    susceptibility:
+      initial_access: 0.4
+      credential_obtained: 0.3
+    routine:
+      - browse_app
+      - check_mail
+      - access_fileshare
+  it_admin:
+    awareness: 0.9
+    susceptibility:
+      credential_obtained: 0.2
+      unauthorized_credential_use: 0.1
+    routine:
+      - review_idp
+      - triage_alerts
+      - reset_password
+
 assets:
   - id: finance_docs
     class: crown_jewel

--- a/src/open_range/_resources/schemas/manifest.schema.json
+++ b/src/open_range/_resources/schemas/manifest.schema.json
@@ -115,6 +115,51 @@
       "title": "MutationBounds",
       "type": "object"
     },
+    "NPCProfileSpec": {
+      "additionalProperties": false,
+      "properties": {
+        "awareness": {
+          "anyOf": [
+            {
+              "maximum": 1.0,
+              "minimum": 0.0,
+              "type": "number"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "title": "Awareness"
+        },
+        "routine": {
+          "anyOf": [
+            {
+              "items": {
+                "type": "string"
+              },
+              "type": "array"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "title": "Routine"
+        },
+        "susceptibility": {
+          "additionalProperties": {
+            "maximum": 1.0,
+            "minimum": 0.0,
+            "type": "number"
+          },
+          "title": "Susceptibility",
+          "type": "object"
+        }
+      },
+      "title": "NPCProfileSpec",
+      "type": "object"
+    },
     "ObjectivePredicate": {
       "additionalProperties": false,
       "properties": {
@@ -353,6 +398,13 @@
     },
     "mutation_bounds": {
       "$ref": "#/$defs/MutationBounds"
+    },
+    "npc_profiles": {
+      "additionalProperties": {
+        "$ref": "#/$defs/NPCProfileSpec"
+      },
+      "title": "Npc Profiles",
+      "type": "object"
     },
     "objectives": {
       "$ref": "#/$defs/ObjectiveSet"

--- a/src/open_range/compiler.py
+++ b/src/open_range/compiler.py
@@ -5,7 +5,12 @@ from __future__ import annotations
 from typing import Protocol
 
 from open_range.build_config import BuildConfig, DEFAULT_BUILD_CONFIG
-from open_range.manifest import EnterpriseSaaSManifest, ManifestAsset, validate_manifest
+from open_range.manifest import (
+    EnterpriseSaaSManifest,
+    ManifestAsset,
+    NPCProfileSpec,
+    validate_manifest,
+)
 from open_range.objectives import objective_tags_for_predicate
 from open_range.predicate_expr import predicate_inner
 from open_range.world_ir import (
@@ -116,6 +121,7 @@ class EnterpriseSaaSManifestCompiler:
             raise ValueError(
                 f"build_config.world_family={build_config.world_family!r} does not match manifest world_family={parsed.world_family!r}"
             )
+        self._validate_npc_profiles(parsed)
         service_names = self._selected_services(parsed, build_config)
         workflow_names = self._selected_workflows(parsed, build_config)
         allowed_families = self._selected_weakness_families(parsed, build_config)
@@ -388,13 +394,13 @@ class EnterpriseSaaSManifestCompiler:
                     )
                 )
                 personas.append(
-                    GreenPersona(
+                    self._persona_for_user(
                         id=user_id,
                         role=role,
                         department=role,
                         home_host=home_host,
                         mailbox=f"{user_id}@corp.local",
-                        routine=self._routine_for_role(role),
+                        profile=manifest.npc_profiles.get(role),
                     )
                 )
             groups.append(
@@ -543,6 +549,48 @@ class EnterpriseSaaSManifestCompiler:
             if layout["service_id"] == service_id:
                 return layout["host_id"]
         return "web-1"
+
+    @classmethod
+    def _validate_npc_profiles(cls, manifest: EnterpriseSaaSManifest) -> None:
+        if not manifest.npc_profiles:
+            return
+        declared_roles = set(manifest.users.roles)
+        unknown_roles = sorted(set(manifest.npc_profiles) - declared_roles)
+        if not unknown_roles:
+            return
+        declared = ", ".join(sorted(declared_roles))
+        unknown = ", ".join(repr(role) for role in unknown_roles)
+        raise ValueError(
+            f"npc_profiles references unknown role(s): {unknown}; declared manifest roles: {declared}"
+        )
+
+    @classmethod
+    def _persona_for_user(
+        cls,
+        *,
+        id: str,
+        role: str,
+        department: str,
+        home_host: str,
+        mailbox: str,
+        profile: NPCProfileSpec | None,
+    ) -> GreenPersona:
+        persona = GreenPersona(
+            id=id,
+            role=role,
+            department=department,
+            home_host=home_host,
+            mailbox=mailbox,
+            routine=cls._routine_for_role(role),
+        )
+        if profile is None:
+            return persona
+        updates = {"susceptibility": profile.susceptibility}
+        if profile.awareness is not None:
+            updates["awareness"] = profile.awareness
+        if profile.routine is not None:
+            updates["routine"] = profile.routine
+        return persona.model_copy(update=updates)
 
     @staticmethod
     def _routine_for_role(role: str) -> tuple[str, ...]:

--- a/src/open_range/green.py
+++ b/src/open_range/green.py
@@ -10,6 +10,7 @@ from typing import Any, Protocol
 from open_range.episode_config import EpisodeConfig
 from open_range.runtime_types import Action, RuntimeEvent
 from open_range.snapshot import RuntimeSnapshot
+from open_range.world_ir import GreenPersona
 
 
 class GreenScheduler(Protocol):
@@ -191,7 +192,11 @@ class ScriptedGreenScheduler:
         reporter = max(
             personas,
             key=lambda persona: (
-                round(persona.awareness - (persona.susceptibility * 0.4), 4),
+                round(
+                    persona.awareness
+                    - (self._susceptibility_score(persona, event) * 0.4),
+                    4,
+                ),
                 persona.id,
             ),
         )
@@ -205,10 +210,21 @@ class ScriptedGreenScheduler:
         if event.event_type in {
             "CredentialObtained",
             "UnauthorizedCredentialUse",
-        } and reporter.awareness >= (reporter.susceptibility * 0.8):
+        } and reporter.awareness >= (
+            self._susceptibility_score(reporter, event) * 0.8
+        ):
             self._reactive_queue[llm_slot].append(
                 self._recover_action(reporter.id, event.target_entity)
             )
+
+    @staticmethod
+    def _susceptibility_score(persona: GreenPersona, event: RuntimeEvent) -> float:
+        if not persona.susceptibility:
+            return 0.0
+        event_key = _event_susceptibility_key(event.event_type)
+        if event_key in persona.susceptibility:
+            return persona.susceptibility[event_key]
+        return max(persona.susceptibility.values())
 
     def _schedule_workflow_orchestrator_reaction(
         self, event: RuntimeEvent, personas: list[Any], slot: int
@@ -285,3 +301,17 @@ def _routine_service(routine: str) -> str:
     if "payroll" in lowered:
         return "svc-db"
     return "svc-web"
+
+
+def _event_susceptibility_key(event_type: str) -> str:
+    chunks: list[str] = []
+    token: list[str] = []
+    for char in event_type:
+        if char.isupper() and token:
+            chunks.append("".join(token).lower())
+            token = [char]
+            continue
+        token.append(char)
+    if token:
+        chunks.append("".join(token).lower())
+    return "_".join(chunks)

--- a/src/open_range/green.py
+++ b/src/open_range/green.py
@@ -210,9 +210,7 @@ class ScriptedGreenScheduler:
         if event.event_type in {
             "CredentialObtained",
             "UnauthorizedCredentialUse",
-        } and reporter.awareness >= (
-            self._susceptibility_score(reporter, event) * 0.8
-        ):
+        } and reporter.awareness >= (self._susceptibility_score(reporter, event) * 0.8):
             self._reactive_queue[llm_slot].append(
                 self._recover_action(reporter.id, event.target_entity)
             )

--- a/src/open_range/manifest.py
+++ b/src/open_range/manifest.py
@@ -6,7 +6,7 @@ public and must not encode a golden path, literal exploit steps, or flag paths.
 
 from __future__ import annotations
 
-from typing import Literal
+from typing import Annotated, Literal
 
 from pydantic import BaseModel, ConfigDict, Field, PositiveInt, model_validator
 
@@ -94,6 +94,7 @@ SupportedWeaknessKind = Literal[
 NoiseDensity = Literal["low", "medium", "high"]
 AssetClass = Literal["crown_jewel", "sensitive", "operational"]
 WeaknessTargetKind = Literal["service", "workflow", "asset", "credential", "telemetry"]
+Probability = Annotated[float, Field(ge=0.0, le=1.0)]
 
 WEAKNESS_KIND_CATALOG: dict[WeaknessFamily, tuple[str, ...]] = {
     "code_web": (
@@ -147,6 +148,12 @@ class TopologySpec(_StrictModel):
 
 class UserRoleSpec(_StrictModel):
     roles: dict[str, PositiveInt] = Field(default_factory=dict, min_length=1)
+
+
+class NPCProfileSpec(_StrictModel):
+    awareness: float | None = Field(default=None, ge=0.0, le=1.0)
+    susceptibility: dict[str, Probability] = Field(default_factory=dict)
+    routine: tuple[str, ...] | None = None
 
 
 class ManifestAsset(_StrictModel):
@@ -249,6 +256,7 @@ class EnterpriseSaaSManifest(_StrictModel):
     business: BusinessSpec
     topology: TopologySpec
     users: UserRoleSpec
+    npc_profiles: dict[str, NPCProfileSpec] = Field(default_factory=dict)
     assets: tuple[ManifestAsset, ...] = Field(default_factory=tuple, min_length=1)
     objectives: ObjectiveSet
     security: SecuritySpec

--- a/tests/test_compiler.py
+++ b/tests/test_compiler.py
@@ -1,5 +1,7 @@
 from __future__ import annotations
 
+import pytest
+
 from open_range.compiler import EnterpriseSaaSManifestCompiler
 from tests.support import manifest_payload
 
@@ -102,3 +104,44 @@ def test_compiler_threads_pinned_weaknesses_into_world():
     assert world.pinned_weaknesses[0].family == "secret_exposure"
     assert world.pinned_weaknesses[0].kind == "credential_in_share"
     assert world.pinned_weaknesses[0].target == "asset:finance_docs"
+
+
+def test_compiler_applies_partial_npc_profile_overrides_and_keeps_defaults():
+    payload = _manifest_payload()
+    payload["npc_profiles"] = {
+        "sales": {
+            "awareness": 0.25,
+        }
+    }
+
+    world = EnterpriseSaaSManifestCompiler().compile(payload)
+
+    sales_personas = [
+        persona for persona in world.green_personas if persona.role == "sales"
+    ]
+
+    assert sales_personas
+    assert all(persona.awareness == 0.25 for persona in sales_personas)
+    assert all(persona.susceptibility == {} for persona in sales_personas)
+    assert all(
+        persona.routine == ("check_mail", "browse_app", "access_fileshare")
+        for persona in sales_personas
+    )
+
+
+def test_compiler_treats_empty_npc_profiles_as_noop():
+    baseline = EnterpriseSaaSManifestCompiler().compile(_manifest_payload())
+    payload = _manifest_payload()
+    payload["npc_profiles"] = {}
+
+    world = EnterpriseSaaSManifestCompiler().compile(payload)
+
+    assert world.green_personas == baseline.green_personas
+
+
+def test_compiler_rejects_npc_profiles_for_unknown_roles():
+    payload = _manifest_payload()
+    payload["npc_profiles"] = {"legal": {"awareness": 0.5}}
+
+    with pytest.raises(ValueError, match="npc_profiles references unknown role"):
+        EnterpriseSaaSManifestCompiler().compile(payload)

--- a/tests/test_configs.py
+++ b/tests/test_configs.py
@@ -76,6 +76,38 @@ def test_build_config_can_filter_services_without_touching_manifest_schema(
     assert candidate.world.allowed_service_kinds == ("web_app", "idp", "siem")
 
 
+def test_build_pipeline_threads_manifest_npc_profiles_into_personas(tmp_path: Path):
+    pipeline = BuildPipeline(store=FileSnapshotStore(tmp_path / "snapshots"))
+    payload = _manifest_payload()
+    payload["npc_profiles"] = {
+        "sales": {
+            "awareness": 0.15,
+            "susceptibility": {"phishing": 0.85, "pretexting": 0.55},
+            "routine": ["check_mail", "browse_app"],
+        }
+    }
+
+    candidate = pipeline.build(
+        payload,
+        tmp_path / "rendered-npc-profiles",
+        BuildConfig(validation_profile="graph_only"),
+    )
+
+    sales_personas = [
+        persona for persona in candidate.world.green_personas if persona.role == "sales"
+    ]
+
+    assert sales_personas
+    assert all(persona.awareness == 0.15 for persona in sales_personas)
+    assert all(
+        persona.susceptibility == {"phishing": 0.85, "pretexting": 0.55}
+        for persona in sales_personas
+    )
+    assert all(
+        persona.routine == ("check_mail", "browse_app") for persona in sales_personas
+    )
+
+
 def test_manifest_accepts_standard_attack_objectives_and_rejects_unknown_predicates() -> (
     None
 ):

--- a/tests/test_package_resources.py
+++ b/tests/test_package_resources.py
@@ -41,4 +41,4 @@ def test_bundled_docs_are_readable():
     assert "Python control plane" in contents
     assert "Blue has two distinct control actions" in weakness_contents
     assert "NPC Profile Spec" in npc_contents
-    assert "What This Does Not Cover Yet" in npc_contents
+    assert "Current Scope" in npc_contents

--- a/tests/test_package_resources.py
+++ b/tests/test_package_resources.py
@@ -36,6 +36,9 @@ def test_bundled_schemas_match_checked_in_schemas():
 def test_bundled_docs_are_readable():
     contents = load_bundled_doc("architecture.md")
     weakness_contents = load_bundled_doc("weakness-lifecycle.md")
+    npc_contents = load_bundled_doc("npc-profiles.md")
 
     assert "Python control plane" in contents
     assert "Blue has two distinct control actions" in weakness_contents
+    assert "NPC Profile Spec" in npc_contents
+    assert "What This Does Not Cover Yet" in npc_contents

--- a/tests/test_runtime.py
+++ b/tests/test_runtime.py
@@ -11,10 +11,11 @@ from open_range.cluster import ExecResult
 from open_range.code_web import code_web_payload
 from open_range.compiler import EnterpriseSaaSManifestCompiler
 from open_range.episode_config import EpisodeConfig
+from open_range.green import ScriptedGreenScheduler
 from open_range.execution import PodActionBackend
 from open_range.render import EnterpriseSaaSKindRenderer
 from open_range.runtime import ReferenceDrivenRuntime
-from open_range.runtime_types import Action
+from open_range.runtime_types import Action, RuntimeEvent
 from open_range.store import FileSnapshotStore
 from open_range.synth import EnterpriseSaaSWorldSynthesizer
 from open_range.weaknesses import CatalogWeaknessSeeder
@@ -793,3 +794,59 @@ def test_green_branch_backends_are_not_aliases(tmp_path: Path):
     assert any(
         event.event_type == "RecoveryCompleted" for event in orchestrated_green_events
     )
+
+
+def test_small_llm_green_branch_handles_profiled_susceptibility_maps(tmp_path: Path):
+    payload = _manifest_payload()
+    payload["npc_profiles"] = {
+        "sales": {
+            "awareness": 0.9,
+            "susceptibility": {"credential_obtained": 0.8, "phishing": 0.6},
+        }
+    }
+    world = CatalogWeaknessSeeder().apply(
+        EnterpriseSaaSManifestCompiler().compile(payload)
+    )
+    synth = EnterpriseSaaSWorldSynthesizer().synthesize(
+        world, tmp_path / "synth-small-llm"
+    )
+    artifacts = EnterpriseSaaSKindRenderer().render(
+        world, synth, tmp_path / "rendered-small-llm"
+    )
+    reference_bundle, report = LocalAdmissionController(mode="fail_fast").admit(
+        world, artifacts, OFFLINE_BUILD_CONFIG
+    )
+    store = FileSnapshotStore(tmp_path / "snapshots-small-llm")
+    snapshot = hydrate_runtime_snapshot(
+        store, store.create(world, artifacts, reference_bundle, report, synth=synth)
+    )
+
+    scheduler = ScriptedGreenScheduler()
+    scheduler.reset(
+        snapshot,
+        EpisodeConfig(
+            mode="joint_pool",
+            green_enabled=True,
+            green_routine_enabled=False,
+            green_branch_backend="small_llm",
+        ),
+    )
+    scheduler.record_event(
+        RuntimeEvent(
+            id="evt-1",
+            event_type="CredentialObtained",
+            actor="red",
+            time=0.0,
+            source_entity="svc-web",
+            target_entity="idp_admin_cred",
+            malicious=True,
+        )
+    )
+    scheduler.advance_until(1.0)
+    actions = scheduler.pop_ready_actions()
+
+    assert any(
+        action.payload.get("branch") == "report_suspicious_activity"
+        for action in actions
+    )
+    assert any(action.payload.get("branch") == "reset_password" for action in actions)

--- a/tests/test_schemas.py
+++ b/tests/test_schemas.py
@@ -95,6 +95,25 @@ def test_manifest_accepts_pinned_weaknesses():
     )
 
 
+def test_manifest_schema_round_trip_supports_npc_profiles():
+    payload = _manifest_payload()
+    payload["npc_profiles"] = {
+        "sales": {
+            "awareness": 0.2,
+            "susceptibility": {"phishing": 0.8},
+            "routine": ["check_mail", "browse_app"],
+        }
+    }
+
+    manifest = validate_manifest(payload)
+    round_tripped = EnterpriseSaaSManifest.model_validate(manifest.model_dump())
+    schema = EnterpriseSaaSManifest.model_json_schema()
+
+    assert round_tripped == manifest
+    assert "npc_profiles" in schema["properties"]
+    assert "NPCProfileSpec" in schema["$defs"]
+
+
 def test_manifest_rejects_pinned_kind_from_wrong_family():
     payload = _manifest_payload()
     payload["security"]["pinned_weaknesses"] = [


### PR DESCRIPTION
Closes #113

## Summary

- add optional manifest-level `npc_profiles` with strict schema validation and compile-time unknown-role rejection
- thread role-level NPC profile overrides into compiled personas, regenerate the manifest schema, add a bundled example manifest, and document the public contract
- preserve backward-compatible behavior when `npc_profiles` is omitted or empty

## Testing

- Manually exercised the bundled manifest/schema/doc surface, inspected compiled persona outputs, verified the explicit offline build/admit/store path preserves NPC profile values, and confirmed a concrete `small_llm` scheduler scenario uses the configured persona fields.

## Review Notes

Scoped to #113 only. This does not attempt the broader NPC behavior, memory, or planning work in #111.
