### PR TITLE
Add k3s-istio-vault-platform infrastructure integration

### DIFF
--- a/deploy/argocd/README.md
+++ b/deploy/argocd/README.md
@@ -1,0 +1,165 @@
+# Argo CD GitOps for open-range
+
+This directory contains everything needed to add Argo CD-based GitOps
+deployment to the open-range cybersecurity gymnasium.  GitOps support is
+**completely optional** -- the existing `build -> render -> deploy` CLI
+workflow continues to work unchanged.
+
+## Overview
+
+With GitOps enabled the deployment pipeline becomes:
+
+```
+build  ->  render  ->  publish (git commit)  ->  auto-deploy (Argo CD)
+```
+
+Rendered snapshot Helm charts are committed to a dedicated Git repository.
+Argo CD watches that repository and automatically reconciles each snapshot
+into a live Kubernetes range, handling creation, updates, and teardown.
+
+This is especially useful for RL training loops where rapid, automated
+environment turnover is required.
+
+## Quick start
+
+### 1. Install Argo CD
+
+```bash
+# From the repository root
+./deploy/argocd/bootstrap-argocd.sh
+```
+
+The script installs Argo CD via Helm into the `argocd` namespace using
+resource-light settings suitable for local k3d / Kind clusters.
+
+Access the UI:
+
+```bash
+kubectl port-forward svc/argocd-server -n argocd 8080:443
+# Open https://localhost:8080  (accept the self-signed cert)
+# Username: admin
+# Password: printed by the bootstrap script, or:
+kubectl -n argocd get secret argocd-initial-admin-secret -o jsonpath='{.data.password}' | base64 -d
+```
+
+### 2. Create the GitOps repository
+
+Create a Git repository that will hold rendered snapshot charts.  The
+publisher places each snapshot under `ranges/<snapshot-id>/`.
+
+```
+gitops-repo/
+  ranges/
+    tier1-web-app-abc123/
+      Chart.yaml
+      values.yaml
+      templates/
+        ...
+    tier2-lateral-move-def456/
+      Chart.yaml
+      values.yaml
+      templates/
+        ...
+```
+
+### 3. Configure environment variables
+
+```bash
+# Required
+export OPENRANGE_GITOPS_ENABLED=true
+export OPENRANGE_GITOPS_REPO_URL=https://github.com/your-org/openrange-gitops.git
+export OPENRANGE_GITOPS_BRANCH=main            # default: main
+export OPENRANGE_GITOPS_BASE_PATH=ranges       # default: ranges
+
+# Optional
+export OPENRANGE_GITOPS_WORK_DIR=/tmp/gitops   # default: auto temp dir
+export OPENRANGE_GITOPS_ARGOCD_NAMESPACE=argocd
+export OPENRANGE_GITOPS_SYNC_TIMEOUT=300
+export OPENRANGE_GITOPS_COMMIT_AUTHOR_NAME=open-range
+export OPENRANGE_GITOPS_COMMIT_AUTHOR_EMAIL=open-range@localhost
+```
+
+### 4. Publish a snapshot
+
+From Python (e.g. in a training loop):
+
+```python
+from open_range.server.gitops_publisher import GitOpsConfig, GitOpsPublisher
+
+config = GitOpsConfig.from_env()
+publisher = GitOpsPublisher.from_config(config)
+
+# After rendering a snapshot
+sha = await publisher.publish("tier1-web-app-abc123", Path("/tmp/rendered/tier1-web-app-abc123"))
+
+# Wait for Argo CD to deploy it
+healthy = await publisher.wait_for_sync("tier1-web-app-abc123", timeout=180)
+
+# When the episode is done, tear it down
+await publisher.unpublish("tier1-web-app-abc123")
+```
+
+## File reference
+
+| File | Purpose |
+|------|---------|
+| `bootstrap-argocd.sh` | Installs Argo CD via Helm into the cluster |
+| `argocd-values.yaml` | Helm values optimised for local dev (minimal resources, no HA) |
+| `snapshot-application.yaml.tpl` | Argo CD Application template for a single snapshot (envsubst) |
+| `src/open_range/server/gitops_publisher.py` | Python module for publishing snapshots to the GitOps repo |
+
+## Environment variables reference
+
+### Bootstrap script
+
+| Variable | Default | Description |
+|----------|---------|-------------|
+| `ARGOCD_NAMESPACE` | `argocd` | Kubernetes namespace for Argo CD |
+| `ARGOCD_CHART_VERSION` | `7.7.11` | Helm chart version |
+| `ARGOCD_ADMIN_PASSWORD` | auto-generated | Initial admin password |
+| `GITOPS_REPO_URL` | *(none)* | GitOps repo URL (enables root Application) |
+| `GITOPS_TARGET_REVISION` | `main` | Branch / tag to track |
+
+### GitOps publisher (`OPENRANGE_GITOPS_` prefix)
+
+| Variable | Default | Description |
+|----------|---------|-------------|
+| `ENABLED` | `false` | Master switch |
+| `REPO_URL` | *(none)* | GitOps repository clone URL |
+| `BRANCH` | `main` | Branch to push to |
+| `BASE_PATH` | `ranges` | Directory for snapshot charts |
+| `WORK_DIR` | *(temp)* | Local working copy path |
+| `ARGOCD_NAMESPACE` | `argocd` | Argo CD namespace |
+| `SYNC_TIMEOUT` | `300` | Seconds to wait for sync |
+| `COMMIT_AUTHOR_NAME` | `open-range` | Git commit author |
+| `COMMIT_AUTHOR_EMAIL` | `open-range@localhost` | Git commit email |
+
+## Integration with the training pipeline
+
+The `GitOpsPublisher` is designed to slot into the `ManagedSnapshotRuntime`
+training loop.  A typical integration:
+
+1. The runtime calls `builder.build()` to generate a snapshot spec.
+2. The renderer produces Helm chart artifacts in a local directory.
+3. If `OPENRANGE_GITOPS_ENABLED=true`, the publisher commits the artifacts
+   to the GitOps repo and waits for Argo CD to reconcile.
+4. The environment runs the training episode against the live range.
+5. After the episode, the publisher removes the snapshot from the GitOps
+   repo, and Argo CD prunes the resources.
+
+This replaces the direct `helm install` path with a declarative, auditable
+Git history of every range that was deployed.
+
+## Manually deploying a snapshot
+
+If you prefer not to use the Python publisher, you can deploy a snapshot
+manually using the Application template:
+
+```bash
+export SNAPSHOT_ID=my-snapshot
+export CHART_PATH=ranges/my-snapshot
+export GITOPS_REPO_URL=https://github.com/your-org/openrange-gitops.git
+export TARGET_REVISION=main
+
+envsubst < deploy/argocd/snapshot-application.yaml.tpl | kubectl apply -f -
+```

--- a/deploy/argocd/argocd-values.yaml
+++ b/deploy/argocd/argocd-values.yaml
@@ -1,0 +1,72 @@
+# Argo CD Helm values for open-range local dev clusters (k3d / Kind).
+#
+# Optimised for single-node local development -- minimal resource requests,
+# no HA, no Dex.  Based on k3s-istio-vault-platform argocd-values-k3d.yaml.
+
+controller:
+  replicas: 1
+  resources:
+    requests:
+      cpu: 100m
+      memory: 256Mi
+    limits:
+      memory: 512Mi
+
+repoServer:
+  replicas: 1
+  resources:
+    requests:
+      cpu: 50m
+      memory: 128Mi
+    limits:
+      memory: 256Mi
+
+server:
+  replicas: 1
+  autoscaling:
+    enabled: false
+  service:
+    type: ClusterIP
+  resources:
+    requests:
+      cpu: 50m
+      memory: 128Mi
+    limits:
+      memory: 256Mi
+
+applicationSet:
+  replicas: 1
+  resources:
+    requests:
+      cpu: 50m
+      memory: 64Mi
+    limits:
+      memory: 128Mi
+
+redis-ha:
+  enabled: false
+
+redis:
+  enabled: true
+  resources:
+    requests:
+      cpu: 50m
+      memory: 64Mi
+    limits:
+      memory: 128Mi
+
+dex:
+  enabled: false
+
+notifications:
+  enabled: false
+
+configs:
+  params:
+    # Serve the UI without TLS so port-forward / ingress can terminate TLS.
+    server.insecure: "true"
+  cm:
+    # Fast reconciliation for rapid range turnover during RL training.
+    timeout.reconciliation: 30s
+    # Allow the open-range Helm charts through without strict schema checks.
+    resource.exclusions: ""

--- a/deploy/argocd/bootstrap-argocd.sh
+++ b/deploy/argocd/bootstrap-argocd.sh
@@ -1,0 +1,109 @@
+#!/usr/bin/env sh
+# ---------------------------------------------------------------------------
+# Bootstrap Argo CD for open-range GitOps workflow.
+#
+# Adapted from k3s-istio-vault-platform/bootstrap/bootstrap-argocd.sh for the
+# open-range cybersecurity gymnasium.  Installs Argo CD via Helm into a local
+# k3d/Kind cluster and optionally creates a root Application pointing at the
+# GitOps repository that holds rendered snapshot charts.
+#
+# Configuration (environment variables):
+#   ARGOCD_NAMESPACE          - namespace for Argo CD        (default: argocd)
+#   ARGOCD_CHART_VERSION      - argo-cd Helm chart version   (default: 7.7.11)
+#   ARGOCD_ADMIN_PASSWORD     - initial admin password        (auto-generated)
+#   GITOPS_REPO_URL           - GitOps repository URL         (optional)
+#   GITOPS_TARGET_REVISION    - branch / tag to track         (default: main)
+#   ARGOCD_VALUES_FILE        - path to Helm values           (auto-detected)
+#   ROOT_APP_TEMPLATE         - path to root Application tpl  (auto-detected)
+# ---------------------------------------------------------------------------
+set -eu
+
+SCRIPT_DIR=$(CDPATH= cd -- "$(dirname -- "$0")" && pwd)
+
+# --- Defaults ---------------------------------------------------------------
+
+ARGOCD_NAMESPACE="${ARGOCD_NAMESPACE:-argocd}"
+ARGOCD_CHART_VERSION="${ARGOCD_CHART_VERSION:-7.7.11}"
+ARGOCD_VALUES_FILE="${ARGOCD_VALUES_FILE:-$SCRIPT_DIR/argocd-values.yaml}"
+ROOT_APP_TEMPLATE="${ROOT_APP_TEMPLATE:-$SCRIPT_DIR/snapshot-application.yaml.tpl}"
+GITOPS_TARGET_REVISION="${GITOPS_TARGET_REVISION:-main}"
+
+# --- Pre-flight checks ------------------------------------------------------
+
+if [ ! -f "$ARGOCD_VALUES_FILE" ]; then
+  echo "ERROR: missing Argo CD values file: $ARGOCD_VALUES_FILE" >&2
+  exit 1
+fi
+
+for cmd in helm kubectl; do
+  command -v "$cmd" >/dev/null 2>&1 || {
+    echo "ERROR: $cmd is required but not found in PATH" >&2
+    exit 1
+  }
+done
+
+# --- Install Argo CD --------------------------------------------------------
+
+echo "==> Creating namespace ${ARGOCD_NAMESPACE}"
+kubectl create namespace "$ARGOCD_NAMESPACE" --dry-run=client -o yaml | kubectl apply -f -
+
+echo "==> Adding Argo Helm repo"
+helm repo add argo https://argoproj.github.io/argo-helm >/dev/null
+helm repo update argo >/dev/null
+
+echo "==> Installing Argo CD ${ARGOCD_CHART_VERSION} into ${ARGOCD_NAMESPACE}"
+helm upgrade --install argocd argo/argo-cd \
+  --namespace "$ARGOCD_NAMESPACE" \
+  --create-namespace \
+  --version "$ARGOCD_CHART_VERSION" \
+  --values "$ARGOCD_VALUES_FILE" \
+  --set crds.install=true \
+  --wait
+
+# --- Wait for readiness -----------------------------------------------------
+
+echo "==> Waiting for argocd-server rollout"
+kubectl -n "$ARGOCD_NAMESPACE" rollout status deploy/argocd-server --timeout=5m
+
+# --- Set admin password (optional) ------------------------------------------
+
+if [ -n "${ARGOCD_ADMIN_PASSWORD:-}" ]; then
+  echo "==> Setting initial admin password"
+  BCRYPT_HASH=$(htpasswd -nbBC 10 "" "$ARGOCD_ADMIN_PASSWORD" | tr -d ':\n' | sed 's/$2y/$2a/')
+  kubectl -n "$ARGOCD_NAMESPACE" patch secret argocd-secret \
+    -p "{\"stringData\":{\"admin.password\":\"${BCRYPT_HASH}\",\"admin.passwordMtime\":\"$(date -u +%FT%TZ)\"}}" \
+    2>/dev/null || echo "  (htpasswd not available -- skipping password set)"
+else
+  echo "==> Retrieving auto-generated admin password"
+  ARGOCD_ADMIN_PASSWORD=$(kubectl -n "$ARGOCD_NAMESPACE" get secret argocd-initial-admin-secret \
+    -o jsonpath='{.data.password}' 2>/dev/null | base64 -d) || true
+  if [ -n "$ARGOCD_ADMIN_PASSWORD" ]; then
+    echo "  Admin password: $ARGOCD_ADMIN_PASSWORD"
+  fi
+fi
+
+# --- Create root Application (optional) ------------------------------------
+
+if [ -n "${GITOPS_REPO_URL:-}" ]; then
+  if [ ! -f "$ROOT_APP_TEMPLATE" ]; then
+    echo "WARNING: GITOPS_REPO_URL set but root Application template not found: $ROOT_APP_TEMPLATE" >&2
+    echo "  Skipping root Application creation."
+  else
+    command -v envsubst >/dev/null 2>&1 || {
+      echo "WARNING: envsubst not found -- skipping root Application creation" >&2
+      exit 0
+    }
+    echo "==> Creating root Application from ${ROOT_APP_TEMPLATE}"
+    export GITOPS_REPO_URL GITOPS_TARGET_REVISION ARGOCD_NAMESPACE
+    envsubst < "$ROOT_APP_TEMPLATE" | kubectl apply -f -
+  fi
+else
+  echo "==> GITOPS_REPO_URL not set -- skipping root Application creation"
+  echo "  Set GITOPS_REPO_URL and re-run, or apply snapshot Applications manually."
+fi
+
+echo ""
+echo "==> Argo CD bootstrap complete."
+echo "  Namespace : ${ARGOCD_NAMESPACE}"
+echo "  UI        : kubectl port-forward svc/argocd-server -n ${ARGOCD_NAMESPACE} 8080:443"
+echo "  Login     : argocd login localhost:8080 --username admin --password <password>"

--- a/deploy/argocd/snapshot-application.yaml.tpl
+++ b/deploy/argocd/snapshot-application.yaml.tpl
@@ -1,0 +1,49 @@
+# Argo CD Application for an open-range rendered snapshot.
+#
+# This template is processed with envsubst.  Required variables:
+#   SNAPSHOT_ID         - unique identifier for the snapshot (e.g. "tier1-web-app-1a2b3c")
+#   CHART_PATH          - path inside the GitOps repo to the rendered Helm chart
+#   GITOPS_REPO_URL     - URL of the GitOps repository
+#   TARGET_REVISION     - branch / tag / commit to track (e.g. "main")
+#
+# Optional variables:
+#   ARGOCD_NAMESPACE    - Argo CD namespace (default: argocd)
+#   SNAPSHOT_NAMESPACE  - target namespace for the range (default: or-${SNAPSHOT_ID})
+#
+apiVersion: argoproj.io/v1alpha1
+kind: Application
+metadata:
+  name: openrange-${SNAPSHOT_ID}
+  namespace: ${ARGOCD_NAMESPACE:-argocd}
+  labels:
+    app.kubernetes.io/part-of: openrange
+    app.kubernetes.io/component: range-snapshot
+    openrange.dev/snapshot-id: "${SNAPSHOT_ID}"
+  finalizers:
+    - resources-finalizer.argocd.argoproj.io
+spec:
+  project: default
+  source:
+    repoURL: ${GITOPS_REPO_URL}
+    targetRevision: ${TARGET_REVISION}
+    path: ${CHART_PATH}
+    helm:
+      releaseName: or-${SNAPSHOT_ID}
+      valueFiles:
+        - values.yaml
+  destination:
+    server: https://kubernetes.default.svc
+    namespace: ${SNAPSHOT_NAMESPACE:-or-${SNAPSHOT_ID}}
+  syncPolicy:
+    automated:
+      prune: true
+      selfHeal: true
+    syncOptions:
+      - CreateNamespace=true
+      - ServerSideApply=true
+    retry:
+      limit: 3
+      backoff:
+        duration: 10s
+        factor: 2
+        maxDuration: 3m

--- a/deploy/cilium/README.md
+++ b/deploy/cilium/README.md
@@ -1,0 +1,167 @@
+# Cilium + Hubble for open-range
+
+This directory contains deployment manifests for installing [Cilium](https://cilium.io/) as the CNI and [Hubble](https://docs.cilium.io/en/stable/observability/hubble/) for network flow observability on open-range clusters.
+
+Cilium is **completely optional**. When not installed, open-range uses standard Kubernetes NetworkPolicy resources enforced by the cluster's default CNI (e.g. kindnetd). Cilium enhances the platform with eBPF-enforced network segmentation and Hubble provides real-time flow visibility for Blue agent training.
+
+## Files
+
+| File | Purpose |
+|------|---------|
+| `bootstrap-cilium.sh` | Install Cilium + Hubble via Helm |
+| `cilium-values.yaml` | Helm values optimized for Kind/k3d |
+| `hubble-relay-patch.yaml` | Patch for Hubble relay hostNetwork access |
+
+## Installation
+
+### Prerequisites
+
+- A running Kind or k3d cluster (the `deploy/kind-config.yaml` works as-is)
+- `helm` CLI installed
+- `kubectl` configured for the target cluster
+- Optionally, the `cilium` CLI for status checks
+
+### Quick start
+
+```bash
+# From the repository root
+./deploy/cilium/bootstrap-cilium.sh
+```
+
+### Configuration via environment variables
+
+```bash
+# Override Cilium version
+export CILIUM_CHART_VERSION=1.16.5
+
+# Use with k3d instead of Kind
+export CLUSTER_TYPE=k3d
+export K3D_CLUSTER_NAME=openrange
+
+# Custom cluster name
+export KIND_CLUSTER_NAME=my-cluster
+
+# Force hostNetwork on Hubble relay (auto-enabled for k3d)
+export HUBBLE_RELAY_HOST_NETWORK=true
+
+# Start Hubble port-forward automatically
+export HUBBLE_PORT_FORWARD=true
+
+./deploy/cilium/bootstrap-cilium.sh
+```
+
+## How Hubble enhances Blue agent training
+
+Without Hubble, the Blue agent relies on application-level logs (syslog, web server access logs, SIEM alerts) to detect attacker activity. Hubble adds a network-layer observation channel:
+
+1. **Flow visibility**: The Blue agent can observe all network flows between zones, including source/destination pods, ports, protocols, and L7 HTTP details (method, path, status code).
+
+2. **Policy enforcement feedback**: Dropped flows tell the Blue agent which connections are being blocked by policy, confirming that isolation is working.
+
+3. **Anomaly detection**: By comparing current flows against a baseline captured during known-good operation, the Blue agent can detect:
+   - New connection paths not seen before
+   - Traffic on unexpected ports
+   - Policy violation attempts (dropped flows)
+   - Volume spikes indicating scanning or exfiltration
+
+4. **Verification**: The Blue agent can programmatically verify zone isolation -- confirming that the attacker in the DMZ cannot reach the management zone.
+
+### Python integration
+
+The `hubble_observer.py` module provides an async Python API:
+
+```python
+from open_range.server.hubble_observer import HubbleObserver, HubbleConfig
+
+observer = HubbleObserver(config=HubbleConfig(
+    hubble_addr="localhost:4245",
+    namespace_prefix="or-my-range",
+))
+
+# Get recent flows
+flows = await observer.get_flows(namespace="or-my-range-dmz", since="5m")
+
+# Check zone isolation
+isolated = await observer.check_isolation("dmz", "management")
+
+# Detect anomalies
+anomalies = await observer.detect_anomalies(baseline_flows)
+
+# Get observation-space summary
+summary = await observer.get_flow_summary()
+```
+
+When Hubble is not available, all methods return empty results rather than raising exceptions.
+
+## CiliumNetworkPolicy vs standard NetworkPolicy
+
+| Feature | NetworkPolicy | CiliumNetworkPolicy |
+|---------|--------------|-------------------|
+| Enforcement | CNI-dependent (iptables) | eBPF datapath |
+| L7 rules | Not supported | HTTP path/method filtering |
+| DNS policies | Not supported | FQDN-based egress rules |
+| Identity-based | Namespace/pod labels only | Cilium security identities |
+| Visibility | None built-in | Hubble flow logs |
+| Performance | iptables rules scale linearly | eBPF maps scale efficiently |
+
+The `cilium_policies.py` module generates CiliumNetworkPolicy resources from the same zone/firewall configuration used for standard NetworkPolicy:
+
+```python
+from open_range.server.cilium_policies import CiliumPolicyGenerator
+
+gen = CiliumPolicyGenerator(name_prefix="or-my-range")
+policies = gen.generate_zone_policies(zones, firewall_rules)
+l7_policies = gen.generate_l7_policies(services)
+```
+
+## Verifying zone isolation
+
+### Using the Hubble CLI
+
+```bash
+# Watch all dropped flows (policy violations)
+hubble observe --verdict DROPPED --server localhost:4245
+
+# Check flows into the management zone
+hubble observe --namespace or-myrange-management --server localhost:4245
+
+# Filter by source zone
+hubble observe --from-namespace or-myrange-dmz --to-namespace or-myrange-internal
+```
+
+### Using the Cilium CLI
+
+```bash
+# Verify Cilium is healthy
+cilium status
+
+# List all CiliumNetworkPolicy resources
+kubectl get ciliumnetworkpolicies --all-namespaces
+
+# Test connectivity between zones
+cilium connectivity test
+```
+
+### Using the Python API
+
+```python
+from open_range.server.hubble_observer import HubbleObserver
+
+observer = HubbleObserver()
+
+# Verify DMZ cannot reach management
+assert await observer.check_isolation("dmz", "management")
+
+# Verify DMZ can reach internal (if firewall rule allows)
+# check_isolation returns True when traffic is BLOCKED
+# so False means traffic is flowing (which may be expected)
+can_reach = not await observer.check_isolation("dmz", "internal")
+```
+
+## Architecture notes
+
+- Cilium runs as a DaemonSet in `kube-system`, replacing or augmenting the default CNI
+- Hubble relay aggregates flow data from all Cilium agents
+- Hubble UI provides a browser-based flow visualization (optional)
+- The Kind cluster config (`deploy/kind-config.yaml`) already sets `disableDefaultCNI: true` for Cilium compatibility
+- When Cilium is not installed, open-range falls back to standard NetworkPolicy resources generated by the Helm chart templates

--- a/deploy/cilium/bootstrap-cilium.sh
+++ b/deploy/cilium/bootstrap-cilium.sh
@@ -1,0 +1,155 @@
+#!/usr/bin/env sh
+# bootstrap-cilium.sh -- Install Cilium + Hubble on an open-range cluster.
+#
+# Adapted from k3s-istio-vault-platform/bootstrap/bootstrap-cilium.sh for the
+# open-range cybersecurity gymnasium. Works with both Kind and k3d clusters.
+#
+# Environment variables (all optional):
+#   CILIUM_CHART_VERSION  Cilium Helm chart version  (default: 1.16.5)
+#   CILIUM_NAMESPACE      Install namespace           (default: kube-system)
+#   CILIUM_VALUES_FILE    Path to Helm values file    (default: <script_dir>/cilium-values.yaml)
+#   CLUSTER_TYPE          "kind" or "k3d"             (default: kind)
+#   KIND_CLUSTER_NAME     Kind cluster name            (default: openrange)
+#   K3D_CLUSTER_NAME      k3d cluster name             (default: openrange)
+#   HUBBLE_RELAY_HOST_NETWORK  Force hostNetwork on hubble-relay ("true"/"false")
+#   CILIUM_K8S_SERVICE_HOST    Override API server host
+#   CILIUM_K8S_SERVICE_PORT    Override API server port
+#   CILIUM_WAIT_TIMEOUT        Helm --timeout value     (default: 300s)
+#   HUBBLE_PORT_FORWARD        Start port-forward after install ("true"/"false", default: false)
+set -eu
+
+SCRIPT_DIR=$(CDPATH= cd -- "$(dirname -- "$0")" && pwd)
+
+# ---------------------------------------------------------------------------
+# Defaults
+# ---------------------------------------------------------------------------
+CILIUM_CHART_VERSION="${CILIUM_CHART_VERSION:-1.16.5}"
+CILIUM_NAMESPACE="${CILIUM_NAMESPACE:-kube-system}"
+CILIUM_VALUES_FILE="${CILIUM_VALUES_FILE:-$SCRIPT_DIR/cilium-values.yaml}"
+CLUSTER_TYPE="${CLUSTER_TYPE:-kind}"
+KIND_CLUSTER_NAME="${KIND_CLUSTER_NAME:-openrange}"
+K3D_CLUSTER_NAME="${K3D_CLUSTER_NAME:-openrange}"
+CILIUM_WAIT_TIMEOUT="${CILIUM_WAIT_TIMEOUT:-300s}"
+HUBBLE_PORT_FORWARD="${HUBBLE_PORT_FORWARD:-false}"
+
+# ---------------------------------------------------------------------------
+# Prerequisite checks
+# ---------------------------------------------------------------------------
+for tool in helm kubectl; do
+  command -v "$tool" >/dev/null 2>&1 || {
+    echo "required tool not found: $tool" >&2
+    exit 1
+  }
+done
+
+if ! [ -f "$CILIUM_VALUES_FILE" ]; then
+  echo "Cilium values file not found: $CILIUM_VALUES_FILE" >&2
+  exit 1
+fi
+
+# ---------------------------------------------------------------------------
+# Ensure kubeconfig context is set for the target cluster
+# ---------------------------------------------------------------------------
+case "$CLUSTER_TYPE" in
+  kind)
+    if command -v kind >/dev/null 2>&1; then
+      kubectl cluster-info --context "kind-${KIND_CLUSTER_NAME}" >/dev/null 2>&1 || true
+    fi
+    ;;
+  k3d)
+    if command -v k3d >/dev/null 2>&1; then
+      kubectl cluster-info --context "k3d-${K3D_CLUSTER_NAME}" >/dev/null 2>&1 || true
+    fi
+    ;;
+  *)
+    echo "Unsupported CLUSTER_TYPE: $CLUSTER_TYPE (expected 'kind' or 'k3d')" >&2
+    exit 1
+    ;;
+esac
+
+echo "Installing Cilium ${CILIUM_CHART_VERSION} into ${CILIUM_NAMESPACE} (cluster type: ${CLUSTER_TYPE})..."
+
+# ---------------------------------------------------------------------------
+# Add / update Helm repo
+# ---------------------------------------------------------------------------
+helm repo add cilium https://helm.cilium.io/ >/dev/null 2>&1 || true
+helm repo update cilium >/dev/null
+
+# ---------------------------------------------------------------------------
+# Build Helm arguments
+# ---------------------------------------------------------------------------
+set -- \
+  cilium/cilium \
+  --namespace "$CILIUM_NAMESPACE" \
+  --version "$CILIUM_CHART_VERSION" \
+  --values "$CILIUM_VALUES_FILE"
+
+if [ -n "${CILIUM_K8S_SERVICE_HOST:-}" ]; then
+  set -- "$@" --set "k8sServiceHost=${CILIUM_K8S_SERVICE_HOST}"
+fi
+
+if [ -n "${CILIUM_K8S_SERVICE_PORT:-}" ]; then
+  set -- "$@" --set "k8sServicePort=${CILIUM_K8S_SERVICE_PORT}"
+fi
+
+set -- "$@" --wait --timeout "$CILIUM_WAIT_TIMEOUT"
+
+# ---------------------------------------------------------------------------
+# Install / upgrade Cilium
+# ---------------------------------------------------------------------------
+helm upgrade --install cilium "$@"
+
+echo "Cilium Helm release installed."
+
+# ---------------------------------------------------------------------------
+# Hubble relay hostNetwork patch (needed for k3d and optionally Kind)
+# ---------------------------------------------------------------------------
+use_hubble_relay_hostnetwork="${HUBBLE_RELAY_HOST_NETWORK:-}"
+if [ -z "$use_hubble_relay_hostnetwork" ] && [ "$CLUSTER_TYPE" = "k3d" ]; then
+  use_hubble_relay_hostnetwork=true
+fi
+
+HUBBLE_PATCH_FILE="$SCRIPT_DIR/hubble-relay-patch.yaml"
+if [ "$use_hubble_relay_hostnetwork" = "true" ] && [ -f "$HUBBLE_PATCH_FILE" ]; then
+  echo "Applying Hubble relay hostNetwork patch..."
+  kubectl -n "$CILIUM_NAMESPACE" patch deployment hubble-relay \
+    --type=merge \
+    --patch-file "$HUBBLE_PATCH_FILE" >/dev/null
+  echo "Hubble relay patch applied."
+fi
+
+# ---------------------------------------------------------------------------
+# Wait for Cilium to report healthy
+# ---------------------------------------------------------------------------
+if command -v cilium >/dev/null 2>&1; then
+  echo "Waiting for Cilium to become ready..."
+  cilium status --wait --wait-duration 120s 2>/dev/null || {
+    echo "Warning: 'cilium status --wait' failed -- Cilium may still be starting." >&2
+  }
+else
+  echo "Cilium CLI not found; skipping 'cilium status --wait'."
+  echo "Falling back to kubectl rollout status..."
+  kubectl -n "$CILIUM_NAMESPACE" rollout status daemonset/cilium --timeout=120s || true
+  kubectl -n "$CILIUM_NAMESPACE" rollout status deployment/cilium-operator --timeout=60s || true
+  kubectl -n "$CILIUM_NAMESPACE" rollout status deployment/hubble-relay --timeout=60s || true
+fi
+
+# ---------------------------------------------------------------------------
+# Optional: port-forward Hubble relay for local access
+# ---------------------------------------------------------------------------
+if [ "$HUBBLE_PORT_FORWARD" = "true" ]; then
+  echo "Starting Hubble relay port-forward on localhost:4245..."
+  kubectl -n "$CILIUM_NAMESPACE" port-forward svc/hubble-relay 4245:80 &
+  HUBBLE_PF_PID=$!
+  echo "Hubble relay port-forward PID: $HUBBLE_PF_PID"
+fi
+
+echo ""
+echo "Cilium + Hubble installation complete."
+echo "  Cilium version : ${CILIUM_CHART_VERSION}"
+echo "  Namespace      : ${CILIUM_NAMESPACE}"
+echo "  Cluster type   : ${CLUSTER_TYPE}"
+echo ""
+echo "Verify with:  cilium status"
+echo "Hubble UI:    cilium hubble ui"
+echo "Hubble flows: hubble observe --namespace <zone-namespace>"

--- a/deploy/cilium/cilium-values.yaml
+++ b/deploy/cilium/cilium-values.yaml
@@ -1,0 +1,100 @@
+# Cilium Helm values for open-range cybersecurity gymnasium.
+#
+# Optimized for Kind/k3d local clusters. Does NOT replace kube-proxy for
+# simplicity -- open-range only needs Cilium's eBPF-enforced network policies
+# and Hubble flow visibility.
+
+# ---------------------------------------------------------------------------
+# Core Cilium settings
+# ---------------------------------------------------------------------------
+
+# Do not replace kube-proxy -- keeps the setup simple for Kind/k3d.
+kubeProxyReplacement: false
+
+# IPAM: use Kubernetes-native pod CIDR allocation.
+ipam:
+  mode: kubernetes
+
+# Cilium operator -- single replica is fine for dev/training clusters.
+operator:
+  replicas: 1
+
+# ---------------------------------------------------------------------------
+# CNI configuration
+# ---------------------------------------------------------------------------
+
+# For Kind clusters that already have kindnetd, run Cilium alongside it.
+# Set exclusive=false so Cilium does not remove other CNI plugins.
+cni:
+  exclusive: false
+
+# ---------------------------------------------------------------------------
+# Hubble -- network flow observability
+# ---------------------------------------------------------------------------
+
+hubble:
+  enabled: true
+
+  # Enable L7 HTTP visibility for web-service traffic analysis.
+  # This lets the Blue agent see HTTP method, path, and status codes.
+  httpProtocol: "HTTP/1.1"
+
+  metrics:
+    enabled:
+      - dns
+      - drop
+      - tcp
+      - flow
+      - icmp
+      - "httpV2:exemplars=true;labelsContext=source_ip,source_namespace,destination_ip,destination_namespace"
+
+  relay:
+    enabled: true
+    # Resource limits appropriate for training clusters.
+    resources:
+      limits:
+        memory: 256Mi
+      requests:
+        cpu: 50m
+        memory: 64Mi
+
+  ui:
+    enabled: true
+    replicas: 1
+
+# ---------------------------------------------------------------------------
+# L7 policy visibility -- enables HTTP-aware CiliumNetworkPolicy
+# ---------------------------------------------------------------------------
+
+# Enable per-endpoint visibility annotations for L7 inspection.
+# This allows CiliumNetworkPolicy rules with HTTP path/method matching.
+enablePolicy: "default"
+
+# Enable DNS proxy for FQDN-based policies.
+dnsproxy:
+  enabled: true
+
+# ---------------------------------------------------------------------------
+# Monitoring -- optional Prometheus integration
+# ---------------------------------------------------------------------------
+
+prometheus:
+  enabled: false  # Enable if you have a Prometheus stack in the cluster.
+
+# ---------------------------------------------------------------------------
+# Resource limits -- conservative for local development
+# ---------------------------------------------------------------------------
+
+resources:
+  limits:
+    memory: 512Mi
+  requests:
+    cpu: 100m
+    memory: 128Mi
+
+# ---------------------------------------------------------------------------
+# Security context -- required for eBPF programs
+# ---------------------------------------------------------------------------
+
+securityContext:
+  privileged: true

--- a/deploy/cilium/hubble-relay-patch.yaml
+++ b/deploy/cilium/hubble-relay-patch.yaml
@@ -1,0 +1,15 @@
+# Patch for Hubble relay deployment to use hostNetwork.
+#
+# Required for k3d clusters and useful for Kind clusters where the relay
+# service is not directly reachable from the host. With hostNetwork, the
+# relay binds to the node's network namespace so port-forwarding and the
+# Hubble CLI can connect without extra Service configuration.
+#
+# Apply with:
+#   kubectl -n kube-system patch deployment hubble-relay \
+#     --type=merge --patch-file hubble-relay-patch.yaml
+spec:
+  template:
+    spec:
+      hostNetwork: true
+      dnsPolicy: ClusterFirstWithHostNet

--- a/deploy/k3d/k3d-config.yaml.tpl
+++ b/deploy/k3d/k3d-config.yaml.tpl
@@ -1,0 +1,53 @@
+## k3d cluster configuration template for open-range.
+## Variables are expanded by envsubst at cluster creation time.
+## See k3d.env.example for variable documentation.
+apiVersion: k3d.io/v1alpha5
+kind: Simple
+metadata:
+  name: ${CLUSTER_NAME}
+servers: 1
+agents: ${K3D_AGENTS}
+image: ${K3D_K3S_IMAGE}
+subnet: ${K3D_SUBNET}
+token: ${K3S_TOKEN}
+kubeAPI:
+  host: ${K3D_API_HOST}
+  hostIP: ${K3D_API_HOST}
+  hostPort: "${K3D_API_PORT}"
+ports:
+  # HTTP/HTTPS ingress via the k3d load-balancer
+  - port: ${K3D_HTTP_PORT}:80
+    nodeFilters:
+      - loadbalancer
+  - port: ${K3D_HTTPS_PORT}:443
+    nodeFilters:
+      - loadbalancer
+  # DMZ NodePort range (30080-30089) mapped through to host
+  - port: ${K3D_DMZ_PORT_START}-${K3D_DMZ_PORT_END}:${K3D_DMZ_PORT_START}-${K3D_DMZ_PORT_END}
+    nodeFilters:
+      - server:0
+options:
+  k3d:
+    wait: true
+    timeout: ${K3D_WAIT_TIMEOUT}
+  k3s:
+    extraArgs:
+      # Disable Traefik -- open-range manages its own ingress
+      - arg: --disable=traefik
+        nodeFilters:
+          - server:*
+      # Disable default CNI for future Cilium support
+      - arg: --flannel-backend=none
+        nodeFilters:
+          - server:*
+      # Disable default network policy controller
+      - arg: --disable-network-policy
+        nodeFilters:
+          - server:*
+    nodeLabels:
+      - label: openrange.io/role=agent
+        nodeFilters:
+          - agent:*
+      - label: openrange.io/role=server
+        nodeFilters:
+          - server:*

--- a/deploy/k3d/k3d-down.sh
+++ b/deploy/k3d/k3d-down.sh
@@ -1,0 +1,33 @@
+#!/usr/bin/env sh
+# k3d-down.sh -- Tear down the open-range k3d cluster.
+#
+# Usage:
+#   ./k3d-down.sh                         # uses default cluster name
+#   CLUSTER_NAME=my-cluster ./k3d-down.sh # override cluster name
+set -eu
+
+SCRIPT_DIR=$(CDPATH= cd -- "$(dirname -- "$0")" && pwd)
+ENV_FILE=${ENV_FILE:-"$SCRIPT_DIR/k3d.env"}
+
+# Source optional env file for CLUSTER_NAME
+if [ -f "$ENV_FILE" ]; then
+  set -a
+  . "$ENV_FILE"
+  set +a
+fi
+
+: "${CLUSTER_NAME:=openrange}"
+
+command -v k3d >/dev/null 2>&1 || {
+  echo "ERROR: k3d is required but not found on PATH" >&2
+  exit 1
+}
+
+if ! k3d cluster list -o json 2>/dev/null | grep -q "\"name\":\"${CLUSTER_NAME}\""; then
+  echo "Cluster '${CLUSTER_NAME}' does not exist. Nothing to delete."
+  exit 0
+fi
+
+echo "Deleting k3d cluster '${CLUSTER_NAME}' ..."
+k3d cluster delete "$CLUSTER_NAME"
+echo "Cluster '${CLUSTER_NAME}' deleted."

--- a/deploy/k3d/k3d-up.sh
+++ b/deploy/k3d/k3d-up.sh
@@ -1,0 +1,124 @@
+#!/usr/bin/env sh
+# k3d-up.sh -- Bootstrap a multi-node k3d cluster for open-range.
+#
+# Creates a k3d cluster with CNI disabled (for future Cilium support),
+# configurable worker agents, and DMZ NodePort mappings.  Pre-pulls
+# chart images into the cluster so pods start quickly.
+#
+# Usage:
+#   ./k3d-up.sh                    # uses defaults / k3d.env
+#   K3D_AGENTS=4 ./k3d-up.sh      # override worker count
+set -eu
+
+SCRIPT_DIR=$(CDPATH= cd -- "$(dirname -- "$0")" && pwd)
+ENV_FILE=${ENV_FILE:-"$SCRIPT_DIR/k3d.env"}
+CONFIG_TEMPLATE=${CONFIG_TEMPLATE:-"$SCRIPT_DIR/k3d-config.yaml.tpl"}
+
+# ---------------------------------------------------------------------------
+# Source optional env file
+# ---------------------------------------------------------------------------
+if [ -f "$ENV_FILE" ]; then
+  set -a
+  . "$ENV_FILE"
+  set +a
+fi
+
+# ---------------------------------------------------------------------------
+# Defaults (all overridable via environment or k3d.env)
+# ---------------------------------------------------------------------------
+: "${CLUSTER_NAME:=openrange}"
+: "${K3D_K3S_IMAGE:=rancher/k3s:v1.31.6-k3s1}"
+: "${K3D_AGENTS:=2}"
+: "${K3D_API_HOST:=127.0.0.1}"
+: "${K3D_API_PORT:=6550}"
+: "${K3D_SUBNET:=172.29.0.0/16}"
+: "${K3S_TOKEN:=openrange-bootstrap-token}"
+: "${K3D_HTTP_PORT:=8080}"
+: "${K3D_HTTPS_PORT:=8443}"
+: "${K3D_DMZ_PORT_START:=30080}"
+: "${K3D_DMZ_PORT_END:=30089}"
+: "${K3D_WAIT_TIMEOUT:=300s}"
+
+export CLUSTER_NAME K3D_K3S_IMAGE K3D_AGENTS K3D_API_HOST K3D_API_PORT
+export K3D_SUBNET K3S_TOKEN K3D_HTTP_PORT K3D_HTTPS_PORT
+export K3D_DMZ_PORT_START K3D_DMZ_PORT_END K3D_WAIT_TIMEOUT
+
+# ---------------------------------------------------------------------------
+# Preflight checks
+# ---------------------------------------------------------------------------
+for required_command in docker k3d kubectl envsubst; do
+  command -v "$required_command" >/dev/null 2>&1 || {
+    echo "ERROR: $required_command is required but not found on PATH" >&2
+    exit 1
+  }
+done
+
+# Abort if cluster already exists
+if k3d cluster list -o json 2>/dev/null | grep -q "\"name\":\"${CLUSTER_NAME}\""; then
+  echo "Cluster '${CLUSTER_NAME}' already exists. Run k3d-down.sh first or:" >&2
+  echo "  k3d cluster delete ${CLUSTER_NAME}" >&2
+  exit 1
+fi
+
+# ---------------------------------------------------------------------------
+# Render k3d config from template
+# ---------------------------------------------------------------------------
+if [ ! -f "$CONFIG_TEMPLATE" ]; then
+  echo "ERROR: missing config template: $CONFIG_TEMPLATE" >&2
+  echo "Copy k3d-config.yaml.tpl from the deploy/k3d directory." >&2
+  exit 1
+fi
+
+TMP_CONFIG=$(mktemp)
+trap 'rm -f "$TMP_CONFIG"' EXIT HUP INT TERM
+envsubst < "$CONFIG_TEMPLATE" > "$TMP_CONFIG"
+
+echo "Creating k3d cluster '${CLUSTER_NAME}' (${K3D_AGENTS} agents, subnet ${K3D_SUBNET}) ..."
+
+# ---------------------------------------------------------------------------
+# Create cluster
+# ---------------------------------------------------------------------------
+k3d cluster create --config "$TMP_CONFIG"
+kubectl config use-context "k3d-${CLUSTER_NAME}" >/dev/null
+
+# ---------------------------------------------------------------------------
+# Wait for nodes to be Ready
+# ---------------------------------------------------------------------------
+echo "Waiting for all nodes to become Ready ..."
+kubectl wait --for=condition=Ready nodes --all --timeout="${K3D_WAIT_TIMEOUT}"
+
+# ---------------------------------------------------------------------------
+# Pre-load images (best-effort)
+# ---------------------------------------------------------------------------
+# If OPENRANGE_PRELOAD_IMAGES is set (comma-separated), import them.
+if [ -n "${OPENRANGE_PRELOAD_IMAGES:-}" ]; then
+  echo "Pre-loading images into cluster ..."
+  # Split comma-separated list
+  OLD_IFS="$IFS"
+  IFS=","
+  set -- $OPENRANGE_PRELOAD_IMAGES
+  IFS="$OLD_IFS"
+  for img in "$@"; do
+    img=$(echo "$img" | xargs)  # trim whitespace
+    if [ -n "$img" ]; then
+      echo "  Importing: $img"
+      k3d image import -c "$CLUSTER_NAME" "$img" 2>/dev/null || \
+        echo "  WARNING: failed to import $img (may need docker pull first)" >&2
+    fi
+  done
+fi
+
+# ---------------------------------------------------------------------------
+# Summary
+# ---------------------------------------------------------------------------
+echo ""
+echo "k3d cluster '${CLUSTER_NAME}' is ready."
+echo "  Context:       k3d-${CLUSTER_NAME}"
+echo "  API server:    https://${K3D_API_HOST}:${K3D_API_PORT}"
+echo "  Agents:        ${K3D_AGENTS}"
+echo "  Subnet:        ${K3D_SUBNET}"
+echo "  DMZ NodePorts: ${K3D_DMZ_PORT_START}-${K3D_DMZ_PORT_END}"
+echo "  HTTP ingress:  http://${K3D_API_HOST}:${K3D_HTTP_PORT}"
+echo "  HTTPS ingress: https://${K3D_API_HOST}:${K3D_HTTPS_PORT}"
+echo ""
+echo "To tear down:  ${SCRIPT_DIR}/k3d-down.sh"

--- a/deploy/k3d/k3d.env.example
+++ b/deploy/k3d/k3d.env.example
@@ -1,0 +1,44 @@
+# k3d.env -- Environment configuration for open-range k3d cluster.
+#
+# Copy this file to k3d.env and adjust values as needed:
+#   cp k3d.env.example k3d.env
+#
+# All variables have sane defaults in k3d-up.sh; this file lets you
+# override them without editing the script.
+
+# Cluster name (also sets kubectl context to k3d-<CLUSTER_NAME>)
+CLUSTER_NAME=openrange
+
+# k3s container image used by k3d
+K3D_K3S_IMAGE=rancher/k3s:v1.31.6-k3s1
+
+# Number of worker agent nodes (server is always 1)
+K3D_AGENTS=2
+
+# kube-apiserver bind address and port on the host
+K3D_API_HOST=127.0.0.1
+K3D_API_PORT=6550
+
+# Docker network subnet for the k3d cluster
+K3D_SUBNET=172.29.0.0/16
+
+# Shared token for k3s node registration
+K3S_TOKEN=openrange-bootstrap-token
+
+# Host ports for HTTP/HTTPS load-balancer ingress
+K3D_HTTP_PORT=8080
+K3D_HTTPS_PORT=8443
+
+# NodePort range mapped to the host for DMZ services
+K3D_DMZ_PORT_START=30080
+K3D_DMZ_PORT_END=30089
+
+# Timeout waiting for the cluster to become ready
+K3D_WAIT_TIMEOUT=300s
+
+# Comma-separated list of container images to pre-load into the cluster.
+# These are imported via "k3d image import" after cluster creation so pods
+# don't have to pull from a registry.  Images must exist locally (docker images).
+# Example:
+#   OPENRANGE_PRELOAD_IMAGES=php:8.1-apache,mysql:8.0,ubuntu:22.04
+# OPENRANGE_PRELOAD_IMAGES=

--- a/deploy/monitoring/README.md
+++ b/deploy/monitoring/README.md
@@ -1,0 +1,145 @@
+# OpenRange Monitoring Stack
+
+Prometheus-based observability for the OpenRange cybersecurity training gymnasium.
+
+## Overview
+
+The monitoring stack deploys [kube-prometheus-stack](https://github.com/prometheus-community/helm-charts/tree/main/charts/kube-prometheus-stack) into a Kubernetes cluster running OpenRange. It provides:
+
+- **Prometheus** for metrics collection and alerting
+- **Grafana** for dashboards and visualization
+- **AlertManager** for alert routing
+- **ServiceMonitor** resources for automatic target discovery
+- **PrometheusRule** resources with cybersecurity-relevant alerts
+
+The stack is **entirely optional**. OpenRange trains agents without it; enabling it adds Prometheus-derived reward signals and operational visibility.
+
+## Deploying
+
+### Prerequisites
+
+- A running Kubernetes cluster (kind, k3s, or equivalent)
+- Helm 3 installed
+- kubectl configured for the target cluster
+
+### Quick start
+
+```bash
+./deploy/monitoring/deploy-monitoring.sh
+```
+
+The script will:
+
+1. Add the `prometheus-community` Helm repo
+2. Create the `monitoring` namespace
+3. Install kube-prometheus-stack with OpenRange-tuned values
+4. Apply the OpenRange ServiceMonitor and alert rules
+5. Wait for Prometheus and Grafana to become ready
+
+### Accessing services
+
+```bash
+# Prometheus UI
+kubectl port-forward -n monitoring svc/kube-prometheus-stack-prometheus 9090:9090
+
+# Grafana (default: admin / prom-operator)
+kubectl port-forward -n monitoring svc/kube-prometheus-stack-grafana 3000:80
+
+# AlertManager
+kubectl port-forward -n monitoring svc/kube-prometheus-stack-alertmanager 9093:9093
+```
+
+### Configuration
+
+Environment variables accepted by `deploy-monitoring.sh`:
+
+| Variable | Default | Description |
+|---|---|---|
+| `MONITORING_NAMESPACE` | `monitoring` | Target namespace |
+| `MONITORING_RELEASE` | `kube-prometheus-stack` | Helm release name |
+| `MONITORING_CHART_VERSION` | `80.13.3` | Chart version |
+| `MONITORING_TIMEOUT` | `300s` | Helm install timeout |
+
+Edit `prometheus-values.yaml` to tune resource requests, retention, scrape intervals, or enable additional components.
+
+## How Blue Agents Use Prometheus Metrics
+
+The `PrometheusRewardDataSource` class in `src/open_range/server/prometheus_rewards.py` queries Prometheus to produce supplementary reward signals for Blue agent training.
+
+### Reward signals
+
+| Method | Signal | Description |
+|---|---|---|
+| `service_availability(service)` | 0.0 - 1.0 | Fraction of `up` targets for a given service |
+| `detection_score(window_minutes)` | 0.0 - 1.0 | Proportion of security alerts currently firing |
+| `error_rate(namespace)` | 0.0 - 1.0 | Aggregate HTTP 5xx error rate |
+| `unauthorized_request_count(...)` | integer | Count of 401/403 responses in a window |
+| `pod_restart_count(...)` | integer | Pod restarts in a window |
+
+### Integration with training
+
+The data source is designed to complement `CompositeBlueReward` in `src/open_range/server/rewards.py`. A training harness can combine signals:
+
+```python
+from open_range.server.prometheus_rewards import (
+    PrometheusConfig,
+    PrometheusRewardDataSource,
+)
+from open_range.server.rewards import CompositeBlueReward
+
+source = PrometheusRewardDataSource(config=PrometheusConfig(
+    url="http://localhost:9090",
+))
+
+availability = await source.service_availability("web")
+detection = await source.detection_score()
+
+# Feed into composite reward or use independently
+blue_reward = CompositeBlueReward()
+```
+
+When Prometheus is unavailable, all methods return safe defaults (configurable via `PrometheusConfig`) so training is never blocked.
+
+## Alert Rules
+
+Defined in `alert-rules.yaml`, these alerts serve dual purposes: operational monitoring and Blue agent input signals.
+
+### Range health alerts
+
+| Alert | Severity | Fires when |
+|---|---|---|
+| `OpenRangeServiceDown` | critical | A range service pod is not ready for > 2 minutes |
+| `OpenRangeHighErrorRate` | warning | HTTP 5xx rate exceeds 10% over 5 minutes |
+| `OpenRangePodRestart` | warning | A container restarts > 3 times in 15 minutes |
+
+### Security signal alerts
+
+| Alert | Severity | Fires when |
+|---|---|---|
+| `OpenRangeUnauthorizedAccess` | warning | > 20 unauthorized (401/403) requests in 5 minutes |
+| `OpenRangeSuspiciousProcess` | warning | > 50 process spawns in a container within 5 minutes |
+| `OpenRangeHighNetworkEgress` | info | Sustained network transmit > 1 MiB/s for 3 minutes |
+
+Security signal alerts carry a `signal` label (`unauthorized_access`, `suspicious_process`, `data_exfiltration`, `instability`) that the Blue agent can use for classification.
+
+## Integration with the Training Pipeline
+
+The monitoring stack integrates at three levels:
+
+1. **Metrics collection** -- The ServiceMonitor discovers any service labelled `app.kubernetes.io/part-of: openrange` and scrapes its `/metrics` endpoint.
+
+2. **Alert generation** -- PrometheusRule evaluates PromQL expressions against collected metrics and fires alerts when thresholds are breached.
+
+3. **Reward computation** -- `PrometheusRewardDataSource` queries the Prometheus API to translate alerts and metrics into numerical reward signals that guide Blue agent learning.
+
+This creates a feedback loop: Red agent actions cause metric changes, Prometheus detects anomalies, and the Blue agent receives reward signals for correct detections.
+
+## File Reference
+
+| File | Purpose |
+|---|---|
+| `deploy-monitoring.sh` | Deployment script |
+| `prometheus-values.yaml` | Helm values for kube-prometheus-stack |
+| `servicemonitor.yaml` | ServiceMonitor for OpenRange services |
+| `alert-rules.yaml` | PrometheusRule with security and health alerts |
+| `src/open_range/server/prometheus_rewards.py` | Python reward data source |

--- a/deploy/monitoring/alert-rules.yaml
+++ b/deploy/monitoring/alert-rules.yaml
@@ -1,0 +1,153 @@
+# alert-rules.yaml -- PrometheusRule for OpenRange cybersecurity training
+#
+# These alerts feed into the Blue agent's detection capabilities and provide
+# observability over training-range health.
+apiVersion: monitoring.coreos.io/v1
+kind: PrometheusRule
+metadata:
+  name: openrange-alerts
+  namespace: monitoring
+  labels:
+    app.kubernetes.io/part-of: openrange
+    app.kubernetes.io/managed-by: helm
+    # Ensure Prometheus picks up these rules
+    release: kube-prometheus-stack
+spec:
+  groups:
+    # -----------------------------------------------------------------
+    # Range health
+    # -----------------------------------------------------------------
+    - name: openrange.health
+      rules:
+        - alert: OpenRangeServiceDown
+          expr: |
+            kube_pod_status_ready{
+              namespace=~"openrange-.*",
+              condition="true"
+            } == 0
+          for: 2m
+          labels:
+            severity: critical
+            team: openrange
+          annotations:
+            summary: "OpenRange service pod is not ready"
+            description: >-
+              Pod {{ $labels.pod }} in namespace {{ $labels.namespace }}
+              has been unready for more than 2 minutes.  This may indicate
+              a crashed range service or a failed deployment.
+
+        - alert: OpenRangeHighErrorRate
+          expr: |
+            (
+              sum by (namespace, service) (
+                rate(http_requests_total{
+                  namespace=~"openrange-.*",
+                  status=~"5.."
+                }[5m])
+              )
+              /
+              sum by (namespace, service) (
+                rate(http_requests_total{
+                  namespace=~"openrange-.*"
+                }[5m])
+              )
+            ) > 0.10
+          for: 3m
+          labels:
+            severity: warning
+            team: openrange
+          annotations:
+            summary: "High HTTP error rate on OpenRange service"
+            description: >-
+              Service {{ $labels.service }} in {{ $labels.namespace }}
+              is returning >10% HTTP 5xx errors over the last 5 minutes
+              (current value: {{ $value | humanizePercentage }}).
+
+    # -----------------------------------------------------------------
+    # Security signals -- inputs for Blue agent reward
+    # -----------------------------------------------------------------
+    - name: openrange.security
+      rules:
+        - alert: OpenRangeUnauthorizedAccess
+          expr: |
+            (
+              sum by (namespace, pod) (
+                increase(http_requests_total{
+                  namespace=~"openrange-.*",
+                  status=~"401|403"
+                }[5m])
+              )
+            ) > 20
+          for: 1m
+          labels:
+            severity: warning
+            team: openrange
+            signal: unauthorized_access
+          annotations:
+            summary: "Unusual unauthorized access pattern detected"
+            description: >-
+              Pod {{ $labels.pod }} in {{ $labels.namespace }} received
+              {{ $value }} unauthorized (401/403) requests in 5 minutes.
+              This may indicate credential brute-forcing or privilege
+              escalation attempts.
+
+        - alert: OpenRangeSuspiciousProcess
+          expr: |
+            (
+              sum by (namespace, pod, container) (
+                increase(container_processes_total{
+                  namespace=~"openrange-.*"
+                }[5m])
+              )
+            ) > 50
+          for: 2m
+          labels:
+            severity: warning
+            team: openrange
+            signal: suspicious_process
+          annotations:
+            summary: "Unexpected process activity in container"
+            description: >-
+              Container {{ $labels.container }} in pod {{ $labels.pod }}
+              ({{ $labels.namespace }}) spawned {{ $value }} processes
+              in 5 minutes, which exceeds the expected baseline.  This
+              may indicate reverse-shell activity or enumeration scripts.
+
+        - alert: OpenRangeHighNetworkEgress
+          expr: |
+            (
+              sum by (namespace, pod) (
+                rate(container_network_transmit_bytes_total{
+                  namespace=~"openrange-.*"
+                }[5m])
+              )
+            ) > 1048576
+          for: 3m
+          labels:
+            severity: info
+            team: openrange
+            signal: data_exfiltration
+          annotations:
+            summary: "Elevated network egress from range pod"
+            description: >-
+              Pod {{ $labels.pod }} in {{ $labels.namespace }} is
+              transmitting more than 1 MiB/s sustained for 3 minutes.
+              This may indicate data exfiltration during a Red team exercise.
+
+        - alert: OpenRangePodRestart
+          expr: |
+            increase(kube_pod_container_status_restarts_total{
+              namespace=~"openrange-.*"
+            }[15m]) > 3
+          for: 1m
+          labels:
+            severity: warning
+            team: openrange
+            signal: instability
+          annotations:
+            summary: "OpenRange pod restarting frequently"
+            description: >-
+              Container {{ $labels.container }} in pod {{ $labels.pod }}
+              ({{ $labels.namespace }}) restarted {{ $value }} times
+              in 15 minutes.  May indicate a crash loop caused by
+              exploitation or misconfiguration.

--- a/deploy/monitoring/deploy-monitoring.sh
+++ b/deploy/monitoring/deploy-monitoring.sh
@@ -1,0 +1,120 @@
+#!/usr/bin/env bash
+# deploy-monitoring.sh -- Deploy kube-prometheus-stack for OpenRange
+#
+# Installs the Prometheus observability stack into the 'monitoring' namespace.
+# This is entirely optional; the training pipeline works without it.
+#
+# Usage:
+#   ./deploy/monitoring/deploy-monitoring.sh
+#
+# Prerequisites:
+#   - Helm 3 installed
+#   - kubectl configured for the target cluster
+#   - Cluster running (kind, k3s, etc.)
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+NAMESPACE="${MONITORING_NAMESPACE:-monitoring}"
+RELEASE_NAME="${MONITORING_RELEASE:-kube-prometheus-stack}"
+CHART_REPO="https://prometheus-community.github.io/helm-charts"
+CHART_NAME="kube-prometheus-stack"
+CHART_VERSION="${MONITORING_CHART_VERSION:-80.13.3}"
+VALUES_FILE="${SCRIPT_DIR}/prometheus-values.yaml"
+TIMEOUT="${MONITORING_TIMEOUT:-300s}"
+
+# -----------------------------------------------------------------------
+# Helpers
+# -----------------------------------------------------------------------
+
+info()  { echo "[INFO]  $*"; }
+warn()  { echo "[WARN]  $*" >&2; }
+error() { echo "[ERROR] $*" >&2; exit 1; }
+
+command_exists() { command -v "$1" &>/dev/null; }
+
+# -----------------------------------------------------------------------
+# Pre-flight
+# -----------------------------------------------------------------------
+
+command_exists helm  || error "helm is not installed"
+command_exists kubectl || error "kubectl is not installed"
+
+if [ ! -f "${VALUES_FILE}" ]; then
+    error "Values file not found: ${VALUES_FILE}"
+fi
+
+# -----------------------------------------------------------------------
+# Add / update Helm repo
+# -----------------------------------------------------------------------
+
+info "Adding prometheus-community Helm repo..."
+helm repo add prometheus-community "${CHART_REPO}" 2>/dev/null || true
+helm repo update prometheus-community
+
+# -----------------------------------------------------------------------
+# Create namespace
+# -----------------------------------------------------------------------
+
+info "Ensuring namespace '${NAMESPACE}' exists..."
+kubectl create namespace "${NAMESPACE}" --dry-run=client -o yaml | kubectl apply -f -
+
+# -----------------------------------------------------------------------
+# Install / upgrade the chart
+# -----------------------------------------------------------------------
+
+info "Installing ${RELEASE_NAME} (chart ${CHART_NAME} v${CHART_VERSION}) into ${NAMESPACE}..."
+helm upgrade --install "${RELEASE_NAME}" "${CHART_NAME}" \
+    --repo "${CHART_REPO}" \
+    --version "${CHART_VERSION}" \
+    --namespace "${NAMESPACE}" \
+    --values "${VALUES_FILE}" \
+    --timeout "${TIMEOUT}" \
+    --wait
+
+# -----------------------------------------------------------------------
+# Apply OpenRange-specific ServiceMonitor and PrometheusRules
+# -----------------------------------------------------------------------
+
+if [ -f "${SCRIPT_DIR}/servicemonitor.yaml" ]; then
+    info "Applying OpenRange ServiceMonitor..."
+    kubectl apply -f "${SCRIPT_DIR}/servicemonitor.yaml" -n "${NAMESPACE}"
+fi
+
+if [ -f "${SCRIPT_DIR}/alert-rules.yaml" ]; then
+    info "Applying OpenRange alert rules..."
+    kubectl apply -f "${SCRIPT_DIR}/alert-rules.yaml" -n "${NAMESPACE}"
+fi
+
+# -----------------------------------------------------------------------
+# Wait for Prometheus to become ready
+# -----------------------------------------------------------------------
+
+info "Waiting for Prometheus pods to be ready..."
+kubectl rollout status statefulset/"${RELEASE_NAME}-prometheus" \
+    -n "${NAMESPACE}" \
+    --timeout="${TIMEOUT}" 2>/dev/null || \
+kubectl wait pod \
+    -l "app.kubernetes.io/name=prometheus" \
+    -n "${NAMESPACE}" \
+    --for=condition=Ready \
+    --timeout="${TIMEOUT}" 2>/dev/null || \
+    warn "Could not verify Prometheus readiness -- check pods manually."
+
+info "Waiting for Grafana deployment to be ready..."
+kubectl rollout status deployment/"${RELEASE_NAME}-grafana" \
+    -n "${NAMESPACE}" \
+    --timeout="${TIMEOUT}" 2>/dev/null || \
+    warn "Could not verify Grafana readiness -- check pods manually."
+
+# -----------------------------------------------------------------------
+# Summary
+# -----------------------------------------------------------------------
+
+info ""
+info "Monitoring stack deployed successfully."
+info ""
+info "  Prometheus:    kubectl port-forward -n ${NAMESPACE} svc/${RELEASE_NAME}-prometheus 9090:9090"
+info "  Grafana:       kubectl port-forward -n ${NAMESPACE} svc/${RELEASE_NAME}-grafana 3000:80"
+info "  AlertManager:  kubectl port-forward -n ${NAMESPACE} svc/${RELEASE_NAME}-alertmanager 9093:9093"
+info ""
+info "Grafana default credentials: admin / prom-operator (change immediately)"

--- a/deploy/monitoring/prometheus-values.yaml
+++ b/deploy/monitoring/prometheus-values.yaml
@@ -1,0 +1,147 @@
+# prometheus-values.yaml -- kube-prometheus-stack Helm values for OpenRange
+#
+# Optimized for local dev clusters (kind / k3s).  Mirrors the structure used
+# in k3s-istio-vault-platform but with minimal resource requests.
+#
+# Chart: prometheus-community/kube-prometheus-stack ~80.13.3
+
+# ---------------------------------------------------------------------------
+# Global
+# ---------------------------------------------------------------------------
+fullnameOverride: ""
+namespaceOverride: ""
+
+# ---------------------------------------------------------------------------
+# Prometheus
+# ---------------------------------------------------------------------------
+prometheus:
+  prometheusSpec:
+    replicas: 1
+    retention: 6h
+    scrapeInterval: 30s
+
+    # Discover ServiceMonitors and PodMonitors from ALL namespaces, not just
+    # those created by this Helm release.
+    serviceMonitorSelectorNilUsesHelmValues: false
+    podMonitorSelectorNilUsesHelmValues: false
+    ruleSelectorNilUsesHelmValues: false
+
+    # Minimal resources for local dev clusters
+    resources:
+      requests:
+        cpu: 100m
+        memory: 256Mi
+      limits:
+        cpu: 500m
+        memory: 512Mi
+
+    # Ephemeral storage is fine for dev; set a PVC for production
+    storageSpec: {}
+
+# ---------------------------------------------------------------------------
+# Grafana
+# ---------------------------------------------------------------------------
+grafana:
+  enabled: true
+  adminPassword: prom-operator
+
+  resources:
+    requests:
+      cpu: 50m
+      memory: 128Mi
+    limits:
+      cpu: 200m
+      memory: 256Mi
+
+  # Load default Kubernetes dashboards
+  defaultDashboardsEnabled: true
+  defaultDashboardsTimezone: utc
+
+  sidecar:
+    dashboards:
+      enabled: true
+      searchNamespace: ALL
+
+# ---------------------------------------------------------------------------
+# AlertManager
+# ---------------------------------------------------------------------------
+alertmanager:
+  enabled: true
+  alertmanagerSpec:
+    replicas: 1
+    resources:
+      requests:
+        cpu: 25m
+        memory: 64Mi
+      limits:
+        cpu: 100m
+        memory: 128Mi
+
+  # Basic config -- alerts go to a null receiver by default.
+  # Override for production with Slack / PagerDuty / email receivers.
+  config:
+    global:
+      resolve_timeout: 5m
+    route:
+      group_by: ["alertname", "namespace"]
+      group_wait: 30s
+      group_interval: 5m
+      repeat_interval: 4h
+      receiver: "null"
+      routes:
+        - match:
+            severity: critical
+          receiver: "null"
+          continue: true
+    receivers:
+      - name: "null"
+
+# ---------------------------------------------------------------------------
+# Disabled components -- not relevant to OpenRange dev clusters
+# ---------------------------------------------------------------------------
+# These targets are unreachable or not meaningful on kind / k3s.
+kubeEtcd:
+  enabled: false
+kubeControllerManager:
+  enabled: false
+kubeScheduler:
+  enabled: false
+kubeProxy:
+  enabled: false
+
+# ---------------------------------------------------------------------------
+# Node exporter -- lightweight; keep it for host-level metrics
+# ---------------------------------------------------------------------------
+nodeExporter:
+  enabled: true
+  resources:
+    requests:
+      cpu: 25m
+      memory: 32Mi
+    limits:
+      cpu: 100m
+      memory: 64Mi
+
+# ---------------------------------------------------------------------------
+# kube-state-metrics
+# ---------------------------------------------------------------------------
+kube-state-metrics:
+  resources:
+    requests:
+      cpu: 25m
+      memory: 32Mi
+    limits:
+      cpu: 100m
+      memory: 128Mi
+
+# ---------------------------------------------------------------------------
+# Prometheus Operator
+# ---------------------------------------------------------------------------
+prometheusOperator:
+  resources:
+    requests:
+      cpu: 50m
+      memory: 64Mi
+    limits:
+      cpu: 200m
+      memory: 256Mi

--- a/deploy/monitoring/servicemonitor.yaml
+++ b/deploy/monitoring/servicemonitor.yaml
@@ -1,0 +1,46 @@
+# servicemonitor.yaml -- ServiceMonitor for OpenRange services
+#
+# Discovers services labelled with `app.kubernetes.io/part-of: openrange` across
+# all namespaces and scrapes their /metrics endpoint.
+#
+# Per-service tuning via annotations:
+#   prometheus.io/scrape: "true"       -- opt-in (default: scraped if label matches)
+#   prometheus.io/port: "8080"         -- override the scrape port
+#   prometheus.io/path: "/custom/metrics" -- override the metrics path
+apiVersion: monitoring.coreos.io/v1
+kind: ServiceMonitor
+metadata:
+  name: openrange-services
+  namespace: monitoring
+  labels:
+    app.kubernetes.io/part-of: openrange
+    app.kubernetes.io/managed-by: helm
+spec:
+  # Discover targets across all namespaces where range services live
+  namespaceSelector:
+    any: true
+
+  # Match any Service carrying the openrange part-of label
+  selector:
+    matchLabels:
+      app.kubernetes.io/part-of: openrange
+
+  endpoints:
+    # Default metrics endpoint
+    - port: http
+      path: /metrics
+      interval: 30s
+      scrapeTimeout: 10s
+      honorLabels: true
+
+    # Fallback: named port "metrics" used by custom exporters
+    - port: metrics
+      path: /metrics
+      interval: 30s
+      scrapeTimeout: 10s
+      honorLabels: true
+
+  # Attach useful target labels from the discovered Service
+  targetLabels:
+    - app.kubernetes.io/part-of
+    - openrange/snapshot

--- a/deploy/vault/README.md
+++ b/deploy/vault/README.md
@@ -1,0 +1,138 @@
+# Vault Integration for OpenRange
+
+Optional HashiCorp Vault integration for managing secrets (LLM API keys,
+database passwords, LDAP credentials) instead of storing them as plaintext
+environment variables.
+
+OpenRange works without Vault. When Vault is not configured, the system
+falls back to environment variables and built-in defaults.
+
+## Quick Start (Local Development)
+
+### 1. Start Vault in dev mode
+
+Using the bootstrap script (requires the `vault` CLI):
+
+```bash
+VAULT_DEV_MODE=true ./deploy/vault/bootstrap-vault.sh
+```
+
+Or manually:
+
+```bash
+vault server -dev -dev-root-token-id=dev-root-token &
+export VAULT_ADDR=http://127.0.0.1:8200
+export VAULT_TOKEN=dev-root-token
+./deploy/vault/bootstrap-vault.sh
+```
+
+### 2. Seed an LLM API key (optional)
+
+```bash
+export OPENRANGE_LLM_API_KEY="sk-your-key-here"
+export OPENRANGE_LLM_API_KEY_NAME="OPENAI_API_KEY"   # default
+./deploy/vault/bootstrap-vault.sh
+```
+
+Or write directly:
+
+```bash
+vault kv put secret/openrange/llm-api-keys OPENAI_API_KEY="sk-..." ANTHROPIC_API_KEY="sk-ant-..."
+```
+
+### 3. Configure OpenRange to use Vault
+
+```bash
+export VAULT_ADDR=http://127.0.0.1:8200
+export VAULT_TOKEN=dev-root-token
+openrange serve
+```
+
+## Kubernetes Deployment
+
+### Install Vault via Helm
+
+```bash
+helm repo add hashicorp https://helm.releases.hashicorp.com
+helm repo update
+helm install vault hashicorp/vault \
+  -n vault --create-namespace \
+  -f deploy/vault/values.yaml
+```
+
+### Bootstrap Vault
+
+```bash
+kubectl port-forward svc/vault -n vault 8200:8200 &
+export VAULT_ADDR=http://127.0.0.1:8200
+export VAULT_TOKEN=dev-root-token
+./deploy/vault/bootstrap-vault.sh
+```
+
+### Kubernetes Auth (production)
+
+For pods running in Kubernetes, configure Vault Kubernetes auth instead of
+using a static token:
+
+```bash
+vault auth enable kubernetes
+vault write auth/kubernetes/config \
+  kubernetes_host="https://$KUBERNETES_PORT_443_TCP_ADDR:443"
+vault write auth/kubernetes/role/openrange \
+  bound_service_account_names=openrange \
+  bound_service_account_namespaces=default \
+  policies=openrange \
+  ttl=1h
+```
+
+Then set in the OpenRange pod:
+
+```bash
+export VAULT_ADDR=http://vault.vault.svc.cluster.local:8200
+export OPENRANGE_VAULT_K8S_ROLE=openrange
+```
+
+## Environment Variables
+
+| Variable | Default | Description |
+|---|---|---|
+| `VAULT_ADDR` | _(none)_ | Vault server address |
+| `VAULT_TOKEN` | _(none)_ | Static Vault token |
+| `VAULT_NAMESPACE` | _(none)_ | Vault namespace (enterprise) |
+| `VAULT_CACERT` | _(none)_ | CA cert path for TLS |
+| `VAULT_SKIP_VERIFY` | `false` | Skip TLS verification |
+| `OPENRANGE_VAULT_KV_MOUNT` | `secret` | KV v2 mount path |
+| `OPENRANGE_VAULT_TRANSIT_MOUNT` | `transit` | Transit mount path |
+| `OPENRANGE_VAULT_TRANSIT_KEY` | `openrange/credentials` | Transit key name |
+| `OPENRANGE_VAULT_K8S_ROLE` | _(none)_ | Kubernetes auth role |
+| `OPENRANGE_VAULT_K8S_MOUNT` | `kubernetes` | Kubernetes auth mount |
+| `OPENRANGE_VAULT_TIMEOUT` | `10` | HTTP timeout (seconds) |
+
+## Secret Paths
+
+| Path | Contents |
+|---|---|
+| `secret/data/openrange/llm-api-keys` | LLM provider API keys (OPENAI_API_KEY, etc.) |
+| `secret/data/openrange/range-credentials` | Range infrastructure credentials (MySQL, LDAP) |
+
+## Python API
+
+```python
+from open_range.server.vault_client import VaultCredentialProvider
+
+provider = VaultCredentialProvider.from_env()
+
+# LLM keys (falls back to env vars)
+key = provider.get_llm_api_key("OPENAI_API_KEY")
+
+# Range credentials (falls back to defaults)
+mysql_pw = provider.get_mysql_root_password()
+
+# Direct Vault client access
+from open_range.server.vault_client import get_vault_client
+
+client = get_vault_client()  # None if Vault is not configured
+if client:
+    client.write_secret("openrange/my-secret", {"key": "value"})
+    ciphertext = client.encrypt("sensitive data")
+```

--- a/deploy/vault/bootstrap-vault.sh
+++ b/deploy/vault/bootstrap-vault.sh
@@ -1,0 +1,160 @@
+#!/usr/bin/env bash
+# bootstrap-vault.sh -- Initialize Vault for OpenRange
+#
+# Enables the Transit and KV v2 engines, creates the transit key for
+# credential encryption, applies the openrange policy, and optionally
+# seeds the initial LLM API key.
+#
+# Adapted from k3s-istio-vault-platform configure-vault.sh.
+#
+# Usage:
+#   # Against a local dev-mode Vault (default):
+#   ./bootstrap-vault.sh
+#
+#   # Against a remote Vault:
+#   VAULT_ADDR=https://vault.example.com:8200 VAULT_TOKEN=s.xxx ./bootstrap-vault.sh
+#
+# Environment variables:
+#   VAULT_ADDR                  Vault address (default: http://127.0.0.1:8200)
+#   VAULT_TOKEN                 Vault root/admin token (default: dev-root-token)
+#   OPENRANGE_VAULT_KV_MOUNT    KV v2 mount path (default: secret)
+#   OPENRANGE_VAULT_TRANSIT_MOUNT Transit mount path (default: transit)
+#   OPENRANGE_VAULT_TRANSIT_KEY Transit key name (default: openrange/credentials)
+#   OPENRANGE_LLM_API_KEY       If set, stored in Vault as the OPENAI_API_KEY
+#   OPENRANGE_LLM_API_KEY_NAME  Env-var-style name for the key (default: OPENAI_API_KEY)
+#   VAULT_DEV_MODE              Set to "true" to start a dev server (default: false)
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd -- "$(dirname -- "$0")" && pwd)"
+
+# Defaults
+VAULT_ADDR="${VAULT_ADDR:-http://127.0.0.1:8200}"
+VAULT_TOKEN="${VAULT_TOKEN:-dev-root-token}"
+KV_MOUNT="${OPENRANGE_VAULT_KV_MOUNT:-secret}"
+TRANSIT_MOUNT="${OPENRANGE_VAULT_TRANSIT_MOUNT:-transit}"
+TRANSIT_KEY="${OPENRANGE_VAULT_TRANSIT_KEY:-openrange/credentials}"
+POLICY_FILE="${SCRIPT_DIR}/policy.hcl"
+VAULT_DEV_MODE="${VAULT_DEV_MODE:-false}"
+
+export VAULT_ADDR
+export VAULT_TOKEN
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+log() { printf '[openrange-vault] %s\n' "$*"; }
+
+check_vault_cli() {
+    if command -v vault >/dev/null 2>&1; then
+        return 0
+    fi
+    echo "ERROR: HashiCorp Vault CLI is required but not found on PATH." >&2
+    echo "Install: https://developer.hashicorp.com/vault/install" >&2
+    exit 1
+}
+
+wait_for_vault() {
+    local attempts=0
+    local max_attempts=30
+    log "Waiting for Vault at ${VAULT_ADDR} ..."
+    while ! vault status >/dev/null 2>&1; do
+        attempts=$((attempts + 1))
+        if [ "$attempts" -ge "$max_attempts" ]; then
+            echo "ERROR: Vault did not become ready within ${max_attempts}s" >&2
+            exit 1
+        fi
+        sleep 1
+    done
+    log "Vault is ready."
+}
+
+# ---------------------------------------------------------------------------
+# Optional: start dev server
+# ---------------------------------------------------------------------------
+
+start_dev_server() {
+    if [ "${VAULT_DEV_MODE}" != "true" ]; then
+        return
+    fi
+    log "Starting Vault in dev mode (root token: ${VAULT_TOKEN}) ..."
+    vault server -dev \
+        -dev-root-token-id="${VAULT_TOKEN}" \
+        -dev-listen-address="127.0.0.1:8200" &
+    VAULT_DEV_PID=$!
+    # shellcheck disable=SC2064
+    trap "kill ${VAULT_DEV_PID} 2>/dev/null || true" EXIT HUP INT TERM
+    sleep 2
+}
+
+# ---------------------------------------------------------------------------
+# Main
+# ---------------------------------------------------------------------------
+
+check_vault_cli
+start_dev_server
+wait_for_vault
+
+# -- Enable Transit engine --------------------------------------------------
+log "Enabling Transit secrets engine at ${TRANSIT_MOUNT}/ ..."
+vault secrets enable -path="${TRANSIT_MOUNT}" transit 2>/dev/null \
+    && log "Transit engine enabled." \
+    || log "Transit engine already enabled (skipped)."
+
+# -- Enable KV v2 engine ---------------------------------------------------
+log "Enabling KV v2 secrets engine at ${KV_MOUNT}/ ..."
+vault secrets enable -path="${KV_MOUNT}" -version=2 kv 2>/dev/null \
+    && log "KV v2 engine enabled." \
+    || log "KV v2 engine already enabled (skipped)."
+
+# -- Create Transit key -----------------------------------------------------
+log "Creating Transit key '${TRANSIT_KEY}' ..."
+vault read "${TRANSIT_MOUNT}/keys/${TRANSIT_KEY}" >/dev/null 2>&1 \
+    || vault write -f "${TRANSIT_MOUNT}/keys/${TRANSIT_KEY}" type="aes256-gcm96"
+log "Transit key '${TRANSIT_KEY}' is ready."
+
+# -- Apply policy -----------------------------------------------------------
+if [ -f "${POLICY_FILE}" ]; then
+    log "Writing Vault policy 'openrange' from ${POLICY_FILE} ..."
+    vault policy write openrange "${POLICY_FILE}"
+    log "Policy 'openrange' applied."
+else
+    log "WARNING: Policy file not found at ${POLICY_FILE}; skipping policy write."
+fi
+
+# -- Seed LLM API key (optional) -------------------------------------------
+if [ -n "${OPENRANGE_LLM_API_KEY:-}" ]; then
+    KEY_NAME="${OPENRANGE_LLM_API_KEY_NAME:-OPENAI_API_KEY}"
+    log "Storing LLM API key (${KEY_NAME}) in Vault KV at ${KV_MOUNT}/openrange/llm-api-keys ..."
+    vault kv put "${KV_MOUNT}/openrange/llm-api-keys" "${KEY_NAME}=${OPENRANGE_LLM_API_KEY}"
+    log "LLM API key stored."
+else
+    log "OPENRANGE_LLM_API_KEY not set; skipping initial LLM key seeding."
+fi
+
+# -- Seed empty range-credentials path (ensures it exists) ------------------
+vault kv get "${KV_MOUNT}/openrange/range-credentials" >/dev/null 2>&1 || {
+    log "Initializing empty range-credentials path ..."
+    vault kv put "${KV_MOUNT}/openrange/range-credentials" _init="true"
+}
+
+# -- Enable audit logging (dev convenience) ---------------------------------
+vault audit list 2>/dev/null | grep -q '^stdout/' || {
+    log "Enabling stdout audit device ..."
+    vault audit enable -path=stdout file file_path=stdout 2>/dev/null || true
+}
+
+# -- Summary ----------------------------------------------------------------
+log ""
+log "=== OpenRange Vault Bootstrap Complete ==="
+log "  Vault address:     ${VAULT_ADDR}"
+log "  KV v2 mount:       ${KV_MOUNT}/"
+log "  Transit mount:     ${TRANSIT_MOUNT}/"
+log "  Transit key:       ${TRANSIT_KEY}"
+log "  Policy:            openrange"
+log ""
+log "Export these to configure the Python client:"
+log "  export VAULT_ADDR=${VAULT_ADDR}"
+log "  export VAULT_TOKEN=${VAULT_TOKEN}"
+log ""

--- a/deploy/vault/policy.hcl
+++ b/deploy/vault/policy.hcl
@@ -1,0 +1,62 @@
+# Vault policy for the OpenRange cybersecurity gymnasium.
+#
+# Grants:
+# - KV v2 read/write on the openrange secret namespace
+# - Transit encrypt/decrypt using the openrange/credentials key
+#
+# Adapted from k3s-istio-vault-platform secret-store-transit.hcl.
+
+# ---------------------------------------------------------------------------
+# Token introspection (required for token renewal / lease management)
+# ---------------------------------------------------------------------------
+
+path "auth/token/lookup-self" {
+  capabilities = ["read"]
+}
+
+path "auth/token/renew-self" {
+  capabilities = ["update"]
+}
+
+# ---------------------------------------------------------------------------
+# KV v2 -- openrange secret namespace
+# ---------------------------------------------------------------------------
+
+# Read and write secrets under secret/data/openrange/*
+path "secret/data/openrange/*" {
+  capabilities = ["create", "update", "read"]
+}
+
+# Allow listing secrets under the openrange namespace
+path "secret/metadata/openrange/*" {
+  capabilities = ["list", "read"]
+}
+
+# Allow deleting secrets (optional -- useful for credential rotation)
+path "secret/delete/openrange/*" {
+  capabilities = ["update"]
+}
+
+# ---------------------------------------------------------------------------
+# Transit -- encrypt / decrypt with the openrange/credentials key
+# ---------------------------------------------------------------------------
+
+# Encrypt data
+path "transit/encrypt/openrange/credentials" {
+  capabilities = ["update"]
+}
+
+# Decrypt data
+path "transit/decrypt/openrange/credentials" {
+  capabilities = ["update"]
+}
+
+# Generate data keys for envelope encryption
+path "transit/datakey/plaintext/openrange/credentials" {
+  capabilities = ["update"]
+}
+
+# Read key metadata (e.g. current key version)
+path "transit/keys/openrange/credentials" {
+  capabilities = ["read"]
+}

--- a/deploy/vault/values.yaml
+++ b/deploy/vault/values.yaml
@@ -1,0 +1,134 @@
+# Helm values for deploying HashiCorp Vault alongside OpenRange.
+#
+# Usage:
+#   helm repo add hashicorp https://helm.releases.hashicorp.com
+#   helm install vault hashicorp/vault -n vault --create-namespace -f values.yaml
+#
+# These values configure Vault in dev mode for local development.
+# See the commented-out HA Raft section below for production guidance.
+#
+# Reference: HashiCorp Vault Helm chart
+#   https://developer.hashicorp.com/vault/docs/platform/k8s/helm
+# Adapted from k3s-istio-vault-platform Vault deployment.
+
+global:
+  enabled: true
+  tlsDisable: true  # Dev mode; set to false for production with TLS
+
+# -- Injector (sidecar agent) -----------------------------------------------
+injector:
+  enabled: false  # Enable if you want automatic sidecar injection
+
+# -- CSI provider -----------------------------------------------------------
+csi:
+  enabled: false
+
+# -- Server -----------------------------------------------------------------
+server:
+  # Dev mode: single-node, in-memory, auto-unsealed, root token = "dev-root-token"
+  dev:
+    enabled: true
+    devRootToken: "dev-root-token"
+
+  # Resource limits for local development
+  resources:
+    requests:
+      memory: 64Mi
+      cpu: 50m
+    limits:
+      memory: 256Mi
+      cpu: 250m
+
+  # Audit log storage (persisted even in dev mode if enabled)
+  auditStorage:
+    enabled: true
+    size: 1Gi
+
+  # Data storage (not used in dev mode, but pre-configured for switching to prod)
+  dataStorage:
+    enabled: true
+    size: 5Gi
+
+  # Standalone mode configuration (used when dev.enabled is true)
+  standalone:
+    enabled: true
+    config: |
+      ui = true
+
+      listener "tcp" {
+        tls_disable = 1
+        address = "[::]:8200"
+        cluster_address = "[::]:8201"
+      }
+
+      storage "file" {
+        path = "/vault/data"
+      }
+
+  # -- HA Raft mode (production) -------------------------------------------
+  # Uncomment and set dev.enabled=false, standalone.enabled=false for production.
+  #
+  # ha:
+  #   enabled: true
+  #   replicas: 3
+  #   raft:
+  #     enabled: true
+  #     setNodeId: true
+  #     config: |
+  #       ui = false
+  #
+  #       listener "tcp" {
+  #         tls_disable = 0
+  #         address = "[::]:8200"
+  #         cluster_address = "[::]:8201"
+  #         tls_cert_file = "/vault/userconfig/tls/tls.crt"
+  #         tls_key_file  = "/vault/userconfig/tls/tls.key"
+  #         tls_client_ca_file = "/vault/userconfig/tls/ca.crt"
+  #       }
+  #
+  #       storage "raft" {
+  #         path = "/vault/data"
+  #
+  #         retry_join {
+  #           leader_api_addr = "https://vault-0.vault-internal:8200"
+  #           leader_ca_cert_file = "/vault/userconfig/tls/ca.crt"
+  #           leader_client_cert_file = "/vault/userconfig/tls/tls.crt"
+  #           leader_client_key_file  = "/vault/userconfig/tls/tls.key"
+  #         }
+  #         retry_join {
+  #           leader_api_addr = "https://vault-1.vault-internal:8200"
+  #           leader_ca_cert_file = "/vault/userconfig/tls/ca.crt"
+  #           leader_client_cert_file = "/vault/userconfig/tls/tls.crt"
+  #           leader_client_key_file  = "/vault/userconfig/tls/tls.key"
+  #         }
+  #         retry_join {
+  #           leader_api_addr = "https://vault-2.vault-internal:8200"
+  #           leader_ca_cert_file = "/vault/userconfig/tls/ca.crt"
+  #           leader_client_cert_file = "/vault/userconfig/tls/tls.crt"
+  #           leader_client_key_file  = "/vault/userconfig/tls/tls.key"
+  #         }
+  #       }
+  #
+  #       service_registration "kubernetes" {}
+  #
+  # -- Production TLS volumes (uncomment for HA mode) ----------------------
+  # volumes:
+  #   - name: vault-server-tls
+  #     secret:
+  #       defaultMode: 420
+  #       secretName: vault-server-tls
+  # volumeMounts:
+  #   - name: vault-server-tls
+  #     mountPath: /vault/userconfig/tls
+  #     readOnly: true
+  # extraEnvironmentVars:
+  #   VAULT_CACERT: /vault/userconfig/tls/ca.crt
+  #   VAULT_TLSCERT: /vault/userconfig/tls/tls.crt
+  #   VAULT_TLSKEY: /vault/userconfig/tls/tls.key
+
+# -- UI ---------------------------------------------------------------------
+ui:
+  enabled: true
+  serviceType: ClusterIP
+  # For local development with port-forward:
+  #   kubectl port-forward svc/vault-ui -n vault 8200:8200

--- a/src/open_range/cilium_policies.py
+++ b/src/open_range/cilium_policies.py
@@ -1,0 +1,424 @@
+"""Generate CiliumNetworkPolicy manifests from open-range zone topology.
+
+This module translates open-range's zone/firewall configuration into Cilium's
+eBPF-enforced network policies, providing stronger isolation than standard
+Kubernetes NetworkPolicy resources.
+
+Key differences from standard NetworkPolicy:
+- ``CiliumNetworkPolicy`` uses Cilium's eBPF datapath for enforcement
+- L7 HTTP rules allow path-based and method-based filtering
+- DNS-aware policies enable FQDN-based egress controls
+- Identity-based selectors provide efficient pod-to-pod filtering
+
+This module is completely optional. When Cilium is not installed, open-range
+falls back to the standard NetworkPolicy templates in the Helm chart.
+"""
+
+from __future__ import annotations
+
+import logging
+from typing import Any
+
+from pydantic import BaseModel, Field
+
+logger = logging.getLogger(__name__)
+
+# ---------------------------------------------------------------------------
+# Configuration model
+# ---------------------------------------------------------------------------
+
+
+class CiliumPolicyConfig(BaseModel):
+    """Configuration for CiliumNetworkPolicy generation."""
+
+    enable_l7: bool = Field(
+        default=True,
+        description="Enable L7 HTTP rules for web services",
+    )
+    enable_dns: bool = Field(
+        default=True,
+        description="Enable DNS-aware egress policies",
+    )
+    dns_match_pattern: str = Field(
+        default="*.cluster.local",
+        description="DNS pattern for in-cluster service discovery",
+    )
+    default_deny_egress: bool = Field(
+        default=False,
+        description="Apply default-deny egress in addition to ingress",
+    )
+    zone_label: str = Field(
+        default="openrange/zone",
+        description="Label key used to identify zone namespaces",
+    )
+    name_prefix_label: str = Field(
+        default="app.kubernetes.io/instance",
+        description="Label key used to identify release instance",
+    )
+
+
+# ---------------------------------------------------------------------------
+# Policy generator
+# ---------------------------------------------------------------------------
+
+
+class CiliumPolicyGenerator:
+    """Generate CiliumNetworkPolicy manifests from open-range zone topology.
+
+    Produces YAML-serializable dicts representing CiliumNetworkPolicy
+    resources.  These are Cilium-specific CRDs that extend standard
+    NetworkPolicy with L7 HTTP rules, DNS-aware egress, and identity-based
+    selectors.
+
+    Usage::
+
+        gen = CiliumPolicyGenerator(name_prefix="or-my-range")
+        zones = {"dmz": [...], "internal": [...], "management": [...]}
+        fw_rules = [
+            {"action": "allow", "fromZone": "dmz", "toZone": "internal", "ports": [80, 443]},
+        ]
+        policies = gen.generate_zone_policies(zones, fw_rules)
+
+        services = {
+            "web": {"ports": [80, 443], "paths": ["/api/*", "/health"]},
+            "db":  {"ports": [3306]},
+        }
+        l7_policies = gen.generate_l7_policies(services)
+    """
+
+    API_VERSION = "cilium.io/v2"
+    KIND = "CiliumNetworkPolicy"
+
+    def __init__(
+        self,
+        name_prefix: str = "openrange",
+        config: CiliumPolicyConfig | None = None,
+    ) -> None:
+        self.name_prefix = name_prefix
+        self.config = config or CiliumPolicyConfig()
+
+    # ------------------------------------------------------------------
+    # Public API
+    # ------------------------------------------------------------------
+
+    def generate_zone_policies(
+        self,
+        zones: dict[str, Any],
+        firewall_rules: list[dict[str, Any]],
+    ) -> list[dict[str, Any]]:
+        """Generate default-deny + zone-allow + cross-zone CiliumNetworkPolicy resources.
+
+        Parameters
+        ----------
+        zones:
+            Mapping of zone name to list of hosts/services in that zone.
+            Example: ``{"dmz": ["web", "proxy"], "internal": ["db", "app"]}``
+        firewall_rules:
+            List of firewall rule dicts with keys ``action``, ``fromZone``,
+            ``toZone``, and optionally ``ports``.
+
+        Returns
+        -------
+        list[dict]:
+            List of CiliumNetworkPolicy manifest dicts ready for YAML
+            serialization or ``kubectl apply``.
+        """
+        policies: list[dict[str, Any]] = []
+
+        for zone_name in zones:
+            namespace = f"{self.name_prefix}-{zone_name}"
+
+            # 1) Default deny all ingress (and optionally egress)
+            policies.append(self._default_deny(zone_name, namespace))
+
+            # 2) Allow intra-zone traffic
+            policies.append(self._allow_same_zone(zone_name, namespace))
+
+            # 3) Allow DNS egress for service discovery
+            if self.config.enable_dns:
+                policies.append(self._dns_egress(zone_name, namespace))
+
+        # 4) Cross-zone allow rules from firewall configuration
+        for rule in firewall_rules:
+            action = rule.get("action", "deny")
+            if action != "allow":
+                continue
+            from_zone = rule.get("fromZone") or rule.get("from_zone", "")
+            to_zone = rule.get("toZone") or rule.get("to_zone", "")
+            ports = rule.get("ports", [])
+            if from_zone and to_zone:
+                namespace = f"{self.name_prefix}-{to_zone}"
+                policies.append(
+                    self._cross_zone_allow(from_zone, to_zone, namespace, ports)
+                )
+
+        return policies
+
+    def generate_l7_policies(
+        self,
+        services: dict[str, dict[str, Any]],
+    ) -> list[dict[str, Any]]:
+        """Generate L7 HTTP policies for web services.
+
+        Parameters
+        ----------
+        services:
+            Mapping of service name to config dict.  Each config may contain:
+            - ``zone`` (str): Zone the service belongs to.
+            - ``ports`` (list[int]): TCP ports the service listens on.
+            - ``paths`` (list[str]): Allowed HTTP paths (e.g. ``["/api/*", "/health"]``).
+            - ``methods`` (list[str]): Allowed HTTP methods (e.g. ``["GET", "POST"]``).
+
+        Returns
+        -------
+        list[dict]:
+            List of CiliumNetworkPolicy manifest dicts with L7 HTTP rules.
+        """
+        if not self.config.enable_l7:
+            logger.debug("L7 policies disabled via config; returning empty list")
+            return []
+
+        policies: list[dict[str, Any]] = []
+
+        for svc_name, svc_config in services.items():
+            zone = svc_config.get("zone", "")
+            ports = svc_config.get("ports", [])
+            paths = svc_config.get("paths", [])
+            methods = svc_config.get("methods", [])
+
+            if not ports:
+                continue
+
+            namespace = f"{self.name_prefix}-{zone}" if zone else self.name_prefix
+
+            ingress_rules: list[dict[str, Any]] = []
+
+            for port in ports:
+                port_rule: dict[str, Any] = {
+                    "fromEndpoints": [{"matchLabels": {}}],
+                    "toPorts": [
+                        {
+                            "ports": [
+                                {"port": str(port), "protocol": "TCP"},
+                            ],
+                        }
+                    ],
+                }
+
+                # Add L7 HTTP rules if paths or methods are specified
+                if paths or methods:
+                    http_rules: list[dict[str, str]] = []
+                    if paths and methods:
+                        for path in paths:
+                            for method in methods:
+                                http_rules.append({"path": path, "method": method})
+                    elif paths:
+                        for path in paths:
+                            http_rules.append({"path": path})
+                    elif methods:
+                        for method in methods:
+                            http_rules.append({"method": method})
+
+                    port_rule["toPorts"][0]["rules"] = {"http": http_rules}
+
+                ingress_rules.append(port_rule)
+
+            policy: dict[str, Any] = {
+                "apiVersion": self.API_VERSION,
+                "kind": self.KIND,
+                "metadata": {
+                    "name": f"l7-{svc_name}",
+                    "namespace": namespace,
+                },
+                "spec": {
+                    "endpointSelector": {
+                        "matchLabels": {"app": svc_name},
+                    },
+                    "ingress": ingress_rules,
+                },
+            }
+            policies.append(policy)
+
+        return policies
+
+    def generate_all(
+        self,
+        zones: dict[str, Any],
+        firewall_rules: list[dict[str, Any]],
+        services: dict[str, dict[str, Any]] | None = None,
+    ) -> list[dict[str, Any]]:
+        """Generate all policy types in a single call.
+
+        Convenience method that combines :meth:`generate_zone_policies` and
+        :meth:`generate_l7_policies`.
+        """
+        policies = self.generate_zone_policies(zones, firewall_rules)
+        if services:
+            policies.extend(self.generate_l7_policies(services))
+        return policies
+
+    # ------------------------------------------------------------------
+    # Internal helpers
+    # ------------------------------------------------------------------
+
+    def _default_deny(
+        self,
+        zone_name: str,
+        namespace: str,
+    ) -> dict[str, Any]:
+        """Default-deny ingress (and optionally egress) for a zone namespace."""
+        policy_types = ["Ingress"]
+        spec: dict[str, Any] = {
+            "endpointSelector": {},
+        }
+
+        if self.config.default_deny_egress:
+            policy_types.append("Egress")
+
+        # CiliumNetworkPolicy uses ingress/egress empty lists for deny
+        spec["ingress"] = [{}]  # placeholder -- overridden by explicit deny
+        # Actually, for default deny: omit ingress entirely with empty selector
+        spec = {
+            "endpointSelector": {},
+        }
+
+        return {
+            "apiVersion": self.API_VERSION,
+            "kind": self.KIND,
+            "metadata": {
+                "name": "default-deny-ingress",
+                "namespace": namespace,
+                "labels": {
+                    self.config.zone_label: zone_name,
+                    "openrange/policy-type": "default-deny",
+                },
+            },
+            "spec": spec,
+        }
+
+    def _allow_same_zone(
+        self,
+        zone_name: str,
+        namespace: str,
+    ) -> dict[str, Any]:
+        """Allow all traffic within the same zone namespace."""
+        return {
+            "apiVersion": self.API_VERSION,
+            "kind": self.KIND,
+            "metadata": {
+                "name": "allow-same-zone",
+                "namespace": namespace,
+                "labels": {
+                    self.config.zone_label: zone_name,
+                    "openrange/policy-type": "intra-zone",
+                },
+            },
+            "spec": {
+                "endpointSelector": {},
+                "ingress": [
+                    {
+                        "fromEndpoints": [
+                            {
+                                "matchLabels": {
+                                    "k8s:io.kubernetes.pod.namespace": namespace,
+                                },
+                            },
+                        ],
+                    },
+                ],
+            },
+        }
+
+    def _cross_zone_allow(
+        self,
+        from_zone: str,
+        to_zone: str,
+        namespace: str,
+        ports: list[int],
+    ) -> dict[str, Any]:
+        """Allow cross-zone traffic based on firewall rules."""
+        from_namespace = f"{self.name_prefix}-{from_zone}"
+
+        ingress_from: dict[str, Any] = {
+            "fromEndpoints": [
+                {
+                    "matchLabels": {
+                        "k8s:io.kubernetes.pod.namespace": from_namespace,
+                    },
+                },
+            ],
+        }
+
+        if ports:
+            ingress_from["toPorts"] = [
+                {
+                    "ports": [{"port": str(p), "protocol": "TCP"} for p in ports],
+                }
+            ]
+
+        return {
+            "apiVersion": self.API_VERSION,
+            "kind": self.KIND,
+            "metadata": {
+                "name": f"allow-{from_zone}-to-{to_zone}",
+                "namespace": namespace,
+                "labels": {
+                    self.config.zone_label: to_zone,
+                    "openrange/policy-type": "cross-zone",
+                    "openrange/from-zone": from_zone,
+                },
+            },
+            "spec": {
+                "endpointSelector": {},
+                "ingress": [ingress_from],
+            },
+        }
+
+    def _dns_egress(
+        self,
+        zone_name: str,
+        namespace: str,
+    ) -> dict[str, Any]:
+        """Allow DNS egress for Kubernetes service discovery."""
+        return {
+            "apiVersion": self.API_VERSION,
+            "kind": self.KIND,
+            "metadata": {
+                "name": "allow-dns-egress",
+                "namespace": namespace,
+                "labels": {
+                    self.config.zone_label: zone_name,
+                    "openrange/policy-type": "dns-egress",
+                },
+            },
+            "spec": {
+                "endpointSelector": {},
+                "egress": [
+                    {
+                        "toEndpoints": [
+                            {
+                                "matchLabels": {
+                                    "k8s:io.kubernetes.pod.namespace": "kube-system",
+                                    "k8s-app": "kube-dns",
+                                },
+                            },
+                        ],
+                        "toPorts": [
+                            {
+                                "ports": [
+                                    {"port": "53", "protocol": "UDP"},
+                                    {"port": "53", "protocol": "TCP"},
+                                ],
+                                "rules": {
+                                    "dns": [
+                                        {
+                                            "matchPattern": self.config.dns_match_pattern,
+                                        },
+                                    ],
+                                },
+                            },
+                        ],
+                    },
+                ],
+            },
+        }

--- a/src/open_range/cli.py
+++ b/src/open_range/cli.py
@@ -289,7 +289,6 @@ def traces_cmd(
     click.echo(f"  Decision SFT: {report.decision_sft_path}")
     click.echo(f"  Report: {report_path}")
 
-
 @cli.command("grpo")
 @click.option(
     "--model",
@@ -388,7 +387,6 @@ def grpo_cmd(
     result = subprocess.run(command, check=False)
     if result.returncode != 0:
         raise SystemExit(result.returncode)
-
 
 if __name__ == "__main__":
     cli()

--- a/src/open_range/credential_lifecycle.py
+++ b/src/open_range/credential_lifecycle.py
@@ -1,0 +1,398 @@
+"""NPC credential lifecycle -- token refresh, session management, rotation.
+
+Manages NPC credential state over time so that NPCs have rotating session
+tokens, bearer JWTs in HTTP headers, and periodic credential changes.
+This creates realistic traffic patterns and new attack surfaces (token
+theft, session hijack, replay).
+
+Ported from k3s-istio-vault-platform's OAuth token lifecycle pattern:
+- Short-lived tokens (5-min default TTL)
+- Automatic refresh before expiry (configurable margin)
+- Token JTI tracking for audit correlation
+- Session files written to container filesystem (accessible to Red)
+
+This module is completely optional -- the NPC system works without it.
+When ``CredentialLifecycleConfig.enabled`` is False (default), no
+sessions or tokens are generated.
+"""
+
+from __future__ import annotations
+
+import json
+import logging
+import secrets
+import time
+import uuid
+from typing import Any
+
+import jwt
+from pydantic import BaseModel, Field
+
+logger = logging.getLogger(__name__)
+
+# Range-local HMAC secret used for HS256 JWTs.  In a live range this
+# would be provisioned per-range; here we use a deterministic default
+# so that tests are reproducible and tokens are verifiable within the
+# same process.
+_DEFAULT_JWT_SECRET = "open-range-npc-jwt-secret-do-not-use-in-prod"
+
+# ---------------------------------------------------------------------------
+# Configuration
+# ---------------------------------------------------------------------------
+
+
+class CredentialLifecycleConfig(BaseModel):
+    """Configuration for NPC credential lifecycle.
+
+    All fields have safe defaults so that a bare
+    ``CredentialLifecycleConfig()`` disables the lifecycle and changes
+    nothing about existing NPC behaviour.
+    """
+
+    enabled: bool = False
+    session_ttl_minutes: int = 30
+    token_ttl_minutes: int = 5  # Matches k3s-istio-vault-platform's 5-min default
+    token_refresh_margin_seconds: int = 30
+    credential_rotation_hours: int = 24
+    jwt_secret: str = _DEFAULT_JWT_SECRET
+    jwt_issuer: str = "open-range-npc"
+    jwt_audience: str = "open-range"
+
+    # Weaknesses that create attack surfaces
+    weaknesses: list[str] = Field(default_factory=list)
+    # Recognised values:
+    #   "predictable_session_id"    -- session IDs are sequential hex
+    #   "no_token_expiry"           -- JWTs have no exp claim
+    #   "session_fixation"          -- session ID never rotates on re-auth
+    #   "token_in_url"              -- bearer token appears in URL query params
+    #   "reusable_token"            -- refreshed tokens keep the same jti
+    #   "plaintext_session_storage" -- session file includes plaintext password
+
+
+# ---------------------------------------------------------------------------
+# Session state
+# ---------------------------------------------------------------------------
+
+
+class NPCSession(BaseModel):
+    """Active session state for an NPC."""
+
+    username: str
+    host: str = ""
+    session_id: str  # UUID or predictable hex depending on weakness
+    bearer_token: str | None = None  # JWT if identity provider is configured
+    token_jti: str | None = None  # Token ID for audit correlation
+    token_expires_at: float | None = None  # Unix timestamp
+    session_created_at: float
+    session_expires_at: float
+    last_refresh_at: float | None = None
+    password: str | None = None  # Only stored when plaintext_session_storage
+
+
+# ---------------------------------------------------------------------------
+# Predictable session counter (weakness)
+# ---------------------------------------------------------------------------
+
+_predictable_counter: int = 0
+
+
+def _next_predictable_session_id() -> str:
+    """Return a short, incrementing hex session ID (guessable)."""
+    global _predictable_counter
+    _predictable_counter += 1
+    return f"{_predictable_counter:08x}"
+
+
+def reset_predictable_counter() -> None:
+    """Reset the predictable counter (for tests)."""
+    global _predictable_counter
+    _predictable_counter = 0
+
+
+# ---------------------------------------------------------------------------
+# Manager
+# ---------------------------------------------------------------------------
+
+
+class CredentialLifecycleManager:
+    """Manages NPC session tokens and credential rotation.
+
+    Ported from k3s-istio-vault-platform's OAuth token lifecycle pattern:
+    - Short-lived tokens (5-min default)
+    - Automatic refresh before expiry
+    - Token JTI tracking for audit correlation
+    - Session files written to container filesystem (accessible to Red)
+    """
+
+    def __init__(self, config: CredentialLifecycleConfig) -> None:
+        self._config = config
+        # Track credentials per username for rotation
+        self._credentials: dict[str, str] = {}
+        # Track active sessions per username
+        self._sessions: dict[str, NPCSession] = {}
+
+    @property
+    def config(self) -> CredentialLifecycleConfig:
+        """Return the lifecycle configuration."""
+        return self._config
+
+    # ------------------------------------------------------------------
+    # Session creation
+    # ------------------------------------------------------------------
+
+    def create_session(self, username: str, host: str) -> NPCSession:
+        """Create a new NPC session with tokens.
+
+        Generates a session ID (UUID or predictable depending on weakness
+        config), a bearer JWT, and tracks the session for later refresh
+        and rotation.
+        """
+        now = time.time()
+
+        # Session ID generation
+        if "predictable_session_id" in self._config.weaknesses:
+            session_id = _next_predictable_session_id()
+        else:
+            session_id = uuid.uuid4().hex
+
+        # Token JTI
+        jti = secrets.token_urlsafe(16)
+
+        # Token expiry
+        if "no_token_expiry" in self._config.weaknesses:
+            token_expires_at = None
+        else:
+            token_expires_at = now + self._config.token_ttl_minutes * 60
+
+        # Build JWT
+        bearer_token = self._issue_jwt(
+            username=username,
+            jti=jti,
+            issued_at=now,
+            expires_at=token_expires_at,
+        )
+
+        session = NPCSession(
+            username=username,
+            host=host,
+            session_id=session_id,
+            bearer_token=bearer_token,
+            token_jti=jti,
+            token_expires_at=token_expires_at,
+            session_created_at=now,
+            session_expires_at=now + self._config.session_ttl_minutes * 60,
+            last_refresh_at=now,
+        )
+
+        # Store plaintext password reference when weakness is active
+        if "plaintext_session_storage" in self._config.weaknesses:
+            session.password = self._credentials.get(username)
+
+        self._sessions[username] = session
+        return session
+
+    # ------------------------------------------------------------------
+    # Token refresh
+    # ------------------------------------------------------------------
+
+    def should_refresh(self, session: NPCSession) -> bool:
+        """Check if token needs refresh (within margin of expiry).
+
+        Returns False when the ``no_token_expiry`` weakness is active
+        (tokens never expire, so they never need refreshing).
+        """
+        if session.token_expires_at is None:
+            return False
+        margin = self._config.token_refresh_margin_seconds
+        return time.time() >= (session.token_expires_at - margin)
+
+    def refresh_token(self, session: NPCSession) -> NPCSession:
+        """Refresh an expired or near-expired token.
+
+        Issues a new JWT with a fresh (or reused, if weakness) JTI and
+        updates the session in place.
+        """
+        now = time.time()
+
+        # JTI handling
+        if "reusable_token" in self._config.weaknesses:
+            jti = session.token_jti or secrets.token_urlsafe(16)
+        else:
+            jti = secrets.token_urlsafe(16)
+
+        # Token expiry
+        if "no_token_expiry" in self._config.weaknesses:
+            token_expires_at = None
+        else:
+            token_expires_at = now + self._config.token_ttl_minutes * 60
+
+        bearer_token = self._issue_jwt(
+            username=session.username,
+            jti=jti,
+            issued_at=now,
+            expires_at=token_expires_at,
+        )
+
+        session.bearer_token = bearer_token
+        session.token_jti = jti
+        session.token_expires_at = token_expires_at
+        session.last_refresh_at = now
+
+        self._sessions[session.username] = session
+        return session
+
+    # ------------------------------------------------------------------
+    # Credential rotation
+    # ------------------------------------------------------------------
+
+    def rotate_credentials(self, username: str) -> dict[str, str]:
+        """Rotate NPC password.
+
+        Returns ``{"old_password": ..., "new_password": ...}``.
+        The new password is stored internally for subsequent session
+        creation.
+        """
+        old_password = self._credentials.get(username, "")
+        new_password = _generate_password()
+        self._credentials[username] = new_password
+        return {"old_password": old_password, "new_password": new_password}
+
+    def set_initial_password(self, username: str, password: str) -> None:
+        """Seed the initial password for a username (before first rotation)."""
+        self._credentials[username] = password
+
+    # ------------------------------------------------------------------
+    # Session file generation
+    # ------------------------------------------------------------------
+
+    def generate_session_file(self, session: NPCSession) -> str:
+        """Generate JSON content for ``/tmp/sessions/{username}.json``.
+
+        This file is written to the container filesystem and is
+        accessible to Red if they compromise the container.
+
+        When the ``plaintext_session_storage`` weakness is active the
+        file additionally contains the NPC's plaintext password.
+        """
+        data: dict[str, Any] = {
+            "username": session.username,
+            "session_id": session.session_id,
+            "token_jti": session.token_jti,
+            "session_created_at": session.session_created_at,
+            "session_expires_at": session.session_expires_at,
+            "last_refresh_at": session.last_refresh_at,
+        }
+
+        if session.bearer_token is not None:
+            data["bearer_token"] = session.bearer_token
+
+        if session.token_expires_at is not None:
+            data["token_expires_at"] = session.token_expires_at
+
+        if "plaintext_session_storage" in self._config.weaknesses:
+            password = session.password or self._credentials.get(session.username, "")
+            if password:
+                data["password"] = password
+
+        return json.dumps(data, indent=2)
+
+    # ------------------------------------------------------------------
+    # HTTP headers
+    # ------------------------------------------------------------------
+
+    def generate_auth_headers(self, session: NPCSession) -> dict[str, str]:
+        """Generate HTTP headers for NPC requests.
+
+        Returns headers like::
+
+            {"Cookie": "session=<session_id>", "Authorization": "Bearer <jwt>"}
+        """
+        headers: dict[str, str] = {
+            "Cookie": f"session={session.session_id}",
+        }
+        if session.bearer_token is not None:
+            headers["Authorization"] = f"Bearer {session.bearer_token}"
+        return headers
+
+    # ------------------------------------------------------------------
+    # Traffic log entries
+    # ------------------------------------------------------------------
+
+    def get_traffic_log_entry(
+        self,
+        session: NPCSession,
+        action: str,
+        target: str,
+    ) -> dict[str, Any]:
+        """Generate a structured log entry for an NPC action with session context.
+
+        Adds ``session_id`` and ``token_jti`` to the log entry for
+        forensic/audit correlation.  When the ``token_in_url`` weakness
+        is active, the target URL is rewritten to include the bearer
+        token as a query parameter.
+        """
+        log_target = target
+        if (
+            "token_in_url" in self._config.weaknesses
+            and session.bearer_token is not None
+        ):
+            separator = "&" if "?" in target else "?"
+            log_target = f"{target}{separator}token={session.bearer_token}"
+
+        entry: dict[str, Any] = {
+            "timestamp": time.time(),
+            "type": f"npc_{action}",
+            "label": "benign",
+            "username": session.username,
+            "session_id": session.session_id,
+            "token_jti": session.token_jti,
+            "action": action,
+            "target": log_target,
+        }
+        return entry
+
+    # ------------------------------------------------------------------
+    # Internal helpers
+    # ------------------------------------------------------------------
+
+    def _issue_jwt(
+        self,
+        username: str,
+        jti: str,
+        issued_at: float,
+        expires_at: float | None,
+    ) -> str:
+        """Issue a compact HS256 JWT for the given NPC.
+
+        Mirrors the claim structure from k3s-istio-vault-platform's
+        ``issueToken`` but uses HS256 with a range-local secret for
+        simplicity (no RSA key management needed in the range).
+        """
+        payload: dict[str, Any] = {
+            "sub": username,
+            "iss": self._config.jwt_issuer,
+            "aud": self._config.jwt_audience,
+            "jti": jti,
+            "iat": int(issued_at),
+        }
+        if expires_at is not None:
+            payload["exp"] = int(expires_at)
+
+        return jwt.encode(
+            payload,
+            self._config.jwt_secret,
+            algorithm="HS256",
+        )
+
+
+# ---------------------------------------------------------------------------
+# Password generation
+# ---------------------------------------------------------------------------
+
+
+def _generate_password(length: int = 16) -> str:
+    """Generate a random password suitable for NPC credential rotation."""
+    # Use secrets for cryptographic randomness; mix in a readable prefix
+    # so forensic analysts can recognise rotated NPC passwords in logs.
+    raw = secrets.token_urlsafe(length)
+    return f"NPC-{raw[:length]}"

--- a/src/open_range/encryption_enforcement.py
+++ b/src/open_range/encryption_enforcement.py
@@ -1,0 +1,96 @@
+"""Check: Encryption enforcement -- validates envelope encryption compliance.
+
+Advisory check that verifies envelope encryption config files are present
+and consistent in the rendered artifact directory.  This check is advisory:
+failures log warnings but never block admission, since envelope encryption
+is an optional layer.
+"""
+
+from __future__ import annotations
+
+import json
+import logging
+from pathlib import Path
+
+from open_range.admission import ValidatorCheckReport
+from open_range.snapshot import KindArtifacts
+from open_range.world_ir import WorldIR
+
+logger = logging.getLogger(__name__)
+
+_BUNDLE_REQUIRED_KEYS = {"ciphertext", "nonce", "wrapped_dek", "aad"}
+
+
+def check_encryption_enforcement(
+    world: WorldIR,
+    artifacts: KindArtifacts,
+    reference_bundle: object = None,
+) -> ValidatorCheckReport:
+    """Validate envelope encryption config in rendered artifacts.
+
+    Matches v1's ``CheckFunc`` signature so it can be registered as an
+    advisory admission check.
+    """
+    security_dir = Path(artifacts.render_dir) / "security" / "encryption"
+    config_path = security_dir / "config.json"
+    dek_path = security_dir / "wrapped_dek.json"
+
+    if not config_path.exists():
+        return ValidatorCheckReport(
+            name="encryption_enforcement",
+            passed=True,
+            advisory=True,
+            details={"note": "envelope encryption not configured -- vacuously passes"},
+        )
+
+    issues: list[str] = []
+
+    try:
+        config = json.loads(config_path.read_text(encoding="utf-8"))
+    except (json.JSONDecodeError, OSError) as exc:
+        return ValidatorCheckReport(
+            name="encryption_enforcement",
+            passed=False,
+            advisory=True,
+            details={"error": f"cannot read encryption config: {exc}"},
+        )
+
+    if not config.get("enabled"):
+        return ValidatorCheckReport(
+            name="encryption_enforcement",
+            passed=True,
+            advisory=True,
+            details={"note": "envelope encryption not enabled -- vacuously passes"},
+        )
+
+    encrypted_paths = config.get("encrypted_paths", [])
+    if not encrypted_paths:
+        issues.append("encryption enabled but no encrypted_paths listed")
+
+    # Validate wrapped DEK file
+    if dek_path.exists():
+        try:
+            dek_data = json.loads(dek_path.read_text(encoding="utf-8"))
+            if not isinstance(dek_data, dict):
+                issues.append("wrapped_dek.json is not a JSON object")
+            else:
+                for ref_id, bundle in dek_data.items():
+                    if isinstance(bundle, dict) and not _BUNDLE_REQUIRED_KEYS.issubset(
+                        bundle.keys()
+                    ):
+                        issues.append(
+                            f"encrypted bundle for '{ref_id}' missing required keys"
+                        )
+        except json.JSONDecodeError:
+            issues.append("wrapped_dek.json is not valid JSON")
+    elif encrypted_paths:
+        issues.append("encrypted_paths defined but wrapped_dek.json not found")
+
+    passed = len(issues) == 0
+    return ValidatorCheckReport(
+        name="encryption_enforcement",
+        passed=passed,
+        advisory=True,
+        details={"encrypted_paths": encrypted_paths, "issues": issues},
+        error="" if passed else "; ".join(issues),
+    )

--- a/src/open_range/envelope_crypto.py
+++ b/src/open_range/envelope_crypto.py
@@ -1,0 +1,415 @@
+"""Envelope encryption for range flags and secrets-at-rest.
+
+Implements AES-256-GCM envelope encryption ported from the
+k3s-istio-vault-platform ``secret-runtime`` write path:
+
+    1. Generate a fresh 256-bit Data Encryption Key (DEK) per write
+    2. Encrypt plaintext locally with AES-256-GCM using a random 12-byte nonce
+    3. Wrap the DEK with the master key (or Vault Transit)
+    4. Store ciphertext + wrapped DEK + nonce; zero the plaintext DEK
+
+Red agents must locate the wrapped DEK and master key (or Vault access)
+to decrypt flags.  Blue agents validate that encrypted paths contain only
+ciphertext and that DEKs are not exposed alongside encrypted data.
+
+The module is **completely optional**: it imports ``cryptography`` at call
+time and raises a clear ``ImportError`` when the library is absent.  All
+Pydantic models use v2 conventions.
+"""
+
+from __future__ import annotations
+
+import base64
+import json
+import logging
+import os
+import secrets
+from typing import Any
+
+from pydantic import BaseModel, Field
+
+logger = logging.getLogger(__name__)
+
+# ---------------------------------------------------------------------------
+# Lazy crypto imports — we defer so the rest of the package works even when
+# the ``cryptography`` library is not installed.
+# ---------------------------------------------------------------------------
+
+_CRYPTO_BACKEND: str | None = None
+
+
+def _get_cipher_module() -> Any:
+    """Return the AES-GCM primitives from ``cryptography`` (preferred) or
+    ``Crypto.Cipher`` (pycryptodome fallback).
+
+    Raises ``ImportError`` with a helpful message when neither is available.
+    """
+    global _CRYPTO_BACKEND
+
+    # Prefer the ``cryptography`` library (already in uv.lock).
+    try:
+        from cryptography.hazmat.primitives.ciphers.aead import AESGCM
+
+        _CRYPTO_BACKEND = "cryptography"
+        return AESGCM
+    except ImportError:
+        pass
+
+    # Fallback: pycryptodome
+    try:
+        from Crypto.Cipher import AES  # type: ignore[import-untyped]
+
+        _CRYPTO_BACKEND = "pycryptodome"
+        return AES
+    except ImportError:
+        pass
+
+    raise ImportError(
+        "Envelope encryption requires the 'cryptography' package "
+        "(pip install cryptography) or 'pycryptodome' as a fallback.  "
+        "Neither is currently installed."
+    )
+
+
+def _aes_gcm_encrypt(key: bytes, nonce: bytes, plaintext: bytes, aad: bytes) -> bytes:
+    """AES-256-GCM encrypt using whichever backend is available."""
+    mod = _get_cipher_module()
+
+    if _CRYPTO_BACKEND == "cryptography":
+        # ``mod`` is AESGCM class
+        aesgcm = mod(key)
+        return aesgcm.encrypt(nonce, plaintext, aad)
+
+    # pycryptodome path
+    cipher = mod.new(key, mod.MODE_GCM, nonce=nonce)
+    cipher.update(aad)
+    ct, tag = cipher.encrypt_and_digest(plaintext)
+    return ct + tag  # append 16-byte tag like ``cryptography`` does
+
+
+def _aes_gcm_decrypt(key: bytes, nonce: bytes, ciphertext: bytes, aad: bytes) -> bytes:
+    """AES-256-GCM decrypt using whichever backend is available."""
+    mod = _get_cipher_module()
+
+    if _CRYPTO_BACKEND == "cryptography":
+        aesgcm = mod(key)
+        return aesgcm.decrypt(nonce, ciphertext, aad)
+
+    # pycryptodome: last 16 bytes are the GCM tag
+    tag = ciphertext[-16:]
+    ct = ciphertext[:-16]
+    cipher = mod.new(key, mod.MODE_GCM, nonce=nonce)
+    cipher.update(aad)
+    return cipher.decrypt_and_verify(ct, tag)
+
+
+# ---------------------------------------------------------------------------
+# Pydantic configuration models
+# ---------------------------------------------------------------------------
+
+
+class EncryptionConfig(BaseModel):
+    """Configuration for envelope encryption of range secrets."""
+
+    enabled: bool = False
+    encrypted_paths: list[str] = Field(default_factory=list)
+    # e.g. ["files:/srv/shares/compliance/hipaa_audit_2024.txt", "db:flags.secrets.value"]
+    master_key_source: str = "env_var"  # "vault_transit" or "env_var"
+    master_key_env_var: str = "OPENRANGE_MASTER_KEY"
+    dek_storage_path: str = "/etc/openrange/wrapped_dek.json"
+    # Where the wrapped DEK is stored in the range (Red must find this)
+
+
+class EncryptedBundle(BaseModel):
+    """Encrypted data bundle following k3s-istio-vault-platform pattern."""
+
+    ciphertext: str  # base64-encoded AES-256-GCM ciphertext
+    nonce: str  # base64-encoded 12-byte nonce
+    wrapped_dek: str  # base64-encoded wrapped DEK
+    aad: str  # canonical Additional Authenticated Data
+    key_version: int = 1
+
+
+# ---------------------------------------------------------------------------
+# Core envelope encryption engine
+# ---------------------------------------------------------------------------
+
+
+class EnvelopeCrypto:
+    """AES-256-GCM envelope encryption ported from k3s-istio-vault-platform.
+
+    Pattern: generate DEK -> encrypt locally with AES-256-GCM -> wrap DEK ->
+    store wrapped DEK + ciphertext. Plaintext DEK zeroed after use.
+    """
+
+    _KEY_BYTES = 32  # AES-256
+    _NONCE_BYTES = 12  # GCM standard nonce size
+
+    def __init__(self, master_key: bytes | None = None) -> None:
+        if master_key is not None and len(master_key) != self._KEY_BYTES:
+            raise ValueError(
+                f"Master key must be exactly {self._KEY_BYTES} bytes, "
+                f"got {len(master_key)}"
+            )
+        self._master_key: bytes | None = master_key
+
+    # -- Key management -----------------------------------------------------
+
+    @staticmethod
+    def generate_master_key() -> bytes:
+        """Generate a 256-bit master key."""
+        return secrets.token_bytes(32)
+
+    def generate_dek(self) -> tuple[bytes, str]:
+        """Generate a fresh DEK and return ``(plaintext_dek, wrapped_dek_b64)``.
+
+        The wrapped DEK is encrypted with the master key using AES-256-GCM.
+        If Vault Transit is available in the future, this method can be
+        extended to delegate wrapping to Vault via
+        ``VaultClient.generate_data_key()``.
+        """
+        if self._master_key is None:
+            raise RuntimeError(
+                "Cannot generate DEK: no master key configured. "
+                "Supply a master key or configure Vault Transit."
+            )
+        plaintext_dek = secrets.token_bytes(self._KEY_BYTES)
+        nonce = secrets.token_bytes(self._NONCE_BYTES)
+
+        # Wrap the DEK with the master key (AES-256-GCM, mirroring the
+        # Vault Transit wrapping concept from k3s-istio-vault-platform).
+        wrapped_ct = _aes_gcm_encrypt(
+            self._master_key, nonce, plaintext_dek, b"dek-wrap"
+        )
+        # Encode nonce + ciphertext together for storage.
+        wrapped_blob = nonce + wrapped_ct
+        wrapped_b64 = base64.b64encode(wrapped_blob).decode()
+        return plaintext_dek, wrapped_b64
+
+    def _unwrap_dek(self, wrapped_dek_b64: str) -> bytes:
+        """Unwrap a DEK using the master key."""
+        if self._master_key is None:
+            raise RuntimeError("Cannot unwrap DEK: no master key configured.")
+        blob = base64.b64decode(wrapped_dek_b64)
+        nonce = blob[: self._NONCE_BYTES]
+        wrapped_ct = blob[self._NONCE_BYTES :]
+        return _aes_gcm_decrypt(self._master_key, nonce, wrapped_ct, b"dek-wrap")
+
+    # -- Encrypt / Decrypt --------------------------------------------------
+
+    def encrypt(self, plaintext: str | bytes, aad: str = "") -> EncryptedBundle:
+        """Encrypt plaintext with a fresh per-write DEK.
+
+        Following k3s-istio-vault-platform pattern:
+
+        1. Generate fresh DEK via ``generate_dek()``
+        2. Generate random 12-byte nonce
+        3. AES-256-GCM encrypt with nonce and AAD
+        4. Zero plaintext DEK
+        5. Return bundle with ciphertext + wrapped DEK + nonce
+        """
+        if isinstance(plaintext, str):
+            plaintext = plaintext.encode()
+
+        # Step 1: fresh DEK
+        dek_bytes, wrapped_dek_b64 = self.generate_dek()
+        dek = bytearray(dek_bytes)
+
+        try:
+            # Step 2: random nonce
+            nonce = secrets.token_bytes(self._NONCE_BYTES)
+
+            # Step 3: AES-256-GCM encrypt
+            aad_bytes = aad.encode() if aad else b""
+            ct = _aes_gcm_encrypt(bytes(dek), nonce, plaintext, aad_bytes)
+
+            # Step 5: build bundle
+            return EncryptedBundle(
+                ciphertext=base64.b64encode(ct).decode(),
+                nonce=base64.b64encode(nonce).decode(),
+                wrapped_dek=wrapped_dek_b64,
+                aad=aad,
+                key_version=1,
+            )
+        finally:
+            # Step 4: zero the plaintext DEK
+            self.zero_key(dek)
+
+    def decrypt(self, bundle: EncryptedBundle) -> bytes:
+        """Decrypt an encrypted bundle.
+
+        1. Unwrap DEK using master key
+        2. AES-256-GCM decrypt with nonce and AAD
+        3. Zero DEK
+        4. Return plaintext
+        """
+        # Step 1: unwrap DEK
+        dek_bytes = self._unwrap_dek(bundle.wrapped_dek)
+        dek = bytearray(dek_bytes)
+
+        try:
+            # Step 2: decrypt
+            ct = base64.b64decode(bundle.ciphertext)
+            nonce = base64.b64decode(bundle.nonce)
+            aad_bytes = bundle.aad.encode() if bundle.aad else b""
+            return _aes_gcm_decrypt(bytes(dek), nonce, ct, aad_bytes)
+        finally:
+            # Step 3: zero the DEK
+            self.zero_key(dek)
+
+    # -- Canonical AAD ------------------------------------------------------
+
+    @staticmethod
+    def build_canonical_aad(
+        tenant: str,
+        environment: str,
+        app: str,
+        name: str,
+        version: int = 1,
+    ) -> str:
+        """Build canonical AAD string from components.
+
+        Follows k3s-istio-vault-platform pattern: JSON-encoded dict of
+        ``{tenant, environment, app, name, version}`` with keys in a
+        deterministic order (guaranteed by ``json.dumps(sort_keys=True)``).
+        """
+        aad_dict = {
+            "app": app,
+            "environment": environment,
+            "name": name,
+            "tenant": tenant,
+            "version": version,
+        }
+        return json.dumps(aad_dict, sort_keys=True, separators=(",", ":"))
+
+    # -- Key zeroing --------------------------------------------------------
+
+    @staticmethod
+    def zero_key(key: bytearray) -> None:
+        """Zero out a key in memory (security pattern from k3s-istio-vault-platform)."""
+        for i in range(len(key)):
+            key[i] = 0
+
+
+# ---------------------------------------------------------------------------
+# High-level helpers for flag encryption / decryption
+# ---------------------------------------------------------------------------
+
+
+def encrypt_flag_content(
+    flag_value: str,
+    config: EncryptionConfig,
+    host: str,
+    path: str,
+) -> tuple[str, dict]:
+    """Encrypt a flag value for deployment into a range.
+
+    Returns ``(encrypted_file_content, dek_metadata_dict)``.
+    The ``dek_metadata_dict`` should be written to ``config.dek_storage_path``
+    inside the range so that Red agents can discover and use it.
+
+    Args:
+        flag_value: The plaintext flag string (e.g. ``FLAG{...}``).
+        config: Encryption configuration for the range.
+        host: Host where the flag resides (used in AAD).
+        path: File path where the flag will be stored (used in AAD).
+
+    Returns:
+        A tuple of ``(base64_bundle_json, dek_metadata)``.  The first element
+        is a JSON string containing the :class:`EncryptedBundle`; the second
+        is a dict suitable for persisting alongside (or inside) the wrapped
+        DEK file.
+    """
+    master_key = _resolve_master_key(config)
+    crypto = EnvelopeCrypto(master_key)
+
+    aad = EnvelopeCrypto.build_canonical_aad(
+        tenant="openrange",
+        environment="range",
+        app=host,
+        name=path,
+        version=1,
+    )
+
+    bundle = crypto.encrypt(flag_value, aad=aad)
+
+    # The encrypted file content is the JSON-serialised bundle.
+    encrypted_content = bundle.model_dump_json()
+
+    # Metadata dict for the DEK storage file.
+    dek_metadata: dict[str, Any] = {
+        "wrapped_dek": bundle.wrapped_dek,
+        "aad": bundle.aad,
+        "key_version": bundle.key_version,
+        "host": host,
+        "path": path,
+        "dek_storage_path": config.dek_storage_path,
+    }
+    return encrypted_content, dek_metadata
+
+
+def decrypt_flag_content(
+    encrypted_content: str,
+    dek_metadata: dict,
+    master_key: bytes,
+) -> str:
+    """Decrypt a flag value.  Used by validators to verify flags.
+
+    Args:
+        encrypted_content: JSON string produced by :func:`encrypt_flag_content`.
+        dek_metadata: The metadata dict written alongside the wrapped DEK.
+        master_key: The 256-bit master key bytes.
+
+    Returns:
+        The original plaintext flag string.
+    """
+    bundle = EncryptedBundle.model_validate_json(encrypted_content)
+    crypto = EnvelopeCrypto(master_key)
+    plaintext_bytes = crypto.decrypt(bundle)
+    return plaintext_bytes.decode()
+
+
+# ---------------------------------------------------------------------------
+# Internal helpers
+# ---------------------------------------------------------------------------
+
+
+def _resolve_master_key(config: EncryptionConfig) -> bytes:
+    """Resolve the master key from the configured source."""
+    if config.master_key_source == "env_var":
+        raw = os.environ.get(config.master_key_env_var, "")
+        if not raw:
+            raise RuntimeError(
+                f"Envelope encryption enabled but master key env var "
+                f"'{config.master_key_env_var}' is not set."
+            )
+        # Accept either raw base64 or hex-encoded keys.
+        try:
+            key = base64.b64decode(raw)
+            if len(key) == 32:
+                return key
+        except Exception:
+            pass
+        try:
+            key = bytes.fromhex(raw)
+            if len(key) == 32:
+                return key
+        except Exception:
+            pass
+        raise RuntimeError(
+            f"Master key in '{config.master_key_env_var}' must be 32 bytes "
+            f"encoded as base64 or hex."
+        )
+
+    if config.master_key_source == "vault_transit":
+        # Vault Transit mode delegates key management to Vault entirely.
+        # The VaultClient.generate_data_key() handles DEK generation and
+        # wrapping, so we do not need a local master key.  For now, raise
+        # NotImplementedError; the integration point is in
+        # EnvelopeCrypto.generate_dek().
+        raise NotImplementedError(
+            "Vault Transit master key source is not yet wired. "
+            "Use 'env_var' or integrate VaultClient.generate_data_key() directly."
+        )
+
+    raise ValueError(f"Unknown master_key_source: '{config.master_key_source}'")

--- a/src/open_range/gitops_publisher.py
+++ b/src/open_range/gitops_publisher.py
@@ -1,0 +1,398 @@
+"""Publish rendered snapshot charts to a GitOps repository for Argo CD.
+
+This module is entirely optional -- it only activates when the environment
+variable ``OPENRANGE_GITOPS_ENABLED=true`` is set.  When active, the
+:class:`GitOpsPublisher` copies rendered Helm chart artifacts into a Git
+repository so that Argo CD can reconcile them into live ranges automatically.
+
+Typical workflow::
+
+    build  ->  render  ->  publish (GitOpsPublisher)  ->  auto-deploy (Argo CD)
+
+Configuration is supplied via :class:`GitOpsConfig`, a Pydantic v2 model that
+reads from environment variables prefixed with ``OPENRANGE_GITOPS_``.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import json
+import logging
+import os
+import shutil
+import tempfile
+from pathlib import Path
+from typing import Any
+
+from pydantic import BaseModel, Field
+
+logger = logging.getLogger(__name__)
+
+
+# ---------------------------------------------------------------------------
+# Configuration
+# ---------------------------------------------------------------------------
+
+
+def _gitops_enabled() -> bool:
+    """Return True when GitOps publishing is explicitly enabled."""
+    return os.getenv("OPENRANGE_GITOPS_ENABLED", "").strip().lower() in {
+        "1",
+        "true",
+        "yes",
+        "on",
+    }
+
+
+class GitOpsConfig(BaseModel):
+    """Configuration for the GitOps publisher.
+
+    All values can be set via environment variables prefixed with
+    ``OPENRANGE_GITOPS_``.  For example ``OPENRANGE_GITOPS_REPO_URL`` maps to
+    :pyattr:`repo_url`.
+    """
+
+    enabled: bool = Field(
+        default=False,
+        description="Master switch -- set OPENRANGE_GITOPS_ENABLED=true to activate.",
+    )
+    repo_url: str = Field(
+        default="",
+        description="Clone URL of the GitOps repository.",
+    )
+    branch: str = Field(
+        default="main",
+        description="Branch to commit rendered charts to.",
+    )
+    base_path: str = Field(
+        default="ranges",
+        description="Directory inside the repo where snapshot charts live.",
+    )
+    work_dir: str = Field(
+        default="",
+        description=(
+            "Local working-copy path. If empty a temporary directory is used."
+        ),
+    )
+    argocd_namespace: str = Field(
+        default="argocd",
+        description="Kubernetes namespace where Argo CD is installed.",
+    )
+    sync_timeout: float = Field(
+        default=300.0,
+        description="Seconds to wait for Argo CD to sync a published snapshot.",
+    )
+    commit_author_name: str = Field(
+        default="open-range",
+        description="Git author name for automated commits.",
+    )
+    commit_author_email: str = Field(
+        default="open-range@localhost",
+        description="Git author email for automated commits.",
+    )
+
+    @classmethod
+    def from_env(cls) -> GitOpsConfig:
+        """Build a config from ``OPENRANGE_GITOPS_*`` environment variables."""
+        prefix = "OPENRANGE_GITOPS_"
+        values: dict[str, Any] = {}
+        for env_key, env_val in os.environ.items():
+            if not env_key.startswith(prefix):
+                continue
+            field_name = env_key[len(prefix) :].lower()
+            if field_name in cls.model_fields:
+                values[field_name] = env_val
+        return cls(**values)
+
+
+# ---------------------------------------------------------------------------
+# Publisher
+# ---------------------------------------------------------------------------
+
+
+class GitOpsPublisher:
+    """Publish rendered snapshot charts to a GitOps repository for Argo CD.
+
+    Usage::
+
+        cfg = GitOpsConfig.from_env()
+        publisher = GitOpsPublisher(
+            repo_url=cfg.repo_url,
+            branch=cfg.branch,
+            base_path=cfg.base_path,
+        )
+        sha = await publisher.publish("snap-001", Path("/tmp/rendered/snap-001"))
+        healthy = await publisher.wait_for_sync("snap-001", timeout=120)
+        await publisher.unpublish("snap-001")
+    """
+
+    def __init__(
+        self,
+        repo_url: str,
+        branch: str = "main",
+        base_path: str = "ranges",
+        *,
+        work_dir: str | None = None,
+        argocd_namespace: str = "argocd",
+        commit_author_name: str = "open-range",
+        commit_author_email: str = "open-range@localhost",
+    ) -> None:
+        self._repo_url = repo_url
+        self._branch = branch
+        self._base_path = base_path
+        self._argocd_namespace = argocd_namespace
+        self._commit_author_name = commit_author_name
+        self._commit_author_email = commit_author_email
+
+        if work_dir:
+            self._work_dir = Path(work_dir)
+            self._tmp_dir: tempfile.TemporaryDirectory[str] | None = None
+        else:
+            self._tmp_dir = tempfile.TemporaryDirectory(prefix="openrange-gitops-")
+            self._work_dir = Path(self._tmp_dir.name)
+
+        self._repo_ready = False
+
+    @classmethod
+    def from_config(cls, config: GitOpsConfig) -> GitOpsPublisher:
+        """Construct a publisher from a :class:`GitOpsConfig`."""
+        return cls(
+            repo_url=config.repo_url,
+            branch=config.branch,
+            base_path=config.base_path,
+            work_dir=config.work_dir or None,
+            argocd_namespace=config.argocd_namespace,
+            commit_author_name=config.commit_author_name,
+            commit_author_email=config.commit_author_email,
+        )
+
+    # ------------------------------------------------------------------
+    # Public API
+    # ------------------------------------------------------------------
+
+    async def publish(self, snapshot_id: str, artifacts_dir: Path) -> str:
+        """Commit rendered chart to GitOps repo.  Returns the commit SHA.
+
+        Parameters
+        ----------
+        snapshot_id:
+            Unique identifier for the snapshot (used as the directory name).
+        artifacts_dir:
+            Local path containing the rendered Helm chart to publish.
+
+        Returns
+        -------
+        str
+            The Git commit SHA after pushing.
+        """
+        if not artifacts_dir.is_dir():
+            raise FileNotFoundError(
+                f"Artifacts directory does not exist: {artifacts_dir}"
+            )
+
+        await self._ensure_repo()
+
+        dest = self._work_dir / self._base_path / snapshot_id
+        if dest.exists():
+            shutil.rmtree(dest)
+        shutil.copytree(artifacts_dir, dest)
+
+        await self._git("add", "--all")
+
+        commit_msg = f"publish snapshot {snapshot_id}"
+        await self._git(
+            "-c",
+            f"user.name={self._commit_author_name}",
+            "-c",
+            f"user.email={self._commit_author_email}",
+            "commit",
+            "-m",
+            commit_msg,
+            "--allow-empty",
+        )
+
+        await self._git("push", "origin", self._branch)
+
+        sha = await self._git("rev-parse", "HEAD")
+        sha = sha.strip()
+        logger.info(
+            "Published snapshot %s to %s (commit %s)",
+            snapshot_id,
+            self._repo_url,
+            sha[:12],
+        )
+        return sha
+
+    async def unpublish(self, snapshot_id: str) -> None:
+        """Remove a snapshot's chart from the GitOps repo.
+
+        Commits and pushes the removal so Argo CD prunes the resources.
+        """
+        await self._ensure_repo()
+
+        dest = self._work_dir / self._base_path / snapshot_id
+        if not dest.exists():
+            logger.warning(
+                "Snapshot %s not found in GitOps repo -- nothing to remove",
+                snapshot_id,
+            )
+            return
+
+        shutil.rmtree(dest)
+
+        await self._git("add", "--all")
+        await self._git(
+            "-c",
+            f"user.name={self._commit_author_name}",
+            "-c",
+            f"user.email={self._commit_author_email}",
+            "commit",
+            "-m",
+            f"unpublish snapshot {snapshot_id}",
+            "--allow-empty",
+        )
+        await self._git("push", "origin", self._branch)
+        logger.info("Unpublished snapshot %s from %s", snapshot_id, self._repo_url)
+
+    async def wait_for_sync(
+        self,
+        snapshot_id: str,
+        timeout: float = 300.0,
+    ) -> bool:
+        """Wait for Argo CD to sync the application.  Returns True if healthy.
+
+        Polls the Argo CD Application status via ``kubectl`` until the sync is
+        complete or *timeout* seconds elapse.
+        """
+        app_name = f"openrange-{snapshot_id}"
+        deadline = asyncio.get_event_loop().time() + timeout
+        poll_interval = 5.0
+
+        while asyncio.get_event_loop().time() < deadline:
+            try:
+                status = await self._get_app_status(app_name)
+                sync_status = status.get("sync", {}).get("status", "")
+                health_status = status.get("health", {}).get("status", "")
+
+                if sync_status == "Synced" and health_status == "Healthy":
+                    logger.info(
+                        "Snapshot %s synced and healthy in Argo CD", snapshot_id
+                    )
+                    return True
+
+                if health_status == "Degraded":
+                    logger.warning("Snapshot %s is Degraded in Argo CD", snapshot_id)
+                    return False
+
+                logger.debug(
+                    "Snapshot %s sync=%s health=%s -- waiting",
+                    snapshot_id,
+                    sync_status,
+                    health_status,
+                )
+            except Exception:
+                logger.debug(
+                    "Could not query Argo CD status for %s -- retrying",
+                    snapshot_id,
+                )
+
+            await asyncio.sleep(poll_interval)
+
+        logger.warning(
+            "Timed out waiting for Argo CD sync of snapshot %s after %.0fs",
+            snapshot_id,
+            timeout,
+        )
+        return False
+
+    # ------------------------------------------------------------------
+    # Private helpers
+    # ------------------------------------------------------------------
+
+    async def _ensure_repo(self) -> None:
+        """Clone or update the GitOps repository working copy."""
+        if self._repo_ready:
+            # Fast-forward existing clone
+            try:
+                await self._git("fetch", "origin", self._branch)
+                await self._git("reset", "--hard", f"origin/{self._branch}")
+            except RuntimeError:
+                logger.warning("Fast-forward failed; re-cloning")
+                self._repo_ready = False
+
+        if not self._repo_ready:
+            git_dir = self._work_dir / ".git"
+            if git_dir.is_dir():
+                # Existing clone -- pull latest
+                await self._git("fetch", "origin", self._branch)
+                await self._git("checkout", self._branch)
+                await self._git("reset", "--hard", f"origin/{self._branch}")
+            else:
+                # Fresh clone
+                await self._run_process(
+                    "git",
+                    "clone",
+                    "--branch",
+                    self._branch,
+                    "--single-branch",
+                    self._repo_url,
+                    str(self._work_dir),
+                )
+            self._repo_ready = True
+
+    async def _git(self, *args: str) -> str:
+        """Run a git command inside the working copy."""
+        return await self._run_process("git", *args, cwd=self._work_dir)
+
+    @staticmethod
+    async def _run_process(
+        *args: str,
+        cwd: Path | None = None,
+        timeout: float = 120.0,
+    ) -> str:
+        """Run a subprocess asynchronously and return its stdout."""
+        proc = await asyncio.create_subprocess_exec(
+            *args,
+            stdout=asyncio.subprocess.PIPE,
+            stderr=asyncio.subprocess.PIPE,
+            cwd=cwd,
+        )
+        try:
+            stdout_bytes, stderr_bytes = await asyncio.wait_for(
+                proc.communicate(), timeout=timeout
+            )
+        except asyncio.TimeoutError:
+            proc.kill()
+            raise RuntimeError(f"Command timed out: {' '.join(args[:4])}")
+
+        stdout = (stdout_bytes or b"").decode(errors="replace")
+        stderr = (stderr_bytes or b"").decode(errors="replace")
+
+        if proc.returncode != 0:
+            detail = stderr.strip() or stdout.strip() or "unknown failure"
+            raise RuntimeError(
+                f"{' '.join(args[:4])}... failed (exit {proc.returncode}): {detail}"
+            )
+        return stdout
+
+    async def _get_app_status(self, app_name: str) -> dict[str, Any]:
+        """Query the Argo CD Application status via kubectl."""
+        raw = await self._run_process(
+            "kubectl",
+            "get",
+            "application",
+            app_name,
+            "-n",
+            self._argocd_namespace,
+            "-o",
+            "json",
+        )
+        obj = json.loads(raw)
+        return obj.get("status", {})
+
+    def __del__(self) -> None:
+        if self._tmp_dir is not None:
+            try:
+                self._tmp_dir.cleanup()
+            except Exception:
+                pass

--- a/src/open_range/hubble_observer.py
+++ b/src/open_range/hubble_observer.py
@@ -1,0 +1,638 @@
+"""Query Hubble for network flow data, useful for Blue agent training.
+
+This module provides a Python interface to Cilium Hubble's network flow
+observability. The Blue (defensive) agent can use this data to:
+
+- Monitor real-time network flows between zones
+- Verify that zone isolation policies are correctly enforced
+- Detect anomalous traffic patterns during an episode
+- Build a network activity baseline and compare against it
+
+The module is completely optional. When Hubble is not installed or
+unavailable, all methods return empty results gracefully.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import json
+import logging
+import shutil
+from datetime import datetime, timezone
+from enum import Enum
+from typing import Any
+
+from pydantic import BaseModel, Field
+
+logger = logging.getLogger(__name__)
+
+# ---------------------------------------------------------------------------
+# Configuration
+# ---------------------------------------------------------------------------
+
+
+class HubbleBackend(str, Enum):
+    """Method used to query Hubble flows."""
+
+    CLI = "cli"
+    GRPC = "grpc"
+
+
+class HubbleConfig(BaseModel):
+    """Configuration for the Hubble observer."""
+
+    hubble_addr: str = Field(
+        default="localhost:4245",
+        description="Hubble relay address (host:port)",
+    )
+    backend: HubbleBackend = Field(
+        default=HubbleBackend.CLI,
+        description="How to query Hubble: 'cli' uses the hubble binary, "
+        "'grpc' uses the relay gRPC API via subprocess",
+    )
+    timeout_s: float = Field(
+        default=10.0,
+        description="Timeout in seconds for Hubble queries",
+    )
+    hubble_binary: str = Field(
+        default="hubble",
+        description="Path to the hubble CLI binary",
+    )
+    kubectl_binary: str = Field(
+        default="kubectl",
+        description="Path to kubectl binary (used for port-forward fallback)",
+    )
+    namespace_prefix: str = Field(
+        default="",
+        description="Namespace prefix for open-range zones (e.g. 'or-myrange')",
+    )
+
+
+# ---------------------------------------------------------------------------
+# Flow data model
+# ---------------------------------------------------------------------------
+
+
+class FlowRecord(BaseModel):
+    """Normalized representation of a single Hubble network flow."""
+
+    time: str = ""
+    verdict: str = ""  # FORWARDED, DROPPED, ERROR, AUDIT
+    source_namespace: str = ""
+    source_pod: str = ""
+    source_labels: list[str] = Field(default_factory=list)
+    destination_namespace: str = ""
+    destination_pod: str = ""
+    destination_labels: list[str] = Field(default_factory=list)
+    destination_port: int = 0
+    protocol: str = ""  # TCP, UDP, ICMP
+    l7_type: str = ""  # HTTP, DNS, etc.
+    http_method: str = ""
+    http_url: str = ""
+    http_status: int = 0
+    dns_query: str = ""
+    drop_reason: str = ""
+    summary: str = ""
+
+    @property
+    def source_zone(self) -> str:
+        """Extract zone name from source namespace (strip prefix)."""
+        return _extract_zone(self.source_namespace)
+
+    @property
+    def destination_zone(self) -> str:
+        """Extract zone name from destination namespace (strip prefix)."""
+        return _extract_zone(self.destination_namespace)
+
+
+class AnomalyRecord(BaseModel):
+    """A detected anomaly compared to baseline traffic."""
+
+    anomaly_type: str = (
+        ""  # new_connection, unexpected_port, policy_violation, volume_spike
+    )
+    severity: str = "medium"  # low, medium, high, critical
+    description: str = ""
+    flow: FlowRecord | None = None
+    baseline_comparison: dict[str, Any] = Field(default_factory=dict)
+
+
+# ---------------------------------------------------------------------------
+# Observer
+# ---------------------------------------------------------------------------
+
+
+class HubbleObserver:
+    """Query Hubble for network flow data, useful for Blue agent training.
+
+    All methods are async and degrade gracefully when Hubble is unavailable.
+    This makes the observer safe to use in environments where Cilium is not
+    installed -- methods simply return empty results.
+
+    Usage::
+
+        observer = HubbleObserver(config=HubbleConfig(
+            hubble_addr="localhost:4245",
+            namespace_prefix="or-my-range",
+        ))
+
+        # Get recent flows for a zone
+        flows = await observer.get_flows(namespace="or-my-range-dmz", since="5m")
+
+        # Verify zone isolation
+        isolated = await observer.check_isolation("dmz", "management")
+
+        # Detect anomalies against a baseline
+        anomalies = await observer.detect_anomalies(baseline_flows)
+    """
+
+    def __init__(
+        self,
+        config: HubbleConfig | None = None,
+        hubble_addr: str = "localhost:4245",
+    ) -> None:
+        if config is not None:
+            self.config = config
+        else:
+            self.config = HubbleConfig(hubble_addr=hubble_addr)
+
+    # ------------------------------------------------------------------
+    # Public API
+    # ------------------------------------------------------------------
+
+    async def is_available(self) -> bool:
+        """Check whether Hubble is reachable.
+
+        Returns True if the hubble CLI exists and can connect to the relay.
+        """
+        if not shutil.which(self.config.hubble_binary):
+            return False
+        try:
+            proc = await asyncio.create_subprocess_exec(
+                self.config.hubble_binary,
+                "status",
+                "--server",
+                self.config.hubble_addr,
+                stdout=asyncio.subprocess.PIPE,
+                stderr=asyncio.subprocess.PIPE,
+            )
+            stdout, _ = await asyncio.wait_for(
+                proc.communicate(), timeout=self.config.timeout_s
+            )
+            return proc.returncode == 0
+        except (asyncio.TimeoutError, OSError):
+            return False
+
+    async def get_flows(
+        self,
+        namespace: str = "",
+        since: str = "5m",
+        limit: int = 100,
+        verdict: str = "",
+        protocol: str = "",
+    ) -> list[FlowRecord]:
+        """Get recent network flows from Hubble.
+
+        Parameters
+        ----------
+        namespace:
+            Filter flows to this Kubernetes namespace. Empty string means all
+            namespaces.
+        since:
+            Time window for flows (e.g. "5m", "1h", "30s").
+        limit:
+            Maximum number of flow records to return.
+        verdict:
+            Filter by verdict: "FORWARDED", "DROPPED", "ERROR", "AUDIT".
+            Empty string means all verdicts.
+        protocol:
+            Filter by protocol: "TCP", "UDP", "ICMP".
+            Empty string means all protocols.
+
+        Returns
+        -------
+        list[FlowRecord]:
+            Parsed flow records. Empty list if Hubble is unavailable.
+        """
+        args = self._build_observe_args(
+            namespace=namespace,
+            since=since,
+            limit=limit,
+            verdict=verdict,
+            protocol=protocol,
+        )
+        raw_flows = await self._run_hubble(args)
+        return [self._parse_flow(f) for f in raw_flows]
+
+    async def get_dropped_flows(
+        self,
+        namespace: str = "",
+        since: str = "5m",
+        limit: int = 100,
+    ) -> list[FlowRecord]:
+        """Get flows that were dropped by network policy.
+
+        Convenience wrapper around :meth:`get_flows` with verdict=DROPPED.
+        Useful for the Blue agent to verify that isolation policies are
+        working.
+        """
+        return await self.get_flows(
+            namespace=namespace,
+            since=since,
+            limit=limit,
+            verdict="DROPPED",
+        )
+
+    async def check_isolation(
+        self,
+        from_zone: str,
+        to_zone: str,
+        since: str = "5m",
+    ) -> bool:
+        """Verify that traffic between two zones is blocked by policy.
+
+        Returns True if no FORWARDED flows exist from ``from_zone`` to
+        ``to_zone`` in the given time window. Returns True (assumed
+        isolated) if Hubble is unavailable.
+
+        Parameters
+        ----------
+        from_zone:
+            Source zone name (without namespace prefix).
+        to_zone:
+            Destination zone name (without namespace prefix).
+        since:
+            Time window to check.
+        """
+        to_namespace = (
+            f"{self.config.namespace_prefix}-{to_zone}"
+            if self.config.namespace_prefix
+            else to_zone
+        )
+        flows = await self.get_flows(
+            namespace=to_namespace,
+            since=since,
+            limit=1000,
+            verdict="FORWARDED",
+        )
+
+        from_namespace = (
+            f"{self.config.namespace_prefix}-{from_zone}"
+            if self.config.namespace_prefix
+            else from_zone
+        )
+
+        # Check if any forwarded flow originated from the source zone
+        for flow in flows:
+            if flow.source_namespace == from_namespace:
+                logger.warning(
+                    "Isolation violation: flow from %s to %s (pod %s -> %s port %d)",
+                    from_zone,
+                    to_zone,
+                    flow.source_pod,
+                    flow.destination_pod,
+                    flow.destination_port,
+                )
+                return False
+
+        return True
+
+    async def detect_anomalies(
+        self,
+        baseline_flows: list[FlowRecord | dict[str, Any]],
+        since: str = "5m",
+        namespace: str = "",
+    ) -> list[AnomalyRecord]:
+        """Compare current flows against a baseline to detect anomalous traffic.
+
+        Anomaly detection heuristics:
+        1. **New connections**: source->destination pairs not seen in baseline.
+        2. **Unexpected ports**: destination ports not seen in baseline.
+        3. **Policy violations**: DROPPED flows indicate policy-blocked attempts.
+        4. **Volume spikes**: significantly more flows than baseline average.
+
+        Parameters
+        ----------
+        baseline_flows:
+            List of flow records (or dicts) representing "normal" traffic.
+            Typically captured during a known-good period.
+        since:
+            Time window for current flow query.
+        namespace:
+            Namespace filter for current flows.
+
+        Returns
+        -------
+        list[AnomalyRecord]:
+            Detected anomalies. Empty list if Hubble is unavailable or no
+            anomalies found.
+        """
+        current_flows = await self.get_flows(
+            namespace=namespace, since=since, limit=1000
+        )
+        if not current_flows:
+            return []
+
+        # Normalize baseline
+        baseline: list[FlowRecord] = []
+        for entry in baseline_flows:
+            if isinstance(entry, FlowRecord):
+                baseline.append(entry)
+            elif isinstance(entry, dict):
+                baseline.append(FlowRecord(**entry))
+
+        # Build baseline fingerprints
+        baseline_pairs: set[tuple[str, str]] = set()
+        baseline_ports: set[int] = set()
+        for flow in baseline:
+            baseline_pairs.add((flow.source_namespace, flow.destination_namespace))
+            if flow.destination_port > 0:
+                baseline_ports.add(flow.destination_port)
+
+        anomalies: list[AnomalyRecord] = []
+
+        for flow in current_flows:
+            pair = (flow.source_namespace, flow.destination_namespace)
+
+            # 1) Policy violations (dropped flows)
+            if flow.verdict == "DROPPED":
+                anomalies.append(
+                    AnomalyRecord(
+                        anomaly_type="policy_violation",
+                        severity="high",
+                        description=(
+                            f"Blocked traffic: {flow.source_pod} ({flow.source_namespace}) "
+                            f"-> {flow.destination_pod} ({flow.destination_namespace}) "
+                            f"port {flow.destination_port}: {flow.drop_reason}"
+                        ),
+                        flow=flow,
+                    )
+                )
+                continue
+
+            # 2) New connection pair
+            if baseline_pairs and pair not in baseline_pairs:
+                anomalies.append(
+                    AnomalyRecord(
+                        anomaly_type="new_connection",
+                        severity="medium",
+                        description=(
+                            f"New traffic path: {flow.source_namespace} -> "
+                            f"{flow.destination_namespace} "
+                            f"(not seen in baseline)"
+                        ),
+                        flow=flow,
+                        baseline_comparison={
+                            "known_pairs": len(baseline_pairs),
+                        },
+                    )
+                )
+
+            # 3) Unexpected port
+            if (
+                baseline_ports
+                and flow.destination_port > 0
+                and flow.destination_port not in baseline_ports
+            ):
+                anomalies.append(
+                    AnomalyRecord(
+                        anomaly_type="unexpected_port",
+                        severity="medium",
+                        description=(
+                            f"Unexpected port {flow.destination_port}: "
+                            f"{flow.source_pod} -> {flow.destination_pod}"
+                        ),
+                        flow=flow,
+                        baseline_comparison={
+                            "known_ports": sorted(baseline_ports),
+                        },
+                    )
+                )
+
+        # 4) Volume spike detection
+        if baseline and len(current_flows) > 3 * len(baseline):
+            anomalies.append(
+                AnomalyRecord(
+                    anomaly_type="volume_spike",
+                    severity="high",
+                    description=(
+                        f"Traffic volume spike: {len(current_flows)} flows "
+                        f"vs baseline {len(baseline)} (>{3}x)"
+                    ),
+                    baseline_comparison={
+                        "current_count": len(current_flows),
+                        "baseline_count": len(baseline),
+                        "ratio": round(len(current_flows) / max(len(baseline), 1), 2),
+                    },
+                )
+            )
+
+        return anomalies
+
+    async def get_flow_summary(
+        self,
+        namespace: str = "",
+        since: str = "10m",
+    ) -> dict[str, Any]:
+        """Get a summary of network flows suitable for an observation space.
+
+        Returns a dict with:
+        - ``total_flows``: total number of flows observed
+        - ``forwarded``: number of allowed flows
+        - ``dropped``: number of policy-blocked flows
+        - ``connections``: list of unique (src_ns, dst_ns, dst_port) tuples
+        - ``drop_sources``: list of (src_ns, src_pod) that had dropped flows
+
+        This is designed to be included in the Blue agent's observation
+        without overwhelming context windows.
+        """
+        flows = await self.get_flows(namespace=namespace, since=since, limit=500)
+
+        forwarded = [f for f in flows if f.verdict == "FORWARDED"]
+        dropped = [f for f in flows if f.verdict == "DROPPED"]
+
+        connections: set[tuple[str, str, int]] = set()
+        for f in forwarded:
+            connections.add(
+                (f.source_namespace, f.destination_namespace, f.destination_port)
+            )
+
+        drop_sources: set[tuple[str, str]] = set()
+        for f in dropped:
+            drop_sources.add((f.source_namespace, f.source_pod))
+
+        return {
+            "total_flows": len(flows),
+            "forwarded": len(forwarded),
+            "dropped": len(dropped),
+            "connections": [
+                {
+                    "src_namespace": c[0],
+                    "dst_namespace": c[1],
+                    "dst_port": c[2],
+                }
+                for c in sorted(connections)
+            ],
+            "drop_sources": [
+                {"namespace": s[0], "pod": s[1]} for s in sorted(drop_sources)
+            ],
+            "timestamp": datetime.now(timezone.utc).isoformat(),
+        }
+
+    # ------------------------------------------------------------------
+    # Internal helpers
+    # ------------------------------------------------------------------
+
+    def _build_observe_args(
+        self,
+        namespace: str = "",
+        since: str = "5m",
+        limit: int = 100,
+        verdict: str = "",
+        protocol: str = "",
+    ) -> list[str]:
+        """Build CLI arguments for ``hubble observe``."""
+        args = [
+            "observe",
+            "--server",
+            self.config.hubble_addr,
+            "--since",
+            since,
+            "--last",
+            str(limit),
+            "--output",
+            "json",
+        ]
+
+        if namespace:
+            args.extend(["--namespace", namespace])
+        if verdict:
+            args.extend(["--verdict", verdict])
+        if protocol:
+            args.extend(["--protocol", protocol])
+
+        return args
+
+    async def _run_hubble(self, args: list[str]) -> list[dict[str, Any]]:
+        """Execute a hubble CLI command and return parsed JSON lines."""
+        binary = self.config.hubble_binary
+        if not shutil.which(binary):
+            logger.debug("Hubble binary %r not found; returning empty results", binary)
+            return []
+
+        full_cmd = [binary] + args
+        try:
+            proc = await asyncio.create_subprocess_exec(
+                *full_cmd,
+                stdout=asyncio.subprocess.PIPE,
+                stderr=asyncio.subprocess.PIPE,
+            )
+            stdout, stderr = await asyncio.wait_for(
+                proc.communicate(), timeout=self.config.timeout_s
+            )
+        except asyncio.TimeoutError:
+            logger.warning(
+                "Hubble command timed out after %.1fs", self.config.timeout_s
+            )
+            return []
+        except OSError as exc:
+            logger.debug("Failed to run hubble: %s", exc)
+            return []
+
+        if proc.returncode != 0:
+            err_msg = (stderr or b"").decode(errors="replace").strip()
+            logger.debug(
+                "Hubble command failed (exit %d): %s", proc.returncode, err_msg
+            )
+            return []
+
+        raw = (stdout or b"").decode(errors="replace")
+        results: list[dict[str, Any]] = []
+        for line in raw.strip().splitlines():
+            line = line.strip()
+            if not line:
+                continue
+            try:
+                obj = json.loads(line)
+                if isinstance(obj, dict) and "flow" in obj:
+                    results.append(obj["flow"])
+                elif isinstance(obj, dict):
+                    results.append(obj)
+            except json.JSONDecodeError:
+                continue
+
+        return results
+
+    @staticmethod
+    def _parse_flow(raw: dict[str, Any]) -> FlowRecord:
+        """Parse a raw Hubble JSON flow into a FlowRecord."""
+        source = raw.get("source", {})
+        destination = raw.get("destination", {})
+        l4 = raw.get("l4", {})
+        l7 = raw.get("l7", {})
+
+        # Extract port from L4 (TCP or UDP)
+        dest_port = 0
+        proto = ""
+        if "TCP" in l4:
+            dest_port = l4["TCP"].get("destination_port", 0)
+            proto = "TCP"
+        elif "UDP" in l4:
+            dest_port = l4["UDP"].get("destination_port", 0)
+            proto = "UDP"
+        elif "ICMPv4" in l4 or "ICMPv6" in l4:
+            proto = "ICMP"
+
+        # Extract L7 info
+        l7_type = l7.get("type", "")
+        http_method = ""
+        http_url = ""
+        http_status = 0
+        dns_query = ""
+
+        http_info = l7.get("http", {})
+        if http_info:
+            l7_type = l7_type or "HTTP"
+            http_method = http_info.get("method", "")
+            http_url = http_info.get("url", "")
+            http_status = http_info.get("code", 0)
+
+        dns_info = l7.get("dns", {})
+        if dns_info:
+            l7_type = l7_type or "DNS"
+            dns_query = dns_info.get("query", "")
+
+        return FlowRecord(
+            time=raw.get("time", ""),
+            verdict=raw.get("verdict", ""),
+            source_namespace=source.get("namespace", ""),
+            source_pod=source.get("pod_name", ""),
+            source_labels=source.get("labels", []),
+            destination_namespace=destination.get("namespace", ""),
+            destination_pod=destination.get("pod_name", ""),
+            destination_labels=destination.get("labels", []),
+            destination_port=dest_port,
+            protocol=proto,
+            l7_type=l7_type,
+            http_method=http_method,
+            http_url=http_url,
+            http_status=http_status,
+            dns_query=dns_query,
+            drop_reason=raw.get("drop_reason_desc", ""),
+            summary=raw.get("Summary", ""),
+        )
+
+
+# ---------------------------------------------------------------------------
+# Module-level helpers
+# ---------------------------------------------------------------------------
+
+
+def _extract_zone(namespace: str) -> str:
+    """Extract zone name from a prefixed namespace.
+
+    E.g. ``"or-myrange-dmz"`` -> ``"dmz"`` (assuming the last segment is
+    the zone). Returns the full namespace if no prefix separator is found.
+    """
+    parts = namespace.rsplit("-", 1)
+    return parts[-1] if len(parts) > 1 else namespace

--- a/src/open_range/identity_enforcement.py
+++ b/src/open_range/identity_enforcement.py
@@ -1,0 +1,185 @@
+"""Check: Identity enforcement -- validates identity provider configuration.
+
+Advisory check that verifies the simulated identity provider is correctly
+configured when enabled.  This check never blocks admission on its own;
+it logs warnings for Red/Blue training completeness.
+"""
+
+from __future__ import annotations
+
+import json
+import logging
+from pathlib import Path
+from typing import Any
+
+from open_range.admission import ValidatorCheckReport
+from open_range.snapshot import KindArtifacts
+from open_range.world_ir import WorldIR
+
+logger = logging.getLogger(__name__)
+
+_CRITICAL_SERVICE_KINDS = {"web_app", "db", "idp"}
+
+
+def check_identity_enforcement(
+    world: WorldIR,
+    artifacts: KindArtifacts,
+    reference_bundle: object = None,
+) -> ValidatorCheckReport:
+    """Validate identity provider config in rendered artifacts.
+
+    Matches v1's ``CheckFunc`` signature so it can be registered as an
+    advisory admission check.
+    """
+    security_dir = Path(artifacts.render_dir) / "security" / "idp"
+    config_path = security_dir / "config.json"
+
+    if not config_path.exists():
+        return ValidatorCheckReport(
+            name="identity_enforcement",
+            passed=True,
+            advisory=True,
+            details={"note": "identity_provider not configured -- vacuously passes"},
+        )
+
+    issues: list[str] = []
+    details: dict[str, Any] = {}
+
+    try:
+        idp_raw = json.loads(config_path.read_text(encoding="utf-8"))
+    except (json.JSONDecodeError, OSError) as exc:
+        return ValidatorCheckReport(
+            name="identity_enforcement",
+            passed=False,
+            advisory=True,
+            details={"error": f"cannot read IdP config: {exc}"},
+        )
+
+    enabled = bool(idp_raw.get("enabled", False))
+    details["idp_enabled"] = enabled
+
+    if not enabled:
+        return ValidatorCheckReport(
+            name="identity_enforcement",
+            passed=True,
+            advisory=True,
+            details={"note": "identity_provider not enabled -- vacuously passes"},
+        )
+
+    # Validate config shape
+    issuer = idp_raw.get("issuer", "")
+    if not issuer:
+        issues.append("identity_provider.issuer is empty")
+
+    ttl = idp_raw.get("token_ttl_seconds", 0)
+    if not isinstance(ttl, (int, float)) or ttl <= 0:
+        issues.append("identity_provider.token_ttl_seconds must be positive")
+
+    signing_alg = idp_raw.get("signing_algorithm", "RS256")
+    if signing_alg not in ("RS256", "HS256", "ES256"):
+        issues.append(
+            f"identity_provider.signing_algorithm '{signing_alg}' is not recognized"
+        )
+
+    # Validate service identities
+    service_identities = idp_raw.get("service_identities", {})
+    details["service_identity_count"] = len(service_identities)
+
+    if world is not None:
+        world_service_kinds = {svc.kind for svc in world.services}
+        for critical in _CRITICAL_SERVICE_KINDS:
+            if critical in world_service_kinds:
+                svc_ids = {svc.id for svc in world.services if svc.kind == critical}
+                if not any(sid in service_identities for sid in svc_ids):
+                    issues.append(
+                        f"critical service kind '{critical}' present but has no "
+                        "service_identity defined"
+                    )
+
+    # Validate SPIFFE URI format
+    for svc_name, identity_raw in service_identities.items():
+        if isinstance(identity_raw, dict):
+            uri = identity_raw.get("identity_uri", "")
+        else:
+            uri = ""
+        if uri and not uri.startswith("spiffe://"):
+            issues.append(f"service_identity '{svc_name}' has non-SPIFFE URI: {uri}")
+
+    # Validate weaknesses
+    weaknesses = idp_raw.get("weaknesses", [])
+    details["weakness_count"] = len(weaknesses)
+
+    known = {
+        "accept_expired",
+        "no_audience_check",
+        "weak_signing_hs256",
+        "overly_broad_scopes",
+        "predictable_jti",
+        "missing_scope_check",
+    }
+    unknown = [w for w in weaknesses if w not in known]
+    if unknown:
+        issues.append(f"unknown weakness type(s): {', '.join(unknown)}")
+
+    if not weaknesses:
+        issues.append(
+            "identity_provider enabled but no weaknesses planted -- "
+            "Red has no identity-based attack surface"
+        )
+
+    # Token smoke test
+    try:
+        from open_range.identity_provider import (
+            IdentityProviderConfig,
+            ServiceIdentity,
+            SimulatedIdentityProvider,
+        )
+
+        svc_identities = {}
+        for svc_name, id_raw in service_identities.items():
+            if isinstance(id_raw, dict):
+                svc_identities[svc_name] = ServiceIdentity(
+                    identity_uri=id_raw.get("identity_uri", ""),
+                    allowed_scopes=id_raw.get("allowed_scopes", []),
+                )
+
+        idp_config = IdentityProviderConfig(
+            enabled=True,
+            issuer=str(issuer),
+            token_ttl_seconds=int(ttl)
+            if isinstance(ttl, (int, float)) and ttl > 0
+            else 300,
+            signing_algorithm=str(signing_alg),
+            weaknesses=list(weaknesses),
+            service_identities=svc_identities,
+        )
+        idp = SimulatedIdentityProvider(idp_config)
+
+        test_token = idp.issue_token(
+            subject="spiffe://range.local/ns/test/sa/validator",
+            scopes=["test:validate:*"],
+        )
+        claims = idp.validate_token(test_token)
+        if claims is None:
+            issues.append("identity_provider smoke test failed: token did not validate")
+        else:
+            details["smoke_test"] = "passed"
+
+        jwks = idp.jwks()
+        if not jwks.get("keys") and "weak_signing_hs256" not in weaknesses:
+            issues.append("JWKS is empty -- token verification will fail for RS256")
+
+    except ImportError:
+        details["smoke_test"] = "skipped (import unavailable)"
+    except Exception as exc:  # noqa: BLE001
+        issues.append(f"identity_provider smoke test error: {exc}")
+
+    passed = len(issues) == 0
+    details["issues"] = issues
+    return ValidatorCheckReport(
+        name="identity_enforcement",
+        passed=passed,
+        advisory=True,
+        details=details,
+        error="" if passed else "; ".join(issues),
+    )

--- a/src/open_range/identity_provider.py
+++ b/src/open_range/identity_provider.py
@@ -1,0 +1,516 @@
+"""Simulated OAuth/OIDC identity provider for range environments.
+
+Ported from k3s-istio-vault-platform's oauth-svid-as pattern.  Generates
+RS256 JWTs with SPIFFE-style service identities and configurable weaknesses
+that create identity-based attack surfaces for Red/Blue training.
+
+This module is entirely optional -- open-range works without it.
+"""
+
+from __future__ import annotations
+
+import base64
+import hashlib
+import json
+import logging
+import secrets
+import textwrap
+import time
+from typing import Any
+
+from pydantic import BaseModel, Field
+
+logger = logging.getLogger(__name__)
+
+# ---------------------------------------------------------------------------
+# Lazy crypto imports -- fall back gracefully
+# ---------------------------------------------------------------------------
+
+_RSA_AVAILABLE = False
+
+try:
+    from cryptography.hazmat.primitives import hashes, serialization  # noqa: F401
+    from cryptography.hazmat.primitives.asymmetric import padding, rsa  # noqa: F401
+
+    _RSA_AVAILABLE = True
+except ImportError:
+    try:
+        import jwt as _pyjwt  # noqa: F401
+
+        _RSA_AVAILABLE = True
+    except ImportError:
+        pass
+
+# We use PyJWT for token encode/decode regardless.
+try:
+    import jwt as pyjwt
+except ImportError:  # pragma: no cover
+    pyjwt = None  # type: ignore[assignment]
+
+
+# ---------------------------------------------------------------------------
+# Known plantable weaknesses
+# ---------------------------------------------------------------------------
+
+KNOWN_WEAKNESSES: frozenset[str] = frozenset(
+    {
+        "accept_expired",
+        "no_audience_check",
+        "weak_signing_hs256",
+        "overly_broad_scopes",
+        "predictable_jti",
+        "missing_scope_check",
+    }
+)
+
+
+# ---------------------------------------------------------------------------
+# Pydantic configuration models
+# ---------------------------------------------------------------------------
+
+
+class ServiceIdentity(BaseModel):
+    """Identity for a range service (inspired by SPIFFE).
+
+    ``identity_uri`` follows the SPIFFE ID format:
+        spiffe://range.local/ns/{zone}/sa/{service_name}
+
+    ``allowed_scopes`` uses hierarchical colon-separated format ported from
+    the k3s-istio-vault-platform authorization policy:
+        data:read:tenant/env/app/*
+    """
+
+    identity_uri: str = ""
+    allowed_scopes: list[str] = Field(default_factory=list)
+
+
+class IdentityProviderConfig(BaseModel):
+    """Configuration for the simulated identity provider.
+
+    All fields have sensible defaults so an empty ``IdentityProviderConfig()``
+    is valid.  Set ``enabled=True`` to activate the IdP in a range build.
+    """
+
+    enabled: bool = False
+    issuer: str = "https://idp.range.local"
+    token_ttl_seconds: int = 300  # 5 min -- matches k3s-istio-vault-platform
+    signing_algorithm: str = "RS256"
+
+    # Configurable weaknesses the Builder can plant for Red to exploit.
+    weaknesses: list[str] = Field(default_factory=list)
+
+    # Service identities keyed by logical service name.
+    service_identities: dict[str, ServiceIdentity] = Field(default_factory=dict)
+
+    # Port the in-container token server listens on.
+    token_endpoint_port: int = 8443
+
+    # Trust domain for SPIFFE ID generation.
+    trust_domain: str = "range.local"
+
+
+# ---------------------------------------------------------------------------
+# Simulated Identity Provider
+# ---------------------------------------------------------------------------
+
+
+class SimulatedIdentityProvider:
+    """Lightweight OAuth token service for range environments.
+
+    Ported from k3s-istio-vault-platform's ``oauth-svid-as`` pattern.
+    Generates RS256 JWTs with scopes, TTLs, and plantable weaknesses.
+
+    Usage::
+
+        config = IdentityProviderConfig(enabled=True, weaknesses=["accept_expired"])
+        idp = SimulatedIdentityProvider(config)
+        token = idp.issue_token("spiffe://range.local/ns/dmz/sa/web", ["data:read:patients/*"])
+        claims = idp.validate_token(token)
+    """
+
+    def __init__(self, config: IdentityProviderConfig) -> None:
+        self.config = config
+        self._private_key_pem: bytes = b""
+        self._public_key_pem: bytes = b""
+        self._kid: str = ""
+        self._n_b64: str = ""
+        self._e_b64: str = ""
+        # HMAC secret used when weak_signing_hs256 weakness is active.
+        self._hmac_secret: str = "range-hmac-secret"
+
+        if config.enabled:
+            self._private_key_pem, self._public_key_pem = self.generate_keypair()
+            self._kid = self._compute_kid(self._public_key_pem)
+            self._extract_jwk_components()
+
+    # ------------------------------------------------------------------
+    # Key management
+    # ------------------------------------------------------------------
+
+    def generate_keypair(self) -> tuple[bytes, bytes]:
+        """Generate an RSA 2048-bit keypair for JWT signing.
+
+        Returns (private_pem, public_pem) as bytes.
+        """
+        try:
+            from cryptography.hazmat.primitives.asymmetric import rsa as _rsa
+
+            private_key = _rsa.generate_private_key(
+                public_exponent=65537,
+                key_size=2048,
+            )
+            private_pem = private_key.private_bytes(
+                encoding=serialization.Encoding.PEM,
+                format=serialization.PrivateFormat.PKCS8,
+                encryption_algorithm=serialization.NoEncryption(),
+            )
+            public_pem = private_key.public_key().public_bytes(
+                encoding=serialization.Encoding.PEM,
+                format=serialization.PublicFormat.SubjectPublicKeyInfo,
+            )
+            return private_pem, public_pem
+        except Exception:
+            # Fallback: use PyJWT's built-in RSA support if available.
+            if pyjwt is not None:
+                try:
+                    from cryptography.hazmat.primitives.asymmetric import (
+                        rsa as _rsa2,
+                    )
+
+                    key = _rsa2.generate_private_key(65537, 2048)
+                    priv = key.private_bytes(
+                        serialization.Encoding.PEM,
+                        serialization.PrivateFormat.PKCS8,
+                        serialization.NoEncryption(),
+                    )
+                    pub = key.public_key().public_bytes(
+                        serialization.Encoding.PEM,
+                        serialization.PublicFormat.SubjectPublicKeyInfo,
+                    )
+                    return priv, pub
+                except Exception:
+                    pass
+
+            logger.warning(
+                "identity_provider: no RSA backend available -- "
+                "token issuance will use HS256 fallback"
+            )
+            return b"", b""
+
+    @staticmethod
+    def _compute_kid(public_key_pem: bytes) -> str:
+        """Derive a key ID from the public key (matches oauth-svid-as pattern)."""
+        digest = hashlib.sha256(public_key_pem).digest()
+        return base64.urlsafe_b64encode(digest[:8]).decode().rstrip("=")
+
+    def _extract_jwk_components(self) -> None:
+        """Extract RSA n and e in base64url for JWKS endpoint."""
+        if not self._public_key_pem:
+            return
+        try:
+            from cryptography.hazmat.primitives.serialization import load_pem_public_key
+
+            pub_key = load_pem_public_key(self._public_key_pem)
+            pub_numbers = pub_key.public_numbers()  # type: ignore[union-attr]
+            n_bytes = pub_numbers.n.to_bytes(
+                (pub_numbers.n.bit_length() + 7) // 8, byteorder="big"
+            )
+            e_bytes = pub_numbers.e.to_bytes(
+                (pub_numbers.e.bit_length() + 7) // 8, byteorder="big"
+            )
+            self._n_b64 = base64.urlsafe_b64encode(n_bytes).decode().rstrip("=")
+            self._e_b64 = base64.urlsafe_b64encode(e_bytes).decode().rstrip("=")
+        except Exception:
+            pass
+
+    # ------------------------------------------------------------------
+    # Token issuance (mirrors oauth-svid-as issueToken)
+    # ------------------------------------------------------------------
+
+    def issue_token(
+        self,
+        subject: str,
+        scopes: list[str],
+        audience: str = "range-api",
+    ) -> str:
+        """Issue a JWT token.
+
+        *subject* is typically a SPIFFE-style identity URI.
+        Returns the signed JWT string.
+        """
+        if pyjwt is None:
+            raise RuntimeError(
+                "PyJWT is required for token issuance. "
+                "Install with: pip install pyjwt[crypto]"
+            )
+
+        now = int(time.time())
+        ttl = self.config.token_ttl_seconds
+
+        # Token ID -- predictable if that weakness is active.
+        if "predictable_jti" in self.config.weaknesses:
+            jti = f"token-{now}-0001"
+        else:
+            jti = base64.urlsafe_b64encode(secrets.token_bytes(16)).decode().rstrip("=")
+
+        # Scopes -- overly_broad_scopes replaces requested scopes with wildcard.
+        effective_scopes = list(scopes)
+        if "overly_broad_scopes" in self.config.weaknesses:
+            effective_scopes = ["*:*:*"]
+
+        claims: dict[str, Any] = {
+            "iss": self.config.issuer,
+            "sub": subject,
+            "aud": audience,
+            "exp": now + ttl,
+            "iat": now,
+            "nbf": now - 30,
+            "jti": jti,
+            "scp": effective_scopes,
+            "scope": " ".join(effective_scopes),
+        }
+
+        # Choose signing algorithm -- weak_signing_hs256 downgrades to HS256.
+        if "weak_signing_hs256" in self.config.weaknesses:
+            token = pyjwt.encode(
+                claims,
+                self._hmac_secret,
+                algorithm="HS256",
+                headers={"kid": self._kid, "typ": "JWT"},
+            )
+        elif self._private_key_pem:
+            token = pyjwt.encode(
+                claims,
+                self._private_key_pem,
+                algorithm="RS256",
+                headers={"kid": self._kid, "typ": "JWT"},
+            )
+        else:
+            # No RSA key -- fall back to HS256.
+            token = pyjwt.encode(
+                claims,
+                self._hmac_secret,
+                algorithm="HS256",
+                headers={"kid": self._kid, "typ": "JWT"},
+            )
+
+        return token
+
+    # ------------------------------------------------------------------
+    # Token validation
+    # ------------------------------------------------------------------
+
+    def validate_token(
+        self,
+        token: str,
+        expected_audience: str = "range-api",
+    ) -> dict[str, Any] | None:
+        """Validate a JWT.  Returns claims dict or ``None`` if invalid.
+
+        Respects configured weaknesses:
+        - ``accept_expired``: expired tokens pass validation
+        - ``no_audience_check``: audience is not verified
+        - ``missing_scope_check``: scopes are not checked
+        """
+        if pyjwt is None:
+            logger.error("PyJWT not available -- cannot validate tokens")
+            return None
+
+        options: dict[str, bool] = {}
+
+        if "accept_expired" in self.config.weaknesses:
+            options["verify_exp"] = False
+
+        if "no_audience_check" in self.config.weaknesses:
+            options["verify_aud"] = False
+            expected_audience = ""
+
+        # Try RS256 with public key first, then HS256 fallback.
+        decode_keys: list[tuple[Any, list[str]]] = []
+        if self._public_key_pem:
+            decode_keys.append((self._public_key_pem, ["RS256"]))
+        decode_keys.append((self._hmac_secret, ["HS256"]))
+
+        for key, algs in decode_keys:
+            try:
+                kwargs: dict[str, Any] = {
+                    "algorithms": algs,
+                    "options": options,
+                }
+                if expected_audience:
+                    kwargs["audience"] = expected_audience
+                claims = pyjwt.decode(token, key, **kwargs)
+                return dict(claims)
+            except pyjwt.InvalidTokenError:
+                continue
+
+        return None
+
+    # ------------------------------------------------------------------
+    # JWKS endpoint data
+    # ------------------------------------------------------------------
+
+    def jwks(self) -> dict[str, Any]:
+        """Return JWKS (JSON Web Key Set) for token verification.
+
+        Follows the same structure as ``oauth-svid-as``'s
+        ``/.well-known/jwks.json`` handler.
+        """
+        keys: list[dict[str, str]] = []
+        if self._n_b64 and self._e_b64:
+            keys.append(
+                {
+                    "kty": "RSA",
+                    "kid": self._kid,
+                    "use": "sig",
+                    "alg": "RS256",
+                    "n": self._n_b64,
+                    "e": self._e_b64,
+                }
+            )
+        return {"keys": keys}
+
+    # ------------------------------------------------------------------
+    # Batch service token generation
+    # ------------------------------------------------------------------
+
+    def generate_service_tokens(self) -> dict[str, str]:
+        """Generate initial tokens for all configured service identities.
+
+        Returns a dict of ``{service_name: jwt_string}``.
+        """
+        tokens: dict[str, str] = {}
+        for svc_name, identity in self.config.service_identities.items():
+            token = self.issue_token(
+                subject=identity.identity_uri,
+                scopes=identity.allowed_scopes,
+            )
+            tokens[svc_name] = token
+        return tokens
+
+    # ------------------------------------------------------------------
+    # Startup script generation (injected into containers)
+    # ------------------------------------------------------------------
+
+    def generate_startup_script(self) -> str:
+        """Generate a shell script that runs a minimal token endpoint.
+
+        The script is injected into the web/ldap container as a payload.
+        It serves:
+          - ``POST /oauth/token`` (client_credentials grant)
+          - ``GET /.well-known/jwks.json``
+          - ``POST /oauth/introspect``
+
+        The embedded Python server uses only stdlib when PyJWT is unavailable.
+        """
+        port = self.config.token_endpoint_port
+        issuer = self.config.issuer
+        ttl = self.config.token_ttl_seconds
+        weaknesses = json.dumps(self.config.weaknesses)
+
+        # Embed the private key (base64 to avoid shell quoting issues).
+        priv_key_b64 = (
+            base64.b64encode(self._private_key_pem).decode()
+            if self._private_key_pem
+            else ""
+        )
+        pub_key_b64 = (
+            base64.b64encode(self._public_key_pem).decode()
+            if self._public_key_pem
+            else ""
+        )
+
+        # Service identities as JSON.
+        identities_json = json.dumps(
+            {
+                name: {"uri": ident.identity_uri, "scopes": ident.allowed_scopes}
+                for name, ident in self.config.service_identities.items()
+            }
+        )
+
+        jwks_json = json.dumps(self.jwks())
+        hmac_secret = self._hmac_secret
+
+        return textwrap.dedent(f"""\
+            #!/bin/bash
+            # OpenRange Identity Provider - Auto-generated token endpoint
+            # Launched as a background service inside the range container.
+            set -e
+
+            echo "[openrange-idp] Starting identity provider on port {port}..."
+
+            python3 /opt/openrange/identity_provider_server.py \\
+                --port {port} \\
+                --issuer '{issuer}' \\
+                --ttl {ttl} \\
+                --weaknesses '{weaknesses}' \\
+                --private-key-b64 '{priv_key_b64}' \\
+                --public-key-b64 '{pub_key_b64}' \\
+                --jwks '{jwks_json}' \\
+                --identities '{identities_json}' \\
+                --hmac-secret '{hmac_secret}' \\
+                &
+
+            echo "[openrange-idp] Identity provider started (PID $!)"
+        """)
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+
+def build_spiffe_id(
+    trust_domain: str,
+    zone: str,
+    service_name: str,
+) -> str:
+    """Build a SPIFFE-style identity URI.
+
+    Format: ``spiffe://{trust_domain}/ns/{zone}/sa/{service_name}``
+    """
+    return f"spiffe://{trust_domain}/ns/{zone}/sa/{service_name}"
+
+
+def default_service_identities(
+    trust_domain: str = "range.local",
+) -> dict[str, ServiceIdentity]:
+    """Return a reasonable default set of service identities for a range.
+
+    These mirror a typical enterprise IdP setup with scoped access.
+    """
+    return {
+        "web": ServiceIdentity(
+            identity_uri=build_spiffe_id(trust_domain, "dmz", "web"),
+            allowed_scopes=[
+                "data:read:patients/*",
+                "data:read:referrals/*",
+                "api:call:internal/*",
+            ],
+        ),
+        "db": ServiceIdentity(
+            identity_uri=build_spiffe_id(trust_domain, "internal", "db"),
+            allowed_scopes=[
+                "data:read:patients/*",
+                "data:write:patients/*",
+                "data:read:referrals/*",
+                "data:write:referrals/*",
+            ],
+        ),
+        "ldap": ServiceIdentity(
+            identity_uri=build_spiffe_id(trust_domain, "internal", "ldap"),
+            allowed_scopes=[
+                "directory:read:users/*",
+                "directory:write:users/*",
+                "auth:bind:*",
+            ],
+        ),
+        "siem": ServiceIdentity(
+            identity_uri=build_spiffe_id(trust_domain, "management", "siem"),
+            allowed_scopes=[
+                "logs:read:*",
+                "logs:write:*",
+                "alerts:read:*",
+            ],
+        ),
+    }

--- a/src/open_range/k3d_renderer.py
+++ b/src/open_range/k3d_renderer.py
@@ -1,0 +1,179 @@
+"""Render WorldIR into a Helm chart targeting k3d (multi-node k3s).
+
+Extends ``EnterpriseSaaSKindRenderer`` but produces a k3d cluster config
+instead of a Kind cluster config.  Zone isolation remains namespace-per-zone
+with NetworkPolicies; the k3d backend adds multi-node support (1 server +
+N agents) and proper subnet isolation (``172.29.0.0/16``).
+"""
+
+from __future__ import annotations
+
+import logging
+from pathlib import Path
+from typing import Any
+
+import yaml
+
+from open_range.render import EnterpriseSaaSKindRenderer
+from open_range.snapshot import KindArtifacts
+from open_range.synth import SynthArtifacts
+from open_range.world_ir import ServiceSpec, WorldIR
+
+logger = logging.getLogger(__name__)
+
+# k3d cluster defaults
+_K3D_SUBNET = "172.29.0.0/16"
+_K3D_AGENTS = 2
+_K3D_API_HOST = "127.0.0.1"
+_K3D_API_PORT = "6550"
+_K3D_K3S_IMAGE = "rancher/k3s:v1.31.6-k3s1"
+_K3D_WAIT_TIMEOUT = "300s"
+_DMZ_NODEPORT_BASE = 30080
+
+
+class K3dRenderer(EnterpriseSaaSKindRenderer):
+    """Render a WorldIR into a Helm chart and k3d cluster config.
+
+    Subclasses ``EnterpriseSaaSKindRenderer`` to reuse all values
+    generation logic.  Only the cluster config output differs: a k3d
+    Simple config is written instead of a Kind Cluster config.
+    """
+
+    def __init__(
+        self,
+        chart_dir: Path | None = None,
+        *,
+        agents: int = _K3D_AGENTS,
+        subnet: str = _K3D_SUBNET,
+        api_host: str = _K3D_API_HOST,
+        api_port: str = _K3D_API_PORT,
+        k3s_image: str = _K3D_K3S_IMAGE,
+        wait_timeout: str = _K3D_WAIT_TIMEOUT,
+    ) -> None:
+        super().__init__(chart_dir=chart_dir)
+        self.agents = agents
+        self.subnet = subnet
+        self.api_host = api_host
+        self.api_port = api_port
+        self.k3s_image = k3s_image
+        self.wait_timeout = wait_timeout
+
+    def render(
+        self, world: WorldIR, synth: SynthArtifacts, outdir: Path
+    ) -> KindArtifacts:
+        """Render the Helm chart and k3d config to *outdir*.
+
+        Delegates most work to ``EnterpriseSaaSKindRenderer.render()``
+        then replaces the Kind config with a k3d config.
+        """
+        artifacts = super().render(world, synth, outdir)
+
+        # Replace kind-config.yaml with k3d-config.yaml
+        kind_config_path = Path(artifacts.kind_config_path)
+        if kind_config_path.exists():
+            kind_config_path.unlink()
+
+        k3d_config = self._build_k3d_config(world)
+        k3d_config_path = Path(outdir) / "k3d-config.yaml"
+        k3d_config_path.write_text(
+            yaml.dump(k3d_config, default_flow_style=False, sort_keys=False),
+            encoding="utf-8",
+        )
+
+        logger.info(
+            "K3dRenderer: wrote k3d-config.yaml (%d agents, subnet %s)",
+            self.agents,
+            self.subnet,
+        )
+
+        # Return updated artifacts with the k3d config path
+        return KindArtifacts(
+            render_dir=artifacts.render_dir,
+            chart_dir=artifacts.chart_dir,
+            values_path=artifacts.values_path,
+            kind_config_path=str(k3d_config_path),
+            manifest_summary_path=artifacts.manifest_summary_path,
+            rendered_files=(*artifacts.rendered_files, str(k3d_config_path)),
+            chart_values=artifacts.chart_values,
+            pinned_image_digests=artifacts.pinned_image_digests,
+        )
+
+    # ------------------------------------------------------------------
+    # k3d cluster config
+    # ------------------------------------------------------------------
+
+    def _build_k3d_config(self, world: WorldIR) -> dict[str, Any]:
+        """Generate a k3d Simple cluster config with DMZ port mappings.
+
+        Disables Traefik and the default CNI (flannel) so the cluster
+        is ready for a Cilium install managed separately.
+        """
+        # Extract DMZ services for port mapping
+        host_by_id = {h.id: h for h in world.hosts}
+        dmz_services: list[ServiceSpec] = []
+        for svc in world.services:
+            host = host_by_id.get(svc.host)
+            if host and host.exposure == "public":
+                dmz_services.append(svc)
+
+        # Build port mappings for the k3d config
+        ports: list[dict[str, Any]] = [
+            {"port": "8080:80", "nodeFilters": ["loadbalancer"]},
+            {"port": "8443:443", "nodeFilters": ["loadbalancer"]},
+        ]
+
+        if dmz_services:
+            base = _DMZ_NODEPORT_BASE
+            for i, svc in enumerate(dmz_services):
+                np = base + i
+                ports.append(
+                    {
+                        "port": f"{np}:{np}",
+                        "nodeFilters": ["server:0"],
+                    }
+                )
+        else:
+            ports.append(
+                {
+                    "port": f"{_DMZ_NODEPORT_BASE}-{_DMZ_NODEPORT_BASE + 9}"
+                    f":{_DMZ_NODEPORT_BASE}-{_DMZ_NODEPORT_BASE + 9}",
+                    "nodeFilters": ["server:0"],
+                }
+            )
+
+        extra_args: list[dict[str, Any]] = [
+            {"arg": "--disable=traefik", "nodeFilters": ["server:*"]},
+            {"arg": "--flannel-backend=none", "nodeFilters": ["server:*"]},
+            {"arg": "--disable-network-policy", "nodeFilters": ["server:*"]},
+        ]
+
+        node_labels: list[dict[str, Any]] = [
+            {"label": "openrange.io/role=agent", "nodeFilters": ["agent:*"]},
+            {"label": "openrange.io/role=server", "nodeFilters": ["server:*"]},
+        ]
+
+        return {
+            "apiVersion": "k3d.io/v1alpha5",
+            "kind": "Simple",
+            "metadata": {"name": "openrange"},
+            "servers": 1,
+            "agents": self.agents,
+            "image": self.k3s_image,
+            "subnet": self.subnet,
+            "kubeAPI": {
+                "host": self.api_host,
+                "hostIP": self.api_host,
+                "hostPort": self.api_port,
+            },
+            "ports": ports,
+            "options": {
+                "k3d": {
+                    "wait": True,
+                    "timeout": self.wait_timeout,
+                },
+                "k3s": {
+                    "extraArgs": extra_args,
+                    "nodeLabels": node_labels,
+                },
+            },
+        }

--- a/src/open_range/k3d_runner.py
+++ b/src/open_range/k3d_runner.py
@@ -1,0 +1,212 @@
+"""Boot and tear down rendered snapshot Helm releases on a k3d cluster.
+
+Extends ``KindBackend`` but uses k3d instead of Kind for cluster
+management and image loading.  The k3d cluster provides multi-node
+support (1 server + N agents) with proper subnet isolation.
+"""
+
+from __future__ import annotations
+
+import logging
+import shutil
+import subprocess
+from dataclasses import dataclass
+from pathlib import Path
+
+from open_range.cluster import KindBackend
+
+logger = logging.getLogger(__name__)
+
+# Default cluster name matches deploy/k3d/k3d-up.sh
+_DEFAULT_CLUSTER = "openrange"
+
+
+def resolve_kubectl_cmd(k3d_cluster: str = _DEFAULT_CLUSTER) -> tuple[str, ...]:
+    """Return a kubectl command prefix configured for the k3d context.
+
+    k3d clusters expose a kubeconfig context named ``k3d-<cluster>``.
+    We prefer a host kubectl when present; otherwise fall back to
+    running kubectl inside the k3d server container.
+    """
+    if shutil.which("kubectl"):
+        return ("kubectl", "--context", f"k3d-{k3d_cluster}")
+    return (
+        "docker",
+        "exec",
+        f"k3d-{k3d_cluster}-server-0",
+        "kubectl",
+    )
+
+
+@dataclass
+class K3dClusterInfo:
+    """Metadata about a running k3d cluster."""
+
+    name: str
+    agents: int
+    subnet: str
+    api_host: str = "127.0.0.1"
+    api_port: int = 6550
+    context: str = ""
+
+    def __post_init__(self) -> None:
+        if not self.context:
+            self.context = f"k3d-{self.name}"
+
+
+class K3dBackend(KindBackend):
+    """Boot and tear down rendered snapshot Helm charts on k3d.
+
+    Extends ``KindBackend`` to use k3d for image loading and cluster
+    lifecycle management.  The ``boot()`` / ``teardown()`` interface
+    remains identical so call sites can swap backends transparently.
+    """
+
+    def __init__(
+        self,
+        *,
+        kind_cluster: str = _DEFAULT_CLUSTER,
+        k3d_agents: int = 2,
+        k3d_subnet: str = "172.29.0.0/16",
+    ) -> None:
+        super().__init__(kind_cluster=kind_cluster)
+        self.k3d_cluster = kind_cluster
+        self.k3d_agents = k3d_agents
+        self.k3d_subnet = k3d_subnet
+
+    # ------------------------------------------------------------------
+    # Cluster lifecycle
+    # ------------------------------------------------------------------
+
+    def create_cluster(
+        self,
+        *,
+        config_path: Path | None = None,
+        env_overrides: dict[str, str] | None = None,
+    ) -> K3dClusterInfo:
+        """Create a k3d cluster.
+
+        If *config_path* points to a rendered k3d-config.yaml, it is
+        used directly.  Otherwise a default k3d configuration is applied.
+
+        Returns metadata about the created cluster.
+        """
+        if self.cluster_exists():
+            logger.info(
+                "k3d cluster '%s' already exists, skipping creation", self.k3d_cluster
+            )
+            return K3dClusterInfo(
+                name=self.k3d_cluster,
+                agents=self.k3d_agents,
+                subnet=self.k3d_subnet,
+            )
+
+        cmd: list[str]
+        if config_path and config_path.exists():
+            cmd = ["k3d", "cluster", "create", "--config", str(config_path)]
+        else:
+            cmd = [
+                "k3d",
+                "cluster",
+                "create",
+                self.k3d_cluster,
+                "--agents",
+                str(self.k3d_agents),
+                "--subnet",
+                self.k3d_subnet,
+                "--k3s-arg",
+                "--disable=traefik@server:*",
+                "--k3s-arg",
+                "--flannel-backend=none@server:*",
+                "--k3s-arg",
+                "--disable-network-policy@server:*",
+                "--port",
+                "30080-30089:30080-30089@server:0",
+                "--wait",
+                "--timeout",
+                "300s",
+            ]
+
+        import os
+
+        run_env = dict(os.environ)
+        if env_overrides:
+            run_env.update(env_overrides)
+
+        self._run(cmd, timeout=360.0)
+        logger.info("Created k3d cluster '%s'", self.k3d_cluster)
+
+        self._run(
+            ["kubectl", "config", "use-context", f"k3d-{self.k3d_cluster}"],
+            timeout=10.0,
+        )
+
+        return K3dClusterInfo(
+            name=self.k3d_cluster,
+            agents=self.k3d_agents,
+            subnet=self.k3d_subnet,
+        )
+
+    def delete_cluster(self) -> None:
+        """Delete the k3d cluster if it exists."""
+        if not self.cluster_exists():
+            logger.info(
+                "k3d cluster '%s' does not exist, nothing to delete", self.k3d_cluster
+            )
+            return
+        self._run(
+            ["k3d", "cluster", "delete", self.k3d_cluster],
+            timeout=120.0,
+        )
+        logger.info("Deleted k3d cluster '%s'", self.k3d_cluster)
+
+    def cluster_exists(self) -> bool:
+        """Check whether the k3d cluster is currently running."""
+        result = subprocess.run(
+            ["k3d", "cluster", "list", "-o", "json"],
+            check=False,
+            capture_output=True,
+            text=True,
+        )
+        if result.returncode != 0:
+            return False
+        return f'"name":"{self.k3d_cluster}"' in result.stdout
+
+    # ------------------------------------------------------------------
+    # Image management -- override Kind's image loading
+    # ------------------------------------------------------------------
+
+    def prepare_images(self, chart_dir: Path) -> None:
+        """Override KindBackend.prepare_images to use k3d image import."""
+        for image in self._chart_images(chart_dir):
+            self._ensure_image_loaded(image)
+
+    def _ensure_image_loaded(self, image: str) -> None:
+        """Pull (if needed) and import an image into the k3d cluster."""
+        if not image:
+            return
+        if not self._docker_image_present(image):
+            try:
+                self._run(["docker", "pull", image], timeout=300.0)
+            except Exception as exc:  # noqa: BLE001
+                logger.warning("Failed to pre-pull image %s: %s", image, exc)
+                return
+        self._load_single_image(image)
+
+    def _load_single_image(self, image: str) -> None:
+        """Import a single image into the k3d cluster (best-effort)."""
+        try:
+            self._run(
+                ["k3d", "image", "import", "-c", self.k3d_cluster, image],
+                timeout=120.0,
+            )
+            logger.debug(
+                "Imported image %s into k3d cluster %s", image, self.k3d_cluster
+            )
+        except Exception as exc:  # noqa: BLE001
+            logger.warning(
+                "Failed to import image %s into k3d cluster %s: %s",
+                image,
+                self.k3d_cluster,
+                exc,
+            )

--- a/src/open_range/mtls_enforcement.py
+++ b/src/open_range/mtls_enforcement.py
@@ -1,0 +1,115 @@
+"""Check: mTLS Enforcement -- validates mTLS configuration is correctly applied.
+
+Verifies that services configured for mTLS have certificate material
+generated in the rendered artifact directory and that the CA trust chain
+is consistent.
+
+This check is advisory-safe: if mTLS is not enabled the check passes
+immediately (mTLS is completely optional).
+"""
+
+from __future__ import annotations
+
+import json
+import logging
+from pathlib import Path
+
+from open_range.admission import ValidatorCheckReport
+from open_range.snapshot import KindArtifacts
+from open_range.world_ir import WorldIR
+
+logger = logging.getLogger(__name__)
+
+_MTLS_CERT_FILES = ("ca.pem", "cert.pem", "key.pem")
+
+
+def check_mtls_enforcement(
+    world: WorldIR,
+    artifacts: KindArtifacts,
+    reference_bundle: object = None,
+) -> ValidatorCheckReport:
+    """Validate mTLS certificate config in rendered artifacts.
+
+    Matches v1's ``CheckFunc`` signature so it can be registered as an
+    advisory admission check.
+    """
+    security_dir = Path(artifacts.render_dir) / "security" / "mtls"
+    config_path = security_dir / "config.json"
+
+    if not config_path.exists():
+        return ValidatorCheckReport(
+            name="mtls_enforcement",
+            passed=True,
+            advisory=True,
+            details={"note": "mTLS not configured -- vacuously passes"},
+        )
+
+    issues: list[str] = []
+
+    try:
+        mtls_config = json.loads(config_path.read_text(encoding="utf-8"))
+    except (json.JSONDecodeError, OSError) as exc:
+        return ValidatorCheckReport(
+            name="mtls_enforcement",
+            passed=False,
+            advisory=True,
+            details={"error": f"cannot read mTLS config: {exc}"},
+        )
+
+    if not mtls_config.get("enabled", False):
+        return ValidatorCheckReport(
+            name="mtls_enforcement",
+            passed=True,
+            advisory=True,
+            details={"note": "mTLS not enabled -- vacuously passes"},
+        )
+
+    mtls_services: list[str] = mtls_config.get("mtls_services", [])
+    weaknesses: dict[str, list[str]] = mtls_config.get("weaknesses", {})
+
+    if not mtls_services:
+        issues.append("mTLS enabled but no services listed")
+
+    # Check cert files exist for each service
+    for svc_name in mtls_services:
+        svc_dir = security_dir / svc_name
+        missing = []
+        for fname in _MTLS_CERT_FILES:
+            if not (svc_dir / fname).exists():
+                missing.append(fname)
+        if missing:
+            issues.append(f"{svc_name}: missing mTLS file(s): {', '.join(missing)}")
+
+    # CA consistency: non-self_signed services should share the same CA
+    consistent_cas: set[str] = set()
+    for svc_name in mtls_services:
+        svc_weaknesses = weaknesses.get(svc_name, [])
+        if "self_signed" in svc_weaknesses:
+            continue
+        ca_path = security_dir / svc_name / "ca.pem"
+        if ca_path.exists():
+            consistent_cas.add(ca_path.read_text(encoding="utf-8"))
+
+    if len(consistent_cas) > 1:
+        issues.append(
+            f"CA certificate inconsistent across mTLS services "
+            f"(found {len(consistent_cas)} distinct CAs excluding self_signed)"
+        )
+
+    # At least one weakness should be planted for training value
+    total_weaknesses = sum(len(v) for v in weaknesses.values())
+    if total_weaknesses == 0:
+        issues.append("No weaknesses planted in any mTLS service")
+
+    passed = len(issues) == 0
+    return ValidatorCheckReport(
+        name="mtls_enforcement",
+        passed=passed,
+        advisory=True,
+        details={
+            "mtls_services": mtls_services,
+            "weaknesses": weaknesses,
+            "issues": issues,
+        },
+        error="" if passed else "; ".join(issues),
+    )

--- a/src/open_range/mtls_sim.py
+++ b/src/open_range/mtls_sim.py
@@ -1,0 +1,489 @@
+"""Simulated mTLS certificate infrastructure for range services.
+
+Generates self-signed CA and per-service TLS certificates with configurable
+weaknesses that Red agents must exploit and Blue agents must detect.
+
+Ported from k3s-istio-vault-platform's Istio PeerAuthentication (STRICT mTLS)
+and SPIFFE mTLS proxy patterns.  In production Istio, every pod gets an
+x509-SVID via the Citadel CA and the mesh enforces mutual authentication.
+Here we simulate the same topology with deliberately breakable certificates
+so agents learn to assess TLS health.
+
+Weaknesses catalogue
+--------------------
+- ``expired_cert``    : notAfter in the past — Red detects with ``openssl s_client``
+- ``weak_key_1024``   : 1024-bit RSA key — weak, factorable with sufficient compute
+- ``no_client_verify``: missing clientAuth EKU — server won't demand client cert
+- ``wrong_san``       : SAN mismatches the service hostname
+- ``self_signed``     : cert signed by a *different* CA (trust-chain break)
+"""
+
+from __future__ import annotations
+
+import datetime
+import logging
+from typing import Any
+
+from pydantic import BaseModel, Field
+
+logger = logging.getLogger(__name__)
+
+# ---------------------------------------------------------------------------
+# Attempt to import cryptography; fall back to None so callers can check.
+# ---------------------------------------------------------------------------
+
+try:
+    from cryptography import x509
+    from cryptography.hazmat.primitives import hashes, serialization
+    from cryptography.hazmat.primitives.asymmetric import rsa
+    from cryptography.x509.oid import ExtendedKeyUsageOID, NameOID
+
+    _HAS_CRYPTOGRAPHY = True
+except ImportError:  # pragma: no cover — only when library absent
+    _HAS_CRYPTOGRAPHY = False
+
+# ---------------------------------------------------------------------------
+# Pydantic models
+# ---------------------------------------------------------------------------
+
+
+class MTLSConfig(BaseModel):
+    """Configuration for mTLS between range services."""
+
+    enabled: bool = False
+    ca_common_name: str = "OpenRange Internal CA"
+    cert_validity_days: int = 365
+    key_size: int = 2048
+    # Services that require mTLS for incoming connections
+    mtls_services: list[str] = Field(default_factory=list)
+    # e.g. ["db", "ldap", "files"]
+    # Configurable weaknesses per service
+    weaknesses: dict[str, list[str]] = Field(default_factory=dict)
+    # e.g. {"db": ["expired_cert"], "ldap": ["no_client_verify"], "files": ["weak_key_1024"]}
+
+
+class CertificateBundle(BaseModel):
+    """Generated certificate material for a service."""
+
+    service_name: str
+    ca_cert_pem: str
+    cert_pem: str
+    key_pem: str
+    # Weakness applied (if any)
+    weakness: str | None = None
+
+
+# Supported weakness identifiers (used for validation).
+SUPPORTED_WEAKNESSES: frozenset[str] = frozenset(
+    {
+        "expired_cert",
+        "weak_key_1024",
+        "no_client_verify",
+        "wrong_san",
+        "self_signed",
+    }
+)
+
+# Service-specific TLS environment variable mappings.
+_SERVICE_TLS_ENV: dict[str, dict[str, str]] = {
+    "mysql": {
+        "SSL_CERT": "/etc/mtls/cert.pem",
+        "SSL_KEY": "/etc/mtls/key.pem",
+        "SSL_CA": "/etc/mtls/ca.pem",
+        "require_secure_transport": "ON",
+    },
+    "db": {
+        "SSL_CERT": "/etc/mtls/cert.pem",
+        "SSL_KEY": "/etc/mtls/key.pem",
+        "SSL_CA": "/etc/mtls/ca.pem",
+        "require_secure_transport": "ON",
+    },
+    "nginx": {
+        "ssl_certificate": "/etc/mtls/cert.pem",
+        "ssl_certificate_key": "/etc/mtls/key.pem",
+        "ssl_client_certificate": "/etc/mtls/ca.pem",
+    },
+    "web": {
+        "ssl_certificate": "/etc/mtls/cert.pem",
+        "ssl_certificate_key": "/etc/mtls/key.pem",
+        "ssl_client_certificate": "/etc/mtls/ca.pem",
+    },
+    "ldap": {
+        "LDAP_TLS_CRT_FILENAME": "/etc/mtls/cert.pem",
+        "LDAP_TLS_KEY_FILENAME": "/etc/mtls/key.pem",
+        "LDAP_TLS_CA_FILE": "/etc/mtls/ca.pem",
+        "LDAP_TLS_VERIFY_CLIENT": "demand",
+    },
+    "openldap": {
+        "LDAP_TLS_CRT_FILENAME": "/etc/mtls/cert.pem",
+        "LDAP_TLS_KEY_FILENAME": "/etc/mtls/key.pem",
+        "LDAP_TLS_CA_FILE": "/etc/mtls/ca.pem",
+        "LDAP_TLS_VERIFY_CLIENT": "demand",
+    },
+}
+
+
+class MTLSSimulator:
+    """Generate CA and per-service TLS certificates for range mTLS.
+
+    Ported from k3s-istio-vault-platform's Istio PeerAuthentication
+    and SPIFFE mTLS patterns.  Generates:
+
+    - Self-signed root CA
+    - Per-service server certificates with SANs
+    - Per-service client certificates for mutual auth
+    - Configurable weaknesses for Red to exploit
+
+    Requires the ``cryptography`` library.  If not installed, instantiation
+    raises :class:`RuntimeError` with installation instructions.
+    """
+
+    def __init__(self, config: MTLSConfig) -> None:
+        if not _HAS_CRYPTOGRAPHY:
+            raise RuntimeError(
+                "The 'cryptography' package is required for mTLS simulation. "
+                "Install it with: pip install cryptography"
+            )
+        self.config = config
+        self._ca_cert: bytes | None = None
+        self._ca_key: Any = None
+
+    # ------------------------------------------------------------------
+    # CA generation
+    # ------------------------------------------------------------------
+
+    def generate_ca(self) -> tuple[bytes, bytes]:
+        """Generate a root CA cert + key.
+
+        Returns ``(ca_cert_pem, ca_key_pem)`` as PEM-encoded bytes.
+        The CA is cached on the instance for subsequent service cert calls.
+        """
+        ca_key = rsa.generate_private_key(
+            public_exponent=65537,
+            key_size=self.config.key_size,
+        )
+
+        subject = issuer = x509.Name(
+            [
+                x509.NameAttribute(NameOID.COMMON_NAME, self.config.ca_common_name),
+                x509.NameAttribute(NameOID.ORGANIZATION_NAME, "OpenRange"),
+            ]
+        )
+
+        now = datetime.datetime.now(datetime.timezone.utc)
+        ca_cert = (
+            x509.CertificateBuilder()
+            .subject_name(subject)
+            .issuer_name(issuer)
+            .public_key(ca_key.public_key())
+            .serial_number(x509.random_serial_number())
+            .not_valid_before(now)
+            .not_valid_after(
+                now + datetime.timedelta(days=self.config.cert_validity_days * 2)
+            )
+            .add_extension(
+                x509.BasicConstraints(ca=True, path_length=None),
+                critical=True,
+            )
+            .add_extension(
+                x509.KeyUsage(
+                    digital_signature=True,
+                    key_cert_sign=True,
+                    crl_sign=True,
+                    content_commitment=False,
+                    key_encipherment=False,
+                    data_encipherment=False,
+                    key_agreement=False,
+                    encipher_only=False,
+                    decipher_only=False,
+                ),
+                critical=True,
+            )
+            .sign(ca_key, hashes.SHA256())
+        )
+
+        self._ca_cert = ca_cert.public_bytes(serialization.Encoding.PEM)
+        self._ca_key = ca_key
+
+        ca_key_pem = ca_key.private_bytes(
+            serialization.Encoding.PEM,
+            serialization.PrivateFormat.TraditionalOpenSSL,
+            serialization.NoEncryption(),
+        )
+
+        return self._ca_cert, ca_key_pem
+
+    # ------------------------------------------------------------------
+    # Per-service certificate generation
+    # ------------------------------------------------------------------
+
+    def generate_service_cert(
+        self,
+        service_name: str,
+        zone: str,
+        domain: str = "range.local",
+        weakness: str | None = None,
+    ) -> CertificateBundle:
+        """Generate a certificate for a service.
+
+        SANs include:
+        - ``{service}.{zone}.svc.cluster.local``
+        - ``{service}.{zone}``
+
+        Weaknesses:
+        - ``"expired_cert"``    : cert already expired (notAfter in the past)
+        - ``"weak_key_1024"``    : use 512-bit RSA (easily factorable)
+        - ``"no_client_verify"``: omit clientAuth extended key usage
+        - ``"wrong_san"``       : SAN doesn't match service hostname
+        - ``"self_signed"``     : use a different CA (trust-chain break)
+        """
+        if weakness and weakness not in SUPPORTED_WEAKNESSES:
+            raise ValueError(
+                f"Unknown weakness {weakness!r}. "
+                f"Supported: {sorted(SUPPORTED_WEAKNESSES)}"
+            )
+
+        # Ensure CA exists
+        if self._ca_cert is None or self._ca_key is None:
+            self.generate_ca()
+
+        signing_key = self._ca_key
+        ca_cert_pem = self._ca_cert
+
+        # --- Determine key size ---
+        key_size = self.config.key_size
+        if weakness == "weak_key_1024":
+            key_size = 1024
+
+        service_key = rsa.generate_private_key(
+            public_exponent=65537,
+            key_size=key_size,
+        )
+
+        # --- Build SANs ---
+        if weakness == "wrong_san":
+            sans = [
+                x509.DNSName(f"wrong-service.{zone}.svc.cluster.local"),
+                x509.DNSName(f"wrong-service.{zone}"),
+            ]
+        else:
+            sans = [
+                x509.DNSName(f"{service_name}.{zone}.svc.cluster.local"),
+                x509.DNSName(f"{service_name}.{zone}"),
+            ]
+
+        # --- Determine validity window ---
+        now = datetime.datetime.now(datetime.timezone.utc)
+        if weakness == "expired_cert":
+            not_valid_before = now - datetime.timedelta(days=730)
+            not_valid_after = now - datetime.timedelta(days=1)
+        else:
+            not_valid_before = now
+            not_valid_after = now + datetime.timedelta(
+                days=self.config.cert_validity_days
+            )
+
+        # --- Handle self_signed weakness (different CA) ---
+        if weakness == "self_signed":
+            rogue_key = rsa.generate_private_key(
+                public_exponent=65537,
+                key_size=self.config.key_size,
+            )
+            rogue_ca_name = x509.Name(
+                [
+                    x509.NameAttribute(NameOID.COMMON_NAME, "Rogue CA"),
+                    x509.NameAttribute(NameOID.ORGANIZATION_NAME, "Untrusted"),
+                ]
+            )
+            rogue_ca_cert = (
+                x509.CertificateBuilder()
+                .subject_name(rogue_ca_name)
+                .issuer_name(rogue_ca_name)
+                .public_key(rogue_key.public_key())
+                .serial_number(x509.random_serial_number())
+                .not_valid_before(now)
+                .not_valid_after(now + datetime.timedelta(days=365))
+                .add_extension(
+                    x509.BasicConstraints(ca=True, path_length=None),
+                    critical=True,
+                )
+                .sign(rogue_key, hashes.SHA256())
+            )
+            signing_key = rogue_key
+            ca_cert_pem = rogue_ca_cert.public_bytes(serialization.Encoding.PEM)
+
+        # --- Build EKU list ---
+        eku_list = [ExtendedKeyUsageOID.SERVER_AUTH]
+        if weakness != "no_client_verify":
+            eku_list.append(ExtendedKeyUsageOID.CLIENT_AUTH)
+
+        # --- Assemble certificate ---
+        subject = x509.Name(
+            [
+                x509.NameAttribute(NameOID.COMMON_NAME, f"{service_name}.{domain}"),
+                x509.NameAttribute(NameOID.ORGANIZATION_NAME, "OpenRange"),
+            ]
+        )
+
+        # Issuer name from the signing CA
+        if weakness == "self_signed":
+            issuer_name = x509.Name(
+                [
+                    x509.NameAttribute(NameOID.COMMON_NAME, "Rogue CA"),
+                    x509.NameAttribute(NameOID.ORGANIZATION_NAME, "Untrusted"),
+                ]
+            )
+        else:
+            issuer_name = x509.Name(
+                [
+                    x509.NameAttribute(NameOID.COMMON_NAME, self.config.ca_common_name),
+                    x509.NameAttribute(NameOID.ORGANIZATION_NAME, "OpenRange"),
+                ]
+            )
+
+        cert = (
+            x509.CertificateBuilder()
+            .subject_name(subject)
+            .issuer_name(issuer_name)
+            .public_key(service_key.public_key())
+            .serial_number(x509.random_serial_number())
+            .not_valid_before(not_valid_before)
+            .not_valid_after(not_valid_after)
+            .add_extension(
+                x509.SubjectAlternativeName(sans),
+                critical=False,
+            )
+            .add_extension(
+                x509.ExtendedKeyUsage(eku_list),
+                critical=False,
+            )
+            .add_extension(
+                x509.BasicConstraints(ca=False, path_length=None),
+                critical=True,
+            )
+            .sign(signing_key, hashes.SHA256())
+        )
+
+        cert_pem = cert.public_bytes(serialization.Encoding.PEM).decode()
+        key_pem = service_key.private_bytes(
+            serialization.Encoding.PEM,
+            serialization.PrivateFormat.TraditionalOpenSSL,
+            serialization.NoEncryption(),
+        ).decode()
+
+        return CertificateBundle(
+            service_name=service_name,
+            ca_cert_pem=ca_cert_pem.decode()
+            if isinstance(ca_cert_pem, bytes)
+            else ca_cert_pem,
+            cert_pem=cert_pem,
+            key_pem=key_pem,
+            weakness=weakness,
+        )
+
+    # ------------------------------------------------------------------
+    # Bulk generation
+    # ------------------------------------------------------------------
+
+    def generate_all_certs(
+        self,
+        services: dict[str, Any],
+        zones: dict[str, Any],
+    ) -> dict[str, CertificateBundle]:
+        """Generate certificates for all mTLS-enabled services.
+
+        Parameters
+        ----------
+        services:
+            Mapping of service names to service config dicts (from topology
+            or the rendered Helm values).
+        zones:
+            Mapping of zone names to lists of hosts in that zone.
+
+        Returns a dict mapping service names to their :class:`CertificateBundle`.
+        """
+        if not self.config.enabled:
+            return {}
+
+        # Ensure CA
+        if self._ca_cert is None:
+            self.generate_ca()
+
+        # Build reverse map: host -> zone
+        host_to_zone: dict[str, str] = {}
+        for zone_name, zone_hosts in zones.items():
+            if isinstance(zone_hosts, list):
+                for h in zone_hosts:
+                    host_name = h if isinstance(h, str) else str(h)
+                    host_to_zone[host_name] = zone_name
+
+        bundles: dict[str, CertificateBundle] = {}
+        mtls_set = set(self.config.mtls_services)
+
+        for svc_name in services:
+            if mtls_set and svc_name not in mtls_set:
+                continue
+
+            zone = host_to_zone.get(svc_name, "default")
+            weaknesses = self.config.weaknesses.get(svc_name, [])
+            # Apply the first configured weakness (one per cert).
+            weakness = weaknesses[0] if weaknesses else None
+
+            bundles[svc_name] = self.generate_service_cert(
+                service_name=svc_name,
+                zone=zone,
+                weakness=weakness,
+            )
+
+        return bundles
+
+    # ------------------------------------------------------------------
+    # Payload integration
+    # ------------------------------------------------------------------
+
+    @staticmethod
+    def get_payload_files(bundle: CertificateBundle) -> list[dict[str, str]]:
+        """Convert a :class:`CertificateBundle` into payload file entries.
+
+        Returns entries compatible with the Helm chart payload format used
+        by :meth:`KindRenderer._service_payloads`:
+
+        .. code-block:: python
+
+            [
+                {"key": "ca.pem",   "mountPath": "/etc/mtls/ca.pem",   "content": ...},
+                {"key": "cert.pem", "mountPath": "/etc/mtls/cert.pem", "content": ...},
+                {"key": "key.pem",  "mountPath": "/etc/mtls/key.pem",  "content": ...},
+            ]
+        """
+        return [
+            {
+                "key": "ca.pem",
+                "mountPath": "/etc/mtls/ca.pem",
+                "content": bundle.ca_cert_pem,
+            },
+            {
+                "key": "cert.pem",
+                "mountPath": "/etc/mtls/cert.pem",
+                "content": bundle.cert_pem,
+            },
+            {
+                "key": "key.pem",
+                "mountPath": "/etc/mtls/key.pem",
+                "content": bundle.key_pem,
+            },
+        ]
+
+    @staticmethod
+    def get_service_tls_env(service_name: str) -> dict[str, str]:
+        """Return environment variables to enable TLS for a service.
+
+        Supported services and their env vars:
+
+        - **MySQL / db** : ``SSL_CERT``, ``SSL_KEY``, ``SSL_CA``, ``require_secure_transport``
+        - **nginx / web** : ``ssl_certificate``, ``ssl_certificate_key``, ``ssl_client_certificate``
+        - **LDAP / openldap** : ``LDAP_TLS_CRT_FILENAME``, ``LDAP_TLS_KEY_FILENAME``, etc.
+
+        Returns an empty dict for unknown services.
+        """
+        return dict(_SERVICE_TLS_ENV.get(service_name, {}))

--- a/src/open_range/prometheus_rewards.py
+++ b/src/open_range/prometheus_rewards.py
@@ -1,0 +1,260 @@
+"""Prometheus-based reward signals for Blue agent training.
+
+Provides a ``PrometheusRewardDataSource`` that queries a Prometheus server
+for metrics used to compute supplementary reward signals.  These signals
+feed into (but do not replace) the existing ``CompositeBlueReward`` in
+``open_range.server.rewards``.
+
+The module is entirely optional.  When Prometheus is unreachable, every
+method returns a safe default value so training can proceed without the
+monitoring stack.
+
+Example usage::
+
+    source = PrometheusRewardDataSource()
+    avail = await source.service_availability("web")
+    detection = await source.detection_score(window_minutes=5)
+"""
+
+from __future__ import annotations
+
+import logging
+from typing import Any
+
+from pydantic import BaseModel, Field
+
+logger = logging.getLogger(__name__)
+
+# ---------------------------------------------------------------------------
+# Configuration
+# ---------------------------------------------------------------------------
+
+
+class PrometheusConfig(BaseModel):
+    """Configuration for the Prometheus reward data source."""
+
+    url: str = Field(
+        default="http://prometheus.monitoring:9090",
+        description="Base URL of the Prometheus server.",
+    )
+    timeout_s: float = Field(
+        default=5.0,
+        description="HTTP request timeout in seconds.",
+    )
+    enabled: bool = Field(
+        default=True,
+        description="Master switch.  When False, all queries return defaults.",
+    )
+    default_availability: float = Field(
+        default=1.0,
+        description="Default availability score when Prometheus is unavailable.",
+    )
+    default_detection: float = Field(
+        default=0.0,
+        description="Default detection score when Prometheus is unavailable.",
+    )
+    alert_label_selector: str = Field(
+        default='team="openrange"',
+        description="PromQL label selector for OpenRange alerts.",
+    )
+
+
+# ---------------------------------------------------------------------------
+# Data source
+# ---------------------------------------------------------------------------
+
+
+class PrometheusRewardDataSource:
+    """Query Prometheus for Blue agent reward signals.
+
+    All public methods are async and safe to call when Prometheus is
+    unavailable -- they log a warning and return a configurable default.
+    """
+
+    def __init__(
+        self,
+        prometheus_url: str = "http://prometheus.monitoring:9090",
+        *,
+        config: PrometheusConfig | None = None,
+    ) -> None:
+        if config is not None:
+            self._config = config
+        else:
+            self._config = PrometheusConfig(url=prometheus_url)
+
+    # -- public API --------------------------------------------------------
+
+    async def service_availability(self, service: str) -> float:
+        """Return a 0.0-1.0 availability score based on ``up`` metrics.
+
+        Queries ``up{job=~".*<service>.*"}`` and returns the fraction of
+        targets that are up.  Returns ``default_availability`` on error.
+        """
+        if not self._config.enabled:
+            return self._config.default_availability
+
+        promql = f'up{{job=~".*{service}.*"}}'
+        try:
+            results = await self.query(promql)
+        except Exception:
+            return self._config.default_availability
+
+        if not results:
+            return self._config.default_availability
+
+        up_count = sum(1 for r in results if self._scalar(r) == 1.0)
+        return up_count / len(results)
+
+    async def detection_score(self, window_minutes: int = 5) -> float:
+        """Return a 0.0-1.0 score based on alerts fired vs expected.
+
+        Queries ``ALERTS{<label_selector>, alertstate="firing"}`` and
+        computes a bounded score:
+            ``min(firing_count / max(expected, 1), 1.0)``
+
+        A higher score means more alerts are firing -- which rewards the
+        Blue agent for having detection coverage.
+
+        Returns ``default_detection`` on error.
+        """
+        if not self._config.enabled:
+            return self._config.default_detection
+
+        selector = self._config.alert_label_selector
+        promql = f'ALERTS{{{selector}, alertstate="firing"}}'
+        try:
+            results = await self.query(promql)
+        except Exception:
+            return self._config.default_detection
+
+        firing = len(results)
+        if firing == 0:
+            return 0.0
+
+        # Normalise: assume 4 expected alert rules as baseline from
+        # alert-rules.yaml (service-down, error-rate, unauth, suspicious).
+        expected = 4
+        return min(firing / expected, 1.0)
+
+    async def error_rate(self, namespace: str = "openrange-.*") -> float:
+        """Return the aggregate HTTP 5xx error rate across a namespace.
+
+        Returns 0.0 on error or when no data is available.
+        """
+        if not self._config.enabled:
+            return 0.0
+
+        promql = (
+            f'sum(rate(http_requests_total{{namespace=~"{namespace}",status=~"5.."}}[5m]))'
+            f" / "
+            f'sum(rate(http_requests_total{{namespace=~"{namespace}"}}[5m]))'
+        )
+        try:
+            results = await self.query(promql)
+        except Exception:
+            return 0.0
+
+        if not results:
+            return 0.0
+
+        return max(0.0, min(self._scalar(results[0]), 1.0))
+
+    async def unauthorized_request_count(
+        self,
+        namespace: str = "openrange-.*",
+        window_minutes: int = 5,
+    ) -> int:
+        """Return count of 401/403 responses in the given window."""
+        if not self._config.enabled:
+            return 0
+
+        promql = (
+            f"sum(increase(http_requests_total"
+            f'{{namespace=~"{namespace}",status=~"401|403"}}'
+            f"[{window_minutes}m]))"
+        )
+        try:
+            results = await self.query(promql)
+        except Exception:
+            return 0
+
+        if not results:
+            return 0
+
+        return int(self._scalar(results[0]))
+
+    async def pod_restart_count(
+        self,
+        namespace: str = "openrange-.*",
+        window_minutes: int = 15,
+    ) -> int:
+        """Return total pod restart count in the given window."""
+        if not self._config.enabled:
+            return 0
+
+        promql = (
+            f"sum(increase(kube_pod_container_status_restarts_total"
+            f'{{namespace=~"{namespace}"}}'
+            f"[{window_minutes}m]))"
+        )
+        try:
+            results = await self.query(promql)
+        except Exception:
+            return 0
+
+        if not results:
+            return 0
+
+        return int(self._scalar(results[0]))
+
+    async def query(self, promql: str) -> list[dict[str, Any]]:
+        """Execute a PromQL instant query and return the result vector.
+
+        Returns an empty list on any error.
+
+        Each element is a dict with ``"metric"`` and ``"value"`` keys, e.g.::
+
+            {"metric": {"__name__": "up", "job": "web"}, "value": [1710000000, "1"]}
+        """
+        try:
+            import httpx
+        except ImportError:
+            logger.warning(
+                "httpx is not installed; Prometheus queries are disabled. "
+                "Install it with: pip install httpx"
+            )
+            return []
+
+        url = f"{self._config.url.rstrip('/')}/api/v1/query"
+        try:
+            async with httpx.AsyncClient(timeout=self._config.timeout_s) as client:
+                resp = await client.get(url, params={"query": promql})
+                resp.raise_for_status()
+                body = resp.json()
+        except httpx.HTTPError as exc:
+            logger.warning("Prometheus query failed: %s", exc)
+            return []
+        except Exception as exc:
+            logger.warning("Prometheus query error: %s", exc)
+            return []
+
+        if body.get("status") != "success":
+            logger.warning(
+                "Prometheus returned non-success status: %s",
+                body.get("error", body.get("status")),
+            )
+            return []
+
+        data = body.get("data", {})
+        return data.get("result", [])
+
+    # -- helpers -----------------------------------------------------------
+
+    @staticmethod
+    def _scalar(result: dict[str, Any]) -> float:
+        """Extract the scalar float from a Prometheus instant-query result."""
+        try:
+            value = result.get("value", [None, "0"])
+            return float(value[1])
+        except (IndexError, TypeError, ValueError):
+            return 0.0

--- a/src/open_range/security_integrator.py
+++ b/src/open_range/security_integrator.py
@@ -1,0 +1,503 @@
+"""Wire security training modules into the v1 build pipeline.
+
+The ``SecurityIntegrator`` orchestrates the four training-layer modules
+(Identity Provider, Envelope Encryption, mTLS Simulation, NPC Credential
+Lifecycle) so that rendered snapshots automatically include security
+infrastructure appropriate for the world's tier.
+
+Tier mapping (configurable):
+
+- **Tier 1**: No security infrastructure (baseline application-level training).
+- **Tier 2**: Identity provider + envelope encryption.
+- **Tier 3+**: Full stack -- identity + encryption + mTLS + NPC credential
+  lifecycle with authorization policies.
+
+The integrator runs as a post-render enrichment step.  It reads the
+``WorldIR``, generates security artefacts, and writes them as JSON
+config files alongside the rendered Kind/Helm artifacts.
+
+Ported from k3s-istio-vault-platform's orchestration patterns:
+- App-of-apps component ordering (root-chart)
+- Service identity registration (ClusterSPIFFEID CRDs)
+- Post-deploy initialization (configure-vault.sh, seed-job)
+"""
+
+from __future__ import annotations
+
+import json
+import logging
+import os
+from copy import deepcopy
+from pathlib import Path
+from typing import Any
+
+from pydantic import BaseModel, Field
+
+from open_range.world_ir import WorldIR
+
+logger = logging.getLogger(__name__)
+
+
+# ---------------------------------------------------------------------------
+# Configuration
+# ---------------------------------------------------------------------------
+
+
+class SecurityTierConfig(BaseModel):
+    """Per-tier security feature flags."""
+
+    identity_provider: bool = False
+    envelope_encryption: bool = False
+    mtls: bool = False
+    npc_credential_lifecycle: bool = False
+
+
+# Default tier mapping -- tier 1 has no security infra, tier 2 adds
+# identity + encryption, tier 3+ adds mTLS + NPC credential lifecycle.
+DEFAULT_TIER_MAP: dict[int, SecurityTierConfig] = {
+    1: SecurityTierConfig(),
+    2: SecurityTierConfig(identity_provider=True, envelope_encryption=True),
+    3: SecurityTierConfig(
+        identity_provider=True,
+        envelope_encryption=True,
+        mtls=True,
+        npc_credential_lifecycle=True,
+    ),
+    4: SecurityTierConfig(
+        identity_provider=True,
+        envelope_encryption=True,
+        mtls=True,
+        npc_credential_lifecycle=True,
+    ),
+    5: SecurityTierConfig(
+        identity_provider=True,
+        envelope_encryption=True,
+        mtls=True,
+        npc_credential_lifecycle=True,
+    ),
+}
+
+
+class SecurityIntegratorConfig(BaseModel):
+    """Top-level configuration for the security integrator."""
+
+    enabled: bool = Field(
+        default=False,
+        description="Master switch. When False the integrator is a no-op.",
+    )
+    tier_map: dict[int, SecurityTierConfig] = Field(
+        default_factory=lambda: deepcopy(DEFAULT_TIER_MAP),
+    )
+    # Identity provider
+    idp_issuer: str = "https://idp.range.local"
+    idp_token_ttl_seconds: int = 300
+    idp_weaknesses: list[str] = Field(
+        default_factory=lambda: ["accept_expired", "overly_broad_scopes"],
+    )
+    # Envelope encryption
+    encryption_fraction: float = Field(
+        default=0.5,
+        description="Fraction of credential secrets to encrypt (0.0-1.0).",
+    )
+    # mTLS
+    mtls_weakness_pool: list[str] = Field(
+        default_factory=lambda: [
+            "expired_cert",
+            "weak_key_1024",
+            "no_client_verify",
+            "wrong_san",
+            "self_signed",
+        ],
+    )
+    # NPC credential lifecycle
+    npc_session_ttl_minutes: int = 30
+    npc_token_ttl_minutes: int = 5
+    npc_weaknesses: list[str] = Field(
+        default_factory=lambda: ["predictable_session_id", "token_in_url"],
+    )
+
+    @classmethod
+    def from_env(cls) -> SecurityIntegratorConfig:
+        """Build config from environment variables."""
+        enabled = os.environ.get("OPENRANGE_SECURITY_INTEGRATION", "").lower() in (
+            "1",
+            "true",
+            "yes",
+        )
+        return cls(enabled=enabled)
+
+
+# ---------------------------------------------------------------------------
+# Security context returned by the integrator
+# ---------------------------------------------------------------------------
+
+
+class SecurityContext(BaseModel):
+    """Result of a security integration pass."""
+
+    tier: int = 1
+    identity_provider: dict[str, Any] = Field(default_factory=dict)
+    encryption: dict[str, Any] = Field(default_factory=dict)
+    mtls: dict[str, Any] = Field(default_factory=dict)
+    npc_credential_lifecycle: dict[str, Any] = Field(default_factory=dict)
+    generated_files: list[str] = Field(default_factory=list)
+
+
+# ---------------------------------------------------------------------------
+# Integrator
+# ---------------------------------------------------------------------------
+
+
+class SecurityIntegrator:
+    """Orchestrate security module integration into rendered snapshots.
+
+    Usage::
+
+        integrator = SecurityIntegrator(SecurityIntegratorConfig(enabled=True))
+        ctx = integrator.integrate(world, render_dir=Path("/tmp/render"), tier=2)
+    """
+
+    def __init__(self, config: SecurityIntegratorConfig | None = None) -> None:
+        self.config = config or SecurityIntegratorConfig()
+
+    def integrate(
+        self,
+        world: WorldIR,
+        *,
+        render_dir: Path,
+        tier: int = 1,
+    ) -> SecurityContext:
+        """Enrich rendered artifacts with security infrastructure.
+
+        Writes security config and artefact files into *render_dir*.
+        Returns a ``SecurityContext`` summarising what was generated.
+        """
+        ctx = SecurityContext(tier=tier)
+
+        if not self.config.enabled:
+            return ctx
+
+        tier_cfg = self.config.tier_map.get(
+            tier,
+            self.config.tier_map.get(max(self.config.tier_map), SecurityTierConfig()),
+        )
+
+        # Build service→zone mapping from WorldIR
+        services: dict[str, str] = {}
+        host_by_id = {h.id: h for h in world.hosts}
+        for svc in world.services:
+            zone = host_by_id[svc.host].zone if svc.host in host_by_id else "default"
+            services[svc.id] = zone
+
+        domain = "range.local"
+        security_dir = render_dir / "security"
+        security_dir.mkdir(parents=True, exist_ok=True)
+
+        if tier_cfg.identity_provider:
+            self._integrate_identity(ctx, services, domain, security_dir)
+
+        if tier_cfg.envelope_encryption:
+            self._integrate_encryption(ctx, world, security_dir)
+
+        if tier_cfg.mtls:
+            self._integrate_mtls(ctx, services, domain, security_dir)
+
+        if tier_cfg.npc_credential_lifecycle:
+            self._integrate_npc_lifecycle(ctx, security_dir)
+
+        # Write the security context summary
+        ctx_path = security_dir / "security-context.json"
+        ctx_path.write_text(
+            json.dumps(ctx.model_dump(), indent=2, sort_keys=True) + "\n",
+            encoding="utf-8",
+        )
+        ctx.generated_files.append(str(ctx_path))
+
+        logger.info(
+            "SecurityIntegrator: enriched render (tier=%d, idp=%s, enc=%s, mtls=%s, npc=%s)",
+            tier,
+            tier_cfg.identity_provider,
+            tier_cfg.envelope_encryption,
+            tier_cfg.mtls,
+            tier_cfg.npc_credential_lifecycle,
+        )
+        return ctx
+
+    # ------------------------------------------------------------------
+    # Identity Provider
+    # ------------------------------------------------------------------
+
+    def _integrate_identity(
+        self,
+        ctx: SecurityContext,
+        services: dict[str, str],
+        domain: str,
+        security_dir: Path,
+    ) -> None:
+        """Generate identity provider config and tokens."""
+        try:
+            from open_range.identity_provider import (
+                IdentityProviderConfig,
+                ServiceIdentity,
+                SimulatedIdentityProvider,
+                build_spiffe_id,
+            )
+        except ImportError:
+            logger.warning(
+                "identity_provider module not available; skipping IdP integration"
+            )
+            return
+
+        identities: dict[str, ServiceIdentity] = {}
+        for svc_name, zone in services.items():
+            if svc_name in ("attacker",):
+                continue
+            spiffe_id = build_spiffe_id("range.local", zone, svc_name)
+            scopes = _default_scopes_for_service(svc_name)
+            identities[svc_name] = ServiceIdentity(
+                identity_uri=spiffe_id,
+                allowed_scopes=scopes,
+            )
+
+        idp_config = IdentityProviderConfig(
+            enabled=True,
+            issuer=self.config.idp_issuer,
+            token_ttl_seconds=self.config.idp_token_ttl_seconds,
+            weaknesses=list(self.config.idp_weaknesses),
+            service_identities=identities,
+        )
+
+        ctx.identity_provider = idp_config.model_dump()
+
+        # Generate startup script
+        idp = SimulatedIdentityProvider(idp_config)
+        startup_script = idp.generate_startup_script()
+
+        # Write IdP artifacts
+        idp_dir = security_dir / "idp"
+        idp_dir.mkdir(parents=True, exist_ok=True)
+        (idp_dir / "config.json").write_text(
+            json.dumps(idp_config.model_dump(), indent=2) + "\n", encoding="utf-8"
+        )
+        (idp_dir / "server.py").write_text(startup_script, encoding="utf-8")
+        ctx.generated_files.extend(
+            [str(idp_dir / "config.json"), str(idp_dir / "server.py")]
+        )
+
+        logger.debug(
+            "Identity provider integrated: %d service identities", len(identities)
+        )
+
+    # ------------------------------------------------------------------
+    # Envelope Encryption
+    # ------------------------------------------------------------------
+
+    def _integrate_encryption(
+        self,
+        ctx: SecurityContext,
+        world: WorldIR,
+        security_dir: Path,
+    ) -> None:
+        """Generate envelope encryption config for credential secrets."""
+        try:
+            from open_range.envelope_crypto import (
+                EncryptionConfig,
+                EnvelopeCrypto,
+            )
+        except ImportError:
+            logger.warning(
+                "envelope_crypto module not available; skipping encryption integration"
+            )
+            return
+
+        # Encrypt a subset of credential secret_refs
+        import math
+        import random as _random
+
+        credentials = list(world.credentials)
+        if not credentials:
+            return
+
+        n_encrypt = max(
+            1, math.ceil(len(credentials) * self.config.encryption_fraction)
+        )
+        indices = _random.sample(
+            list(range(len(credentials))),
+            min(n_encrypt, len(credentials)),
+        )
+
+        master_key = EnvelopeCrypto.generate_master_key()
+        import base64
+
+        master_key_b64 = base64.b64encode(master_key).decode()
+
+        encrypted_refs: list[str] = []
+        dek_metadata: dict[str, Any] = {}
+
+        prev_env = os.environ.get("OPENRANGE_MASTER_KEY")
+        os.environ["OPENRANGE_MASTER_KEY"] = master_key_b64
+        try:
+            crypto = EnvelopeCrypto(master_key)
+            for idx in indices:
+                cred = credentials[idx]
+                aad = f"openrange:range:{cred.subject}:{cred.id}"
+                bundle = crypto.encrypt(cred.secret_ref, aad=aad)
+                encrypted_refs.append(cred.id)
+                dek_metadata[cred.id] = bundle.model_dump()
+        finally:
+            if prev_env is None:
+                os.environ.pop("OPENRANGE_MASTER_KEY", None)
+            else:
+                os.environ["OPENRANGE_MASTER_KEY"] = prev_env
+
+        if encrypted_refs:
+            enc_dir = security_dir / "encryption"
+            enc_dir.mkdir(parents=True, exist_ok=True)
+
+            enc_config = EncryptionConfig(
+                enabled=True,
+                encrypted_paths=encrypted_refs,
+                master_key_source="file",
+                dek_storage_path="/etc/openrange/wrapped_dek.json",
+            )
+            ctx.encryption = enc_config.model_dump()
+
+            (enc_dir / "config.json").write_text(
+                json.dumps(enc_config.model_dump(), indent=2) + "\n", encoding="utf-8"
+            )
+            (enc_dir / "wrapped_dek.json").write_text(
+                json.dumps(dek_metadata, indent=2) + "\n", encoding="utf-8"
+            )
+            ctx.generated_files.extend(
+                [
+                    str(enc_dir / "config.json"),
+                    str(enc_dir / "wrapped_dek.json"),
+                ]
+            )
+
+        logger.debug(
+            "Encryption integrated: %d credentials encrypted", len(encrypted_refs)
+        )
+
+    # ------------------------------------------------------------------
+    # mTLS Simulation
+    # ------------------------------------------------------------------
+
+    def _integrate_mtls(
+        self,
+        ctx: SecurityContext,
+        services: dict[str, str],
+        domain: str,
+        security_dir: Path,
+    ) -> None:
+        """Generate TLS certificates for service-to-service mTLS."""
+        try:
+            from open_range.mtls_sim import MTLSConfig, MTLSSimulator
+        except ImportError:
+            logger.warning("mtls_sim module not available; skipping mTLS integration")
+            return
+
+        mtls_services = [svc for svc in services if svc not in ("attacker", "siem")]
+        if not mtls_services:
+            return
+
+        import random as _random
+
+        weaknesses: dict[str, list[str]] = {}
+        if mtls_services and self.config.mtls_weakness_pool:
+            target_svc = _random.choice(mtls_services)
+            weakness = _random.choice(self.config.mtls_weakness_pool)
+            weaknesses[target_svc] = [weakness]
+
+        mtls_config = MTLSConfig(
+            enabled=True,
+            mtls_services=mtls_services,
+            weaknesses=weaknesses,
+        )
+
+        sim = MTLSSimulator(mtls_config)
+        # Build zones dict from services mapping
+        zones_dict: dict[str, list[str]] = {}
+        for svc_name, zone in services.items():
+            zones_dict.setdefault(zone, []).append(svc_name)
+
+        bundles = sim.generate_all_certs(services, zones_dict)
+
+        mtls_dir = security_dir / "mtls"
+        mtls_dir.mkdir(parents=True, exist_ok=True)
+
+        for svc_name, bundle in bundles.items():
+            svc_dir = mtls_dir / svc_name
+            svc_dir.mkdir(parents=True, exist_ok=True)
+            for payload in sim.get_payload_files(bundle):
+                fname = payload["mountPath"].rsplit("/", 1)[-1]
+                (svc_dir / fname).write_text(payload["content"], encoding="utf-8")
+                ctx.generated_files.append(str(svc_dir / fname))
+
+        ctx.mtls = mtls_config.model_dump()
+
+        (mtls_dir / "config.json").write_text(
+            json.dumps(mtls_config.model_dump(), indent=2) + "\n", encoding="utf-8"
+        )
+        ctx.generated_files.append(str(mtls_dir / "config.json"))
+
+        logger.debug(
+            "mTLS integrated: %d services, weaknesses=%s", len(bundles), weaknesses
+        )
+
+    # ------------------------------------------------------------------
+    # NPC Credential Lifecycle
+    # ------------------------------------------------------------------
+
+    def _integrate_npc_lifecycle(
+        self,
+        ctx: SecurityContext,
+        security_dir: Path,
+    ) -> None:
+        """Configure NPC credential lifecycle."""
+        try:
+            from open_range.credential_lifecycle import CredentialLifecycleConfig
+        except ImportError:
+            logger.warning(
+                "credential_lifecycle module not available; skipping NPC lifecycle integration"
+            )
+            return
+
+        lifecycle_config = CredentialLifecycleConfig(
+            enabled=True,
+            session_ttl_minutes=self.config.npc_session_ttl_minutes,
+            token_ttl_minutes=self.config.npc_token_ttl_minutes,
+            weaknesses=list(self.config.npc_weaknesses),
+        )
+
+        ctx.npc_credential_lifecycle = lifecycle_config.model_dump()
+
+        npc_dir = security_dir / "npc"
+        npc_dir.mkdir(parents=True, exist_ok=True)
+        (npc_dir / "config.json").write_text(
+            json.dumps(lifecycle_config.model_dump(), indent=2) + "\n", encoding="utf-8"
+        )
+        ctx.generated_files.append(str(npc_dir / "config.json"))
+
+        logger.debug(
+            "NPC credential lifecycle integrated: weaknesses=%s",
+            self.config.npc_weaknesses,
+        )
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+
+def _default_scopes_for_service(service_name: str) -> list[str]:
+    """Return default authorization scopes for a service."""
+    scope_map: dict[str, list[str]] = {
+        "web": ["data:read:patients/*", "data:read:referrals/*", "api:access:portal"],
+        "db": ["data:read:*", "data:write:*"],
+        "ldap": ["auth:bind:*", "auth:search:*"],
+        "mail": ["mail:send:*", "mail:read:*"],
+        "files": ["file:read:general/*", "file:read:hr/*"],
+        "siem": ["log:read:*", "log:write:*", "alert:read:*"],
+    }
+    return scope_map.get(service_name, [f"service:access:{service_name}"])

--- a/src/open_range/session_traffic.py
+++ b/src/open_range/session_traffic.py
@@ -1,0 +1,181 @@
+"""Shell script templates for NPC traffic with session/token headers.
+
+Generates shell script snippets that run inside NPC containers to
+produce authenticated HTTP traffic (curl with Cookie and Authorization
+headers), periodic token refresh loops, and session cleanup.
+
+These scripts are deployed by the NPC manager alongside the existing
+Level 0 traffic scripts.  They are completely optional -- when the
+credential lifecycle is not enabled the NPC manager simply skips them.
+"""
+
+from __future__ import annotations
+
+import shlex
+
+from open_range.credential_lifecycle import (
+    CredentialLifecycleConfig,
+    NPCSession,
+)
+
+
+def generate_authenticated_http_traffic(
+    session: NPCSession,
+    target_url: str,
+    actions: list[str],
+) -> str:
+    """Generate a shell script snippet for authenticated HTTP traffic.
+
+    Uses curl with Cookie and Authorization headers from the session.
+    Each action becomes a separate curl call so that Blue sees distinct
+    log entries per request.
+
+    Args:
+        session: Active NPC session with tokens.
+        target_url: Base URL to target (e.g. ``http://web``).
+        actions: List of URL paths / endpoints to hit.
+
+    Returns:
+        A multi-line shell script string ready for ``sh -c`` execution.
+    """
+    lines: list[str] = [
+        "#!/bin/sh",
+        "# NPC authenticated traffic for " + shlex.quote(session.username),
+        f"SESSION_ID={shlex.quote(session.session_id)}",
+    ]
+
+    if session.bearer_token is not None:
+        lines.append(f"BEARER={shlex.quote(session.bearer_token)}")
+        auth_flags = (
+            '-H "Cookie: session=$SESSION_ID" -H "Authorization: Bearer $BEARER"'
+        )
+    else:
+        auth_flags = '-H "Cookie: session=$SESSION_ID"'
+
+    safe_ua = shlex.quote(f"Mozilla/5.0 (NPC/{session.username})")
+
+    for action in actions:
+        safe_url = shlex.quote(f"{target_url.rstrip('/')}/{action.lstrip('/')}")
+        lines.append(f"curl -s -o /dev/null -A {safe_ua} {auth_flags} {safe_url}")
+
+    return "\n".join(lines) + "\n"
+
+
+def generate_token_refresh_script(
+    config: CredentialLifecycleConfig,
+    username: str,
+) -> str:
+    """Generate a shell script that periodically refreshes tokens.
+
+    Runs as a background process in the NPC's container.  Reads the
+    current session file, requests a fresh token from a local endpoint,
+    and writes the updated token back to the session file.
+
+    In practice the NPC manager calls ``CredentialLifecycleManager.refresh_token``
+    in Python and re-deploys the session file.  This script is a
+    self-contained fallback that simulates the refresh cycle purely in
+    shell so that traffic patterns remain visible to Blue even when the
+    Python manager is not actively driving the container.
+
+    Args:
+        config: Credential lifecycle configuration.
+        username: NPC username whose tokens should be refreshed.
+
+    Returns:
+        A complete shell script string.
+    """
+    session_file = f"/tmp/sessions/{shlex.quote(username)}.json"
+    refresh_interval = (
+        config.token_ttl_minutes * 60 - config.token_refresh_margin_seconds
+    )
+    # Ensure a sane minimum interval
+    if refresh_interval < 30:
+        refresh_interval = 30
+
+    script = f"""\
+#!/bin/sh
+# Token refresh loop for NPC {shlex.quote(username)}
+# Refreshes every {refresh_interval}s (TTL {config.token_ttl_minutes}m - margin {config.token_refresh_margin_seconds}s)
+
+SESSION_FILE="{session_file}"
+REFRESH_INTERVAL={refresh_interval}
+
+mkdir -p /tmp/sessions
+
+while true; do
+    sleep "$REFRESH_INTERVAL"
+
+    if [ ! -f "$SESSION_FILE" ]; then
+        echo "[$(date -Iseconds)] session file missing for {shlex.quote(username)}, skipping refresh" >&2
+        continue
+    fi
+
+    # Read current session data
+    OLD_JTI=$(cat "$SESSION_FILE" | grep -o '"token_jti": *"[^"]*"' | head -1 | cut -d'"' -f4)
+    TIMESTAMP=$(date +%s)
+
+    # Generate a new pseudo-random JTI (best-effort without Python)
+    NEW_JTI=$(head -c 16 /dev/urandom 2>/dev/null | od -An -tx1 | tr -d ' \\n' | head -c 22)
+
+    # Update the session file with new refresh timestamp and JTI
+    if command -v jq >/dev/null 2>&1; then
+        jq --arg jti "$NEW_JTI" --argjson ts "$TIMESTAMP" \\
+            '.token_jti = $jti | .last_refresh_at = $ts' \\
+            "$SESSION_FILE" > "$SESSION_FILE.tmp" && mv "$SESSION_FILE.tmp" "$SESSION_FILE"
+    else
+        # Fallback: sed-based rewrite (less robust but works without jq)
+        sed -i "s/\\"token_jti\\": *\\"[^\\"]*\\"/\\"token_jti\\": \\"$NEW_JTI\\"/" "$SESSION_FILE" 2>/dev/null
+        sed -i "s/\\"last_refresh_at\\": *[0-9.]*/\\"last_refresh_at\\": $TIMESTAMP/" "$SESSION_FILE" 2>/dev/null
+    fi
+
+    echo "[$(date -Iseconds)] refreshed token for {shlex.quote(username)} (jti: $OLD_JTI -> $NEW_JTI)"
+done
+"""
+    return script
+
+
+def generate_session_cleanup_script() -> str:
+    """Generate a script that cleans up expired session files.
+
+    Designed to run periodically (e.g. via cron or a background loop)
+    to remove stale session files from ``/tmp/sessions/``.
+
+    Returns:
+        A complete shell script string.
+    """
+    script = """\
+#!/bin/sh
+# Clean up expired NPC session files from /tmp/sessions/
+# Run periodically to remove stale sessions.
+
+SESSION_DIR="/tmp/sessions"
+
+if [ ! -d "$SESSION_DIR" ]; then
+    exit 0
+fi
+
+NOW=$(date +%s)
+
+for f in "$SESSION_DIR"/*.json; do
+    [ -f "$f" ] || continue
+
+    # Extract session_expires_at from the JSON file
+    if command -v jq >/dev/null 2>&1; then
+        EXPIRES=$(jq -r '.session_expires_at // 0' "$f" 2>/dev/null)
+    else
+        EXPIRES=$(grep -o '"session_expires_at": *[0-9.]*' "$f" | head -1 | grep -o '[0-9.]*$')
+    fi
+
+    # Default to 0 if extraction failed
+    EXPIRES=${EXPIRES:-0}
+    # Truncate to integer for shell comparison
+    EXPIRES_INT=${EXPIRES%%.*}
+
+    if [ "$EXPIRES_INT" -gt 0 ] && [ "$EXPIRES_INT" -lt "$NOW" ]; then
+        USERNAME=$(basename "$f" .json)
+        echo "[$(date -Iseconds)] removing expired session for $USERNAME (expired at $EXPIRES)"
+        rm -f "$f"
+    fi
+done
+"""
+    return script

--- a/src/open_range/templates/identity_provider_server.py.tpl
+++ b/src/open_range/templates/identity_provider_server.py.tpl
@@ -1,0 +1,499 @@
+#!/usr/bin/env python3
+"""OpenRange Identity Provider -- in-container token endpoint server.
+
+Self-contained OAuth token service injected into range containers.
+Serves:
+  POST /oauth/token          -- client_credentials grant (issue JWT)
+  GET  /.well-known/jwks.json -- JWKS public key set
+  POST /oauth/introspect     -- RFC 7662 token introspection
+  GET  /healthz              -- health check
+
+Uses stdlib http.server + json.  PyJWT used when available; falls back
+to manual HMAC-SHA256 signing with stdlib only.
+
+Ported from k3s-istio-vault-platform oauth-svid-as pattern.
+"""
+
+from __future__ import annotations
+
+import argparse
+import base64
+import hashlib
+import hmac
+import json
+import secrets
+import sys
+import time
+import urllib.parse
+from http.server import BaseHTTPRequestHandler, HTTPServer
+from typing import Any
+
+# ---------------------------------------------------------------------------
+# Try importing PyJWT; fall back to manual JWT construction
+# ---------------------------------------------------------------------------
+
+_HAS_PYJWT = False
+try:
+    import jwt as pyjwt
+
+    _HAS_PYJWT = True
+except ImportError:
+    pyjwt = None  # type: ignore[assignment]
+
+_HAS_CRYPTOGRAPHY = False
+try:
+    from cryptography.hazmat.primitives import hashes, serialization
+    from cryptography.hazmat.primitives.asymmetric import padding, utils
+
+    _HAS_CRYPTOGRAPHY = True
+except ImportError:
+    pass
+
+
+# ---------------------------------------------------------------------------
+# Configuration (populated from CLI args at startup)
+# ---------------------------------------------------------------------------
+
+CONFIG: dict[str, Any] = {
+    "port": 8443,
+    "issuer": "https://idp.range.local",
+    "ttl": 300,
+    "weaknesses": [],
+    "private_key_pem": b"",
+    "public_key_pem": b"",
+    "jwks": {"keys": []},
+    "identities": {},
+    "hmac_secret": "range-hmac-secret",
+}
+
+
+# ---------------------------------------------------------------------------
+# Manual JWT helpers (stdlib-only fallback)
+# ---------------------------------------------------------------------------
+
+
+def _b64url_encode(data: bytes) -> str:
+    return base64.urlsafe_b64encode(data).rstrip(b"=").decode("ascii")
+
+
+def _b64url_decode(s: str) -> bytes:
+    padding_needed = 4 - len(s) % 4
+    if padding_needed != 4:
+        s += "=" * padding_needed
+    return base64.urlsafe_b64decode(s)
+
+
+def _manual_jwt_hs256(payload: dict[str, Any], secret: str, kid: str = "") -> str:
+    """Create an HS256-signed JWT using only stdlib."""
+    header = {"alg": "HS256", "typ": "JWT"}
+    if kid:
+        header["kid"] = kid
+
+    header_b64 = _b64url_encode(json.dumps(header, separators=(",", ":")).encode())
+    payload_b64 = _b64url_encode(json.dumps(payload, separators=(",", ":")).encode())
+    signing_input = f"{header_b64}.{payload_b64}"
+
+    signature = hmac.new(
+        secret.encode("utf-8"),
+        signing_input.encode("ascii"),
+        hashlib.sha256,
+    ).digest()
+    sig_b64 = _b64url_encode(signature)
+
+    return f"{signing_input}.{sig_b64}"
+
+
+def _manual_jwt_rs256(
+    payload: dict[str, Any],
+    private_key_pem: bytes,
+    kid: str = "",
+) -> str:
+    """Create an RS256-signed JWT using cryptography library."""
+    if not _HAS_CRYPTOGRAPHY:
+        raise RuntimeError("cryptography library required for RS256")
+
+    from cryptography.hazmat.primitives.asymmetric import padding as _padding
+    from cryptography.hazmat.primitives.serialization import load_pem_private_key
+
+    header = {"alg": "RS256", "typ": "JWT"}
+    if kid:
+        header["kid"] = kid
+
+    header_b64 = _b64url_encode(json.dumps(header, separators=(",", ":")).encode())
+    payload_b64 = _b64url_encode(json.dumps(payload, separators=(",", ":")).encode())
+    signing_input = f"{header_b64}.{payload_b64}".encode("ascii")
+
+    private_key = load_pem_private_key(private_key_pem, password=None)
+    signature = private_key.sign(  # type: ignore[union-attr]
+        signing_input,
+        _padding.PKCS1v15(),
+        hashes.SHA256(),
+    )
+    sig_b64 = _b64url_encode(signature)
+
+    return f"{header_b64}.{payload_b64}.{sig_b64}"
+
+
+def _decode_jwt_claims(token: str) -> dict[str, Any] | None:
+    """Decode JWT claims without verification (for introspection)."""
+    parts = token.split(".")
+    if len(parts) != 3:
+        return None
+    try:
+        payload_bytes = _b64url_decode(parts[1])
+        return json.loads(payload_bytes)
+    except Exception:
+        return None
+
+
+# ---------------------------------------------------------------------------
+# Token issuance
+# ---------------------------------------------------------------------------
+
+
+def issue_token(
+    subject: str,
+    scopes: list[str],
+    audience: str = "range-api",
+) -> str:
+    """Issue a JWT token following the oauth-svid-as pattern."""
+    now = int(time.time())
+    ttl = CONFIG["ttl"]
+    weaknesses = CONFIG["weaknesses"]
+
+    # Predictable JTI weakness.
+    if "predictable_jti" in weaknesses:
+        jti = f"token-{now}-0001"
+    else:
+        jti = _b64url_encode(secrets.token_bytes(16))
+
+    # Overly broad scopes weakness.
+    effective_scopes = list(scopes)
+    if "overly_broad_scopes" in weaknesses:
+        effective_scopes = ["*:*:*"]
+
+    claims: dict[str, Any] = {
+        "iss": CONFIG["issuer"],
+        "sub": subject,
+        "aud": audience,
+        "exp": now + ttl,
+        "iat": now,
+        "nbf": now - 30,
+        "jti": jti,
+        "scp": effective_scopes,
+        "scope": " ".join(effective_scopes),
+    }
+
+    kid = ""
+    jwks_keys = CONFIG["jwks"].get("keys", [])
+    if jwks_keys:
+        kid = jwks_keys[0].get("kid", "")
+
+    # Choose signing method.
+    if "weak_signing_hs256" in weaknesses:
+        if _HAS_PYJWT:
+            return pyjwt.encode(claims, CONFIG["hmac_secret"], algorithm="HS256",
+                                headers={"kid": kid, "typ": "JWT"})
+        return _manual_jwt_hs256(claims, CONFIG["hmac_secret"], kid=kid)
+
+    private_key = CONFIG["private_key_pem"]
+    if private_key:
+        if _HAS_PYJWT:
+            return pyjwt.encode(claims, private_key, algorithm="RS256",
+                                headers={"kid": kid, "typ": "JWT"})
+        if _HAS_CRYPTOGRAPHY:
+            return _manual_jwt_rs256(claims, private_key, kid=kid)
+
+    # Final fallback: HS256.
+    if _HAS_PYJWT:
+        return pyjwt.encode(claims, CONFIG["hmac_secret"], algorithm="HS256",
+                            headers={"kid": kid, "typ": "JWT"})
+    return _manual_jwt_hs256(claims, CONFIG["hmac_secret"], kid=kid)
+
+
+def validate_token(token: str, expected_audience: str = "range-api") -> dict[str, Any] | None:
+    """Validate a JWT and return claims or None."""
+    weaknesses = CONFIG["weaknesses"]
+
+    # Fast path with PyJWT.
+    if _HAS_PYJWT:
+        options: dict[str, bool] = {}
+        if "accept_expired" in weaknesses:
+            options["verify_exp"] = False
+        if "no_audience_check" in weaknesses:
+            options["verify_aud"] = False
+            expected_audience = ""
+
+        decode_keys: list[tuple[Any, list[str]]] = []
+        if CONFIG["private_key_pem"]:
+            decode_keys.append((CONFIG["public_key_pem"], ["RS256"]))
+        decode_keys.append((CONFIG["hmac_secret"], ["HS256"]))
+
+        for key, algs in decode_keys:
+            try:
+                kwargs: dict[str, Any] = {"algorithms": algs, "options": options}
+                if expected_audience:
+                    kwargs["audience"] = expected_audience
+                return dict(pyjwt.decode(token, key, **kwargs))
+            except Exception:
+                continue
+        return None
+
+    # Stdlib fallback: decode without cryptographic verification.
+    claims = _decode_jwt_claims(token)
+    if claims is None:
+        return None
+
+    now = int(time.time())
+    if "accept_expired" not in weaknesses:
+        exp = claims.get("exp", 0)
+        if isinstance(exp, (int, float)) and now > exp:
+            return None
+
+    if "no_audience_check" not in weaknesses and expected_audience:
+        aud = claims.get("aud", "")
+        if isinstance(aud, str) and aud != expected_audience:
+            return None
+        if isinstance(aud, list) and expected_audience not in aud:
+            return None
+
+    return claims
+
+
+# ---------------------------------------------------------------------------
+# HTTP Request Handler
+# ---------------------------------------------------------------------------
+
+
+class TokenHandler(BaseHTTPRequestHandler):
+    """Minimal HTTP handler for the identity provider endpoints."""
+
+    server_version = "OpenRange-IdP/1.0"
+
+    def log_message(self, format: str, *args: Any) -> None:
+        """Log with [openrange-idp] prefix."""
+        sys.stderr.write(
+            f"[openrange-idp] {self.address_string()} - "
+            f"{format % args}\n"
+        )
+
+    def _send_json(self, status: int, body: dict[str, Any]) -> None:
+        payload = json.dumps(body, indent=2).encode("utf-8")
+        self.send_response(status)
+        self.send_header("Content-Type", "application/json")
+        self.send_header("Content-Length", str(len(payload)))
+        self.send_header("Cache-Control", "no-store")
+        self.end_headers()
+        self.wfile.write(payload)
+
+    def _read_body(self) -> bytes:
+        length = int(self.headers.get("Content-Length", 0))
+        return self.rfile.read(length) if length > 0 else b""
+
+    # --- GET endpoints ---
+
+    def do_GET(self) -> None:
+        path = self.path.split("?")[0]
+
+        if path == "/.well-known/jwks.json":
+            self._handle_jwks()
+        elif path == "/healthz":
+            self._handle_healthz()
+        else:
+            self._send_json(404, {"error": "not_found"})
+
+    # --- POST endpoints ---
+
+    def do_POST(self) -> None:
+        path = self.path.split("?")[0]
+
+        if path == "/oauth/token":
+            self._handle_token()
+        elif path == "/oauth/introspect":
+            self._handle_introspect()
+        else:
+            self._send_json(404, {"error": "not_found"})
+
+    # --- Handlers ---
+
+    def _handle_jwks(self) -> None:
+        self._send_json(200, CONFIG["jwks"])
+
+    def _handle_healthz(self) -> None:
+        self._send_json(200, {"status": "ok"})
+
+    def _handle_token(self) -> None:
+        """Handle POST /oauth/token (client_credentials grant).
+
+        Expects form-encoded body with:
+          grant_type=client_credentials
+          scope=<space-separated scopes>
+          client_id=<service name or SPIFFE URI>
+        """
+        body = self._read_body()
+        content_type = self.headers.get("Content-Type", "")
+
+        if "application/x-www-form-urlencoded" in content_type:
+            params = dict(urllib.parse.parse_qsl(body.decode("utf-8", errors="replace")))
+        elif "application/json" in content_type:
+            try:
+                params = json.loads(body)
+            except json.JSONDecodeError:
+                self._send_json(400, {"error": "invalid_request"})
+                return
+        else:
+            # Try form-encoded as default.
+            params = dict(urllib.parse.parse_qsl(body.decode("utf-8", errors="replace")))
+
+        grant_type = params.get("grant_type", "")
+        if grant_type != "client_credentials":
+            self._send_json(400, {"error": "unsupported_grant_type"})
+            return
+
+        client_id = params.get("client_id", "")
+        requested_scopes_str = params.get("scope", "")
+        requested_scopes = requested_scopes_str.split() if requested_scopes_str else []
+        audience = params.get("audience", "range-api")
+
+        # Resolve subject from client_id.
+        identities = CONFIG.get("identities", {})
+        subject = client_id
+        allowed_scopes: list[str] | None = None
+
+        if client_id in identities:
+            identity_info = identities[client_id]
+            subject = identity_info.get("uri", client_id)
+            allowed_scopes = identity_info.get("scopes", [])
+        elif client_id.startswith("spiffe://"):
+            subject = client_id
+
+        # Scope enforcement (unless missing_scope_check weakness is active).
+        weaknesses = CONFIG["weaknesses"]
+        if allowed_scopes is not None and "missing_scope_check" not in weaknesses:
+            if not requested_scopes:
+                requested_scopes = list(allowed_scopes)
+            else:
+                allowed_set = set(allowed_scopes)
+                for scope in requested_scopes:
+                    if scope not in allowed_set:
+                        self._send_json(403, {"error": "scope_not_allowed",
+                                              "scope": scope})
+                        return
+        elif not requested_scopes:
+            requested_scopes = ["default"]
+
+        try:
+            token = issue_token(subject, requested_scopes, audience)
+        except Exception as exc:
+            self._send_json(500, {"error": "token_issue_failed",
+                                  "detail": str(exc)})
+            return
+
+        self._send_json(200, {
+            "access_token": token,
+            "token_type": "Bearer",
+            "expires_in": CONFIG["ttl"],
+            "scope": " ".join(requested_scopes),
+        })
+
+    def _handle_introspect(self) -> None:
+        """Handle POST /oauth/introspect (RFC 7662).
+
+        Expects form-encoded body with:
+          token=<JWT>
+        """
+        body = self._read_body()
+        params = dict(urllib.parse.parse_qsl(body.decode("utf-8", errors="replace")))
+        token_str = params.get("token", "")
+
+        if not token_str:
+            self._send_json(400, {"error": "invalid_request",
+                                  "detail": "missing token parameter"})
+            return
+
+        claims = validate_token(token_str)
+        if claims is None:
+            self._send_json(200, {"active": False})
+            return
+
+        response: dict[str, Any] = {
+            "active": True,
+            "sub": claims.get("sub", ""),
+            "iss": claims.get("iss", ""),
+            "aud": claims.get("aud", ""),
+            "exp": claims.get("exp", 0),
+            "iat": claims.get("iat", 0),
+            "scope": claims.get("scope", ""),
+            "jti": claims.get("jti", ""),
+            "token_type": "Bearer",
+        }
+        self._send_json(200, response)
+
+
+# ---------------------------------------------------------------------------
+# Main
+# ---------------------------------------------------------------------------
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser(description="OpenRange Identity Provider Server")
+    parser.add_argument("--port", type=int, default=8443)
+    parser.add_argument("--issuer", default="https://idp.range.local")
+    parser.add_argument("--ttl", type=int, default=300)
+    parser.add_argument("--weaknesses", default="[]")
+    parser.add_argument("--private-key-b64", default="")
+    parser.add_argument("--public-key-b64", default="")
+    parser.add_argument("--jwks", default='{"keys":[]}')
+    parser.add_argument("--identities", default="{}")
+    parser.add_argument("--hmac-secret", default="range-hmac-secret")
+    args = parser.parse_args()
+
+    CONFIG["port"] = args.port
+    CONFIG["issuer"] = args.issuer
+    CONFIG["ttl"] = args.ttl
+    CONFIG["hmac_secret"] = args.hmac_secret
+
+    try:
+        CONFIG["weaknesses"] = json.loads(args.weaknesses)
+    except json.JSONDecodeError:
+        CONFIG["weaknesses"] = []
+
+    try:
+        CONFIG["jwks"] = json.loads(args.jwks)
+    except json.JSONDecodeError:
+        CONFIG["jwks"] = {"keys": []}
+
+    try:
+        CONFIG["identities"] = json.loads(args.identities)
+    except json.JSONDecodeError:
+        CONFIG["identities"] = {}
+
+    if args.private_key_b64:
+        try:
+            CONFIG["private_key_pem"] = base64.b64decode(args.private_key_b64)
+        except Exception:
+            CONFIG["private_key_pem"] = b""
+
+    if args.public_key_b64:
+        try:
+            CONFIG["public_key_pem"] = base64.b64decode(args.public_key_b64)
+        except Exception:
+            CONFIG["public_key_pem"] = b""
+
+    server = HTTPServer(("0.0.0.0", args.port), TokenHandler)
+    print(f"[openrange-idp] Listening on 0.0.0.0:{args.port}", file=sys.stderr)
+    print(f"[openrange-idp] Issuer: {args.issuer}", file=sys.stderr)
+    print(f"[openrange-idp] TTL: {args.ttl}s", file=sys.stderr)
+    print(f"[openrange-idp] Weaknesses: {CONFIG['weaknesses']}", file=sys.stderr)
+    print(f"[openrange-idp] PyJWT available: {_HAS_PYJWT}", file=sys.stderr)
+    print(f"[openrange-idp] cryptography available: {_HAS_CRYPTOGRAPHY}", file=sys.stderr)
+
+    try:
+        server.serve_forever()
+    except KeyboardInterrupt:
+        print("\n[openrange-idp] Shutting down.", file=sys.stderr)
+        server.server_close()
+
+
+if __name__ == "__main__":
+    main()

--- a/src/open_range/vault_client.py
+++ b/src/open_range/vault_client.py
@@ -1,0 +1,623 @@
+"""Optional Vault integration for OpenRange secret management.
+
+Provides a lightweight Vault HTTP client for:
+- KV v2 secret storage (LLM API keys, range credentials)
+- Transit encryption / decryption (envelope encryption for sensitive data)
+
+When Vault is not configured the module degrades gracefully:
+- ``get_vault_client()`` returns ``None``
+- ``VaultCredentialProvider`` falls back to environment variables and defaults
+
+Configuration is driven entirely by environment variables or an explicit
+``VaultConfig`` pydantic model, keeping the integration fully optional.
+
+Adapted from the k3s-istio-vault-platform secret-runtime Vault client.
+"""
+
+from __future__ import annotations
+
+import base64
+import json
+import logging
+import os
+import ssl
+import urllib.error
+import urllib.request
+from typing import Any
+
+from pydantic import BaseModel, Field
+
+logger = logging.getLogger(__name__)
+
+# ---------------------------------------------------------------------------
+# Exceptions
+# ---------------------------------------------------------------------------
+
+
+class VaultError(Exception):
+    """Base exception for all Vault client errors."""
+
+
+class VaultUnavailableError(VaultError):
+    """Raised when Vault is not configured or unreachable."""
+
+
+class VaultAuthError(VaultError):
+    """Raised when authentication to Vault fails."""
+
+
+class VaultRequestError(VaultError):
+    """Raised when a Vault API request returns a non-success status."""
+
+    def __init__(
+        self, message: str, status_code: int = 0, errors: list[str] | None = None
+    ):
+        self.status_code = status_code
+        self.errors = errors or []
+        super().__init__(message)
+
+
+# ---------------------------------------------------------------------------
+# Configuration
+# ---------------------------------------------------------------------------
+
+
+class VaultConfig(BaseModel):
+    """Pydantic v2 configuration for the Vault client.
+
+    All fields have sensible defaults.  At minimum ``addr`` and one auth
+    method (``token`` or ``kubernetes_role``) must be supplied for the
+    client to be usable.
+    """
+
+    addr: str = Field(
+        default="",
+        description="Vault server address, e.g. http://127.0.0.1:8200",
+    )
+    token: str = Field(
+        default="",
+        description="Vault token for token-based authentication.",
+    )
+    namespace: str = Field(
+        default="",
+        description="Vault namespace (enterprise feature).",
+    )
+
+    # KV v2 settings
+    kv_mount: str = Field(
+        default="secret",
+        description="Mount path for the KV v2 secrets engine.",
+    )
+
+    # Transit settings
+    transit_mount: str = Field(
+        default="transit",
+        description="Mount path for the Transit secrets engine.",
+    )
+    transit_key: str = Field(
+        default="openrange/credentials",
+        description="Default Transit key name for encrypt/decrypt operations.",
+    )
+
+    # Kubernetes auth (optional)
+    kubernetes_role: str = Field(
+        default="",
+        description="Vault Kubernetes auth role. When set, enables K8s auth.",
+    )
+    kubernetes_mount: str = Field(
+        default="kubernetes",
+        description="Mount path for the Kubernetes auth method.",
+    )
+    kubernetes_token_path: str = Field(
+        default="/var/run/secrets/kubernetes.io/serviceaccount/token",
+        description="Path to the Kubernetes service account JWT.",
+    )
+
+    # TLS
+    ca_cert: str = Field(
+        default="",
+        description="Path to a CA certificate bundle for TLS verification.",
+    )
+    skip_verify: bool = Field(
+        default=False,
+        description="Skip TLS verification (development only).",
+    )
+
+    # Timeouts
+    timeout: float = Field(
+        default=10.0,
+        description="HTTP request timeout in seconds.",
+    )
+
+    @classmethod
+    def from_env(cls) -> VaultConfig:
+        """Build configuration from ``VAULT_*`` / ``OPENRANGE_VAULT_*`` environment variables."""
+        return cls(
+            addr=os.getenv("VAULT_ADDR", os.getenv("OPENRANGE_VAULT_ADDR", "")),
+            token=os.getenv("VAULT_TOKEN", os.getenv("OPENRANGE_VAULT_TOKEN", "")),
+            namespace=os.getenv("VAULT_NAMESPACE", ""),
+            kv_mount=os.getenv("OPENRANGE_VAULT_KV_MOUNT", "secret"),
+            transit_mount=os.getenv("OPENRANGE_VAULT_TRANSIT_MOUNT", "transit"),
+            transit_key=os.getenv(
+                "OPENRANGE_VAULT_TRANSIT_KEY", "openrange/credentials"
+            ),
+            kubernetes_role=os.getenv("OPENRANGE_VAULT_K8S_ROLE", ""),
+            kubernetes_mount=os.getenv("OPENRANGE_VAULT_K8S_MOUNT", "kubernetes"),
+            kubernetes_token_path=os.getenv(
+                "OPENRANGE_VAULT_K8S_TOKEN_PATH",
+                "/var/run/secrets/kubernetes.io/serviceaccount/token",
+            ),
+            ca_cert=os.getenv("VAULT_CACERT", ""),
+            skip_verify=os.getenv("VAULT_SKIP_VERIFY", "").lower()
+            in ("1", "true", "yes"),
+            timeout=float(os.getenv("OPENRANGE_VAULT_TIMEOUT", "10")),
+        )
+
+    @property
+    def is_configured(self) -> bool:
+        """Return True when enough information is present to attempt a connection."""
+        if not self.addr:
+            return False
+        return bool(self.token or self.kubernetes_role)
+
+
+# ---------------------------------------------------------------------------
+# Low-level Vault HTTP client
+# ---------------------------------------------------------------------------
+
+
+class VaultClient:
+    """Lightweight Vault HTTP client using only the Python standard library.
+
+    Supports token auth and Kubernetes auth.  Provides KV v2 read/write
+    and Transit encrypt/decrypt/generate-data-key operations.
+    """
+
+    def __init__(self, config: VaultConfig) -> None:
+        if not config.is_configured:
+            raise VaultUnavailableError(
+                "Vault is not configured. Set VAULT_ADDR and either VAULT_TOKEN "
+                "or OPENRANGE_VAULT_K8S_ROLE to enable Vault integration."
+            )
+        self._config = config
+        self._addr = config.addr.rstrip("/")
+        self._token: str = config.token
+        self._ssl_context = self._build_ssl_context()
+
+    # -- SSL ----------------------------------------------------------------
+
+    def _build_ssl_context(self) -> ssl.SSLContext | None:
+        if not self._addr.startswith("https"):
+            return None
+        ctx = ssl.create_default_context()
+        if self._config.ca_cert:
+            ctx.load_verify_locations(self._config.ca_cert)
+        if self._config.skip_verify:
+            ctx.check_hostname = False
+            ctx.verify_mode = ssl.CERT_NONE
+        return ctx
+
+    # -- HTTP helpers -------------------------------------------------------
+
+    def _request(
+        self,
+        method: str,
+        path: str,
+        body: dict[str, Any] | None = None,
+        token: str | None = None,
+    ) -> dict[str, Any]:
+        """Execute an HTTP request against Vault and return the parsed JSON response."""
+        url = f"{self._addr}{path}"
+        data = json.dumps(body).encode() if body else None
+
+        headers: dict[str, str] = {"Content-Type": "application/json"}
+        effective_token = token or self._token
+        if effective_token:
+            headers["X-Vault-Token"] = effective_token
+        if self._config.namespace:
+            headers["X-Vault-Namespace"] = self._config.namespace
+
+        req = urllib.request.Request(url, data=data, headers=headers, method=method)
+
+        try:
+            with urllib.request.urlopen(
+                req,
+                timeout=self._config.timeout,
+                context=self._ssl_context,
+            ) as resp:
+                resp_body = resp.read()
+                if not resp_body:
+                    return {}
+                return json.loads(resp_body)
+        except urllib.error.HTTPError as exc:
+            resp_body = exc.read().decode(errors="replace")
+            errors: list[str] = []
+            try:
+                errors = json.loads(resp_body).get("errors", [])
+            except (json.JSONDecodeError, AttributeError):
+                if resp_body:
+                    errors = [resp_body]
+            msg = f"Vault {method} {path} returned {exc.code}: {'; '.join(errors)}"
+            if exc.code in (401, 403):
+                raise VaultAuthError(msg) from exc
+            raise VaultRequestError(msg, status_code=exc.code, errors=errors) from exc
+        except urllib.error.URLError as exc:
+            raise VaultUnavailableError(
+                f"Cannot reach Vault at {self._addr}: {exc.reason}"
+            ) from exc
+
+    # -- Authentication -----------------------------------------------------
+
+    def authenticate(self) -> None:
+        """Authenticate to Vault, obtaining or refreshing the client token.
+
+        If a static token is already set, this is a no-op.
+        For Kubernetes auth, exchanges the service-account JWT for a Vault token.
+        """
+        if self._token:
+            return
+
+        if self._config.kubernetes_role:
+            self._kubernetes_login()
+            return
+
+        raise VaultAuthError(
+            "No authentication method available. Provide VAULT_TOKEN or "
+            "configure Kubernetes auth via OPENRANGE_VAULT_K8S_ROLE."
+        )
+
+    def _kubernetes_login(self) -> None:
+        """Authenticate via Kubernetes service account JWT."""
+        try:
+            with open(self._config.kubernetes_token_path) as fh:
+                jwt = fh.read().strip()
+        except OSError as exc:
+            raise VaultAuthError(
+                f"Cannot read Kubernetes SA token at "
+                f"{self._config.kubernetes_token_path}: {exc}"
+            ) from exc
+
+        mount = self._config.kubernetes_mount
+        resp = self._request(
+            "POST",
+            f"/v1/auth/{mount}/login",
+            body={"role": self._config.kubernetes_role, "jwt": jwt},
+        )
+        auth = resp.get("auth", {})
+        self._token = auth.get("client_token", "")
+        if not self._token:
+            raise VaultAuthError(
+                "Kubernetes auth succeeded but no client_token returned."
+            )
+        logger.info(
+            "Vault: authenticated via Kubernetes auth (role=%s)",
+            self._config.kubernetes_role,
+        )
+
+    @property
+    def is_authenticated(self) -> bool:
+        return bool(self._token)
+
+    # -- KV v2 operations ---------------------------------------------------
+
+    def read_secret(self, path: str) -> dict[str, Any] | None:
+        """Read a secret from KV v2.
+
+        Args:
+            path: Secret path relative to the KV mount, e.g. ``openrange/llm-api-key``.
+
+        Returns:
+            The ``data`` dict from the KV v2 response, or ``None`` if the secret
+            does not exist.
+        """
+        self.authenticate()
+        mount = self._config.kv_mount
+        try:
+            resp = self._request("GET", f"/v1/{mount}/data/{path}")
+        except VaultRequestError as exc:
+            if exc.status_code == 404:
+                return None
+            raise
+        data = resp.get("data", {})
+        return data.get("data")
+
+    def write_secret(self, path: str, data: dict[str, Any]) -> dict[str, Any]:
+        """Write a secret to KV v2.
+
+        Args:
+            path: Secret path relative to the KV mount.
+            data: Key-value pairs to store.
+
+        Returns:
+            The full Vault response metadata.
+        """
+        self.authenticate()
+        mount = self._config.kv_mount
+        resp = self._request("POST", f"/v1/{mount}/data/{path}", body={"data": data})
+        return resp.get("data", {})
+
+    # -- Transit operations -------------------------------------------------
+
+    def encrypt(self, plaintext: str | bytes, key_name: str | None = None) -> str:
+        """Encrypt data using the Transit secrets engine.
+
+        Args:
+            plaintext: Data to encrypt.  Strings are UTF-8 encoded first.
+            key_name: Transit key name.  Defaults to ``config.transit_key``.
+
+        Returns:
+            Vault ciphertext string (``vault:v1:...``).
+        """
+        self.authenticate()
+        if isinstance(plaintext, str):
+            plaintext = plaintext.encode()
+        b64 = base64.b64encode(plaintext).decode()
+        key = key_name or self._config.transit_key
+        mount = self._config.transit_mount
+        resp = self._request(
+            "POST",
+            f"/v1/{mount}/encrypt/{key}",
+            body={"plaintext": b64},
+        )
+        return resp["data"]["ciphertext"]
+
+    def decrypt(self, ciphertext: str, key_name: str | None = None) -> bytes:
+        """Decrypt data using the Transit secrets engine.
+
+        Args:
+            ciphertext: Vault ciphertext string (``vault:v1:...``).
+            key_name: Transit key name.  Defaults to ``config.transit_key``.
+
+        Returns:
+            Decrypted bytes.
+        """
+        self.authenticate()
+        key = key_name or self._config.transit_key
+        mount = self._config.transit_mount
+        resp = self._request(
+            "POST",
+            f"/v1/{mount}/decrypt/{key}",
+            body={"ciphertext": ciphertext},
+        )
+        b64 = resp["data"]["plaintext"]
+        return base64.b64decode(b64)
+
+    def generate_data_key(
+        self, key_name: str | None = None, *, bits: int = 256
+    ) -> tuple[bytes, str]:
+        """Generate a Transit data key for envelope encryption.
+
+        Returns a tuple of ``(plaintext_key_bytes, wrapped_ciphertext)`` so the
+        caller can use the plaintext key locally and persist only the wrapped
+        (encrypted) copy.
+
+        Args:
+            key_name: Transit key name.  Defaults to ``config.transit_key``.
+            bits: Key size in bits (128 or 256).
+
+        Returns:
+            ``(plaintext_key, wrapped_key)`` tuple.
+        """
+        self.authenticate()
+        key = key_name or self._config.transit_key
+        mount = self._config.transit_mount
+        resp = self._request(
+            "POST",
+            f"/v1/{mount}/datakey/plaintext/{key}",
+            body={"bits": bits},
+        )
+        plaintext_b64 = resp["data"]["plaintext"]
+        ciphertext = resp["data"]["ciphertext"]
+        return base64.b64decode(plaintext_b64), ciphertext
+
+    # -- Health check -------------------------------------------------------
+
+    def health(self) -> dict[str, Any]:
+        """Check Vault health (does not require authentication)."""
+        return self._request("GET", "/v1/sys/health")
+
+
+# ---------------------------------------------------------------------------
+# Credential provider (high-level interface)
+# ---------------------------------------------------------------------------
+
+# LLM API key names that open-range checks via environment variables.
+# See: open_range/builder/builder.py  _BUILDER_PROVIDER_ENV_VARS
+_LLM_API_KEY_ENV_VARS = (
+    "OPENAI_API_KEY",
+    "ANTHROPIC_API_KEY",
+    "GOOGLE_API_KEY",
+    "GEMINI_API_KEY",
+    "LITELLM_API_KEY",
+    "AZURE_API_KEY",
+    "AZURE_OPENAI_API_KEY",
+)
+
+# Default KV paths within the openrange Vault namespace.
+_KV_LLM_API_KEYS = "openrange/llm-api-keys"
+_KV_RANGE_CREDENTIALS = "openrange/range-credentials"
+
+
+class VaultCredentialProvider:
+    """High-level credential provider that reads secrets from Vault KV
+    and falls back to environment variables / hardcoded defaults when
+    Vault is unavailable.
+
+    Usage::
+
+        provider = VaultCredentialProvider.from_env()
+        api_key = provider.get_llm_api_key("OPENAI_API_KEY")
+        mysql_pw = provider.get_range_credential("mysql_root_password", default="r00tP@ss!")
+    """
+
+    def __init__(self, client: VaultClient | None = None) -> None:
+        self._client = client
+
+    @classmethod
+    def from_env(cls) -> VaultCredentialProvider:
+        """Create a provider using environment-based Vault configuration.
+
+        Returns a provider backed by Vault when configuration is present,
+        or an env-var-only provider when Vault is not configured.
+        """
+        client = get_vault_client()
+        return cls(client=client)
+
+    @property
+    def vault_available(self) -> bool:
+        """Return True when a functional Vault client is present."""
+        return self._client is not None
+
+    # -- LLM API Keys ------------------------------------------------------
+
+    def get_llm_api_key(self, key_name: str) -> str | None:
+        """Retrieve an LLM API key, trying Vault first then the environment.
+
+        Args:
+            key_name: Environment variable style name, e.g. ``OPENAI_API_KEY``.
+
+        Returns:
+            The API key string, or ``None`` if not found anywhere.
+        """
+        # Try Vault KV first.
+        if self._client is not None:
+            try:
+                secret = self._client.read_secret(_KV_LLM_API_KEYS)
+                if secret and key_name in secret:
+                    logger.debug("Vault: resolved LLM API key %s from KV", key_name)
+                    return str(secret[key_name])
+            except VaultError as exc:
+                logger.warning(
+                    "Vault: failed to read LLM API key %s: %s", key_name, exc
+                )
+
+        # Fallback to environment variable.
+        value = os.getenv(key_name)
+        if value:
+            logger.debug("Resolved LLM API key %s from environment", key_name)
+        return value
+
+    def get_all_llm_api_keys(self) -> dict[str, str]:
+        """Return all available LLM API keys from Vault and/or the environment.
+
+        Keys found in Vault take precedence over environment variables.
+        """
+        keys: dict[str, str] = {}
+
+        # Gather from environment first (lower priority).
+        for name in _LLM_API_KEY_ENV_VARS:
+            val = os.getenv(name)
+            if val:
+                keys[name] = val
+
+        # Overlay with Vault values (higher priority).
+        if self._client is not None:
+            try:
+                secret = self._client.read_secret(_KV_LLM_API_KEYS)
+                if secret:
+                    for name in _LLM_API_KEY_ENV_VARS:
+                        if name in secret:
+                            keys[name] = str(secret[name])
+            except VaultError as exc:
+                logger.warning("Vault: failed to read LLM API keys: %s", exc)
+
+        return keys
+
+    # -- Range Credentials (DB passwords, LDAP, etc.) ----------------------
+
+    def get_range_credential(self, name: str, *, default: str = "") -> str:
+        """Retrieve a range credential (e.g. ``mysql_root_password``).
+
+        Checks Vault KV at ``openrange/range-credentials`` first, then falls
+        back to the provided default.
+
+        Args:
+            name: Credential key, e.g. ``mysql_root_password``, ``ldap_admin_password``.
+            default: Fallback value when credential is not in Vault.
+
+        Returns:
+            The credential value.
+        """
+        if self._client is not None:
+            try:
+                secret = self._client.read_secret(_KV_RANGE_CREDENTIALS)
+                if secret and name in secret:
+                    logger.debug("Vault: resolved range credential %s from KV", name)
+                    return str(secret[name])
+            except VaultError as exc:
+                logger.warning(
+                    "Vault: failed to read range credential %s: %s", name, exc
+                )
+
+        return default
+
+    def store_range_credential(self, name: str, value: str) -> bool:
+        """Write or update a single range credential in Vault KV.
+
+        Merges with any existing credentials at the path.  Returns ``False``
+        if Vault is unavailable.
+        """
+        if self._client is None:
+            logger.debug("Vault unavailable; cannot store credential %s", name)
+            return False
+        try:
+            existing = self._client.read_secret(_KV_RANGE_CREDENTIALS) or {}
+            existing[name] = value
+            self._client.write_secret(_KV_RANGE_CREDENTIALS, existing)
+            logger.info("Vault: stored range credential %s", name)
+            return True
+        except VaultError as exc:
+            logger.warning("Vault: failed to store range credential %s: %s", name, exc)
+            return False
+
+    def get_mysql_root_password(self, *, default: str = "r00tP@ss!") -> str:
+        """Convenience method for the MySQL root password used by range containers."""
+        return self.get_range_credential("mysql_root_password", default=default)
+
+    def get_ldap_admin_password(self, *, default: str = "admin") -> str:
+        """Convenience method for the LDAP admin password used by range containers."""
+        return self.get_range_credential("ldap_admin_password", default=default)
+
+
+# ---------------------------------------------------------------------------
+# Module-level helpers
+# ---------------------------------------------------------------------------
+
+_cached_client: VaultClient | None = None
+_client_attempted: bool = False
+
+
+def get_vault_client() -> VaultClient | None:
+    """Return a configured ``VaultClient`` or ``None`` if Vault is not available.
+
+    The result is cached for the process lifetime.  Call ``reset_vault_client()``
+    to force re-initialization (useful in tests).
+    """
+    global _cached_client, _client_attempted
+    if _client_attempted:
+        return _cached_client
+
+    _client_attempted = True
+    config = VaultConfig.from_env()
+    if not config.is_configured:
+        logger.debug("Vault integration disabled (VAULT_ADDR / auth not configured)")
+        return None
+
+    try:
+        client = VaultClient(config)
+        client.authenticate()
+        _cached_client = client
+        logger.info("Vault client initialized (addr=%s)", config.addr)
+        return _cached_client
+    except VaultError as exc:
+        logger.warning(
+            "Vault client initialization failed: %s. Continuing without Vault.", exc
+        )
+        return None
+
+
+def reset_vault_client() -> None:
+    """Reset the cached Vault client.  Primarily useful for testing."""
+    global _cached_client, _client_attempted
+    _cached_client = None
+    _client_attempted = False

--- a/tests/test_credential_lifecycle.py
+++ b/tests/test_credential_lifecycle.py
@@ -1,0 +1,527 @@
+"""Tests for NPC credential lifecycle (Idea 5).
+
+Tests session creation, token refresh, credential rotation, weakness
+injection, session file generation, auth header formatting, and traffic
+log entries.  No Docker or network dependency.
+"""
+
+from __future__ import annotations
+
+import json
+import time
+
+import pytest
+
+jwt = pytest.importorskip("jwt", reason="PyJWT not installed")
+
+from open_range.credential_lifecycle import (  # noqa: E402
+    CredentialLifecycleConfig,
+    CredentialLifecycleManager,
+    NPCSession,
+    _DEFAULT_JWT_SECRET,
+    reset_predictable_counter,
+)
+from open_range.session_traffic import (  # noqa: E402
+    generate_authenticated_http_traffic,
+    generate_session_cleanup_script,
+    generate_token_refresh_script,
+)
+
+
+# ===================================================================
+# Fixtures
+# ===================================================================
+
+
+@pytest.fixture(autouse=True)
+def _reset_counter():
+    """Reset the predictable session counter between tests."""
+    reset_predictable_counter()
+    yield
+    reset_predictable_counter()
+
+
+@pytest.fixture
+def default_config() -> CredentialLifecycleConfig:
+    """Config with lifecycle enabled, no weaknesses."""
+    return CredentialLifecycleConfig(enabled=True)
+
+
+@pytest.fixture
+def manager(default_config: CredentialLifecycleConfig) -> CredentialLifecycleManager:
+    return CredentialLifecycleManager(default_config)
+
+
+@pytest.fixture
+def weak_config() -> CredentialLifecycleConfig:
+    """Config with all weaknesses enabled."""
+    return CredentialLifecycleConfig(
+        enabled=True,
+        weaknesses=[
+            "predictable_session_id",
+            "no_token_expiry",
+            "session_fixation",
+            "token_in_url",
+            "reusable_token",
+            "plaintext_session_storage",
+        ],
+    )
+
+
+@pytest.fixture
+def weak_manager(weak_config: CredentialLifecycleConfig) -> CredentialLifecycleManager:
+    return CredentialLifecycleManager(weak_config)
+
+
+# ===================================================================
+# Session creation
+# ===================================================================
+
+
+class TestSessionCreation:
+    def test_create_session_returns_npc_session(
+        self, manager: CredentialLifecycleManager
+    ):
+        session = manager.create_session("jsmith", "web")
+        assert isinstance(session, NPCSession)
+
+    def test_session_has_uuid_session_id(self, manager: CredentialLifecycleManager):
+        session = manager.create_session("jsmith", "web")
+        # UUID hex is 32 characters
+        assert len(session.session_id) == 32
+        # Should be valid hex
+        int(session.session_id, 16)
+
+    def test_session_has_bearer_token(self, manager: CredentialLifecycleManager):
+        session = manager.create_session("jsmith", "web")
+        assert session.bearer_token is not None
+        assert len(session.bearer_token) > 0
+
+    def test_bearer_token_is_valid_jwt(self, manager: CredentialLifecycleManager):
+        session = manager.create_session("jsmith", "web")
+        assert session.bearer_token is not None
+        decoded = jwt.decode(
+            session.bearer_token,
+            _DEFAULT_JWT_SECRET,
+            algorithms=["HS256"],
+            audience="open-range",
+        )
+        assert decoded["sub"] == "jsmith"
+        assert decoded["iss"] == "open-range-npc"
+        assert decoded["aud"] == "open-range"
+        assert "jti" in decoded
+        assert "exp" in decoded
+        assert "iat" in decoded
+
+    def test_session_has_token_jti(self, manager: CredentialLifecycleManager):
+        session = manager.create_session("jsmith", "web")
+        assert session.token_jti is not None
+        assert len(session.token_jti) > 0
+
+    def test_session_expiry_matches_config(self, manager: CredentialLifecycleManager):
+        before = time.time()
+        session = manager.create_session("jsmith", "web")
+        after = time.time()
+        expected_ttl = manager.config.session_ttl_minutes * 60
+        assert session.session_expires_at >= before + expected_ttl
+        assert session.session_expires_at <= after + expected_ttl
+
+    def test_token_expiry_matches_config(self, manager: CredentialLifecycleManager):
+        before = time.time()
+        session = manager.create_session("jsmith", "web")
+        after = time.time()
+        assert session.token_expires_at is not None
+        expected_ttl = manager.config.token_ttl_minutes * 60
+        assert session.token_expires_at >= before + expected_ttl
+        assert session.token_expires_at <= after + expected_ttl
+
+    def test_session_stores_username_and_host(
+        self, manager: CredentialLifecycleManager
+    ):
+        session = manager.create_session("jsmith", "web")
+        assert session.username == "jsmith"
+        assert session.host == "web"
+
+    def test_last_refresh_at_set_on_creation(self, manager: CredentialLifecycleManager):
+        before = time.time()
+        session = manager.create_session("jsmith", "web")
+        assert session.last_refresh_at is not None
+        assert session.last_refresh_at >= before
+
+    def test_no_password_stored_by_default(self, manager: CredentialLifecycleManager):
+        session = manager.create_session("jsmith", "web")
+        assert session.password is None
+
+
+# ===================================================================
+# Token refresh
+# ===================================================================
+
+
+class TestTokenRefresh:
+    def test_should_refresh_false_when_token_fresh(
+        self, manager: CredentialLifecycleManager
+    ):
+        session = manager.create_session("jsmith", "web")
+        assert not manager.should_refresh(session)
+
+    def test_should_refresh_true_near_expiry(self, manager: CredentialLifecycleManager):
+        session = manager.create_session("jsmith", "web")
+        # Simulate time passing to near token expiry
+        assert session.token_expires_at is not None
+        session.token_expires_at = time.time() + 10  # 10s left, margin is 30s
+        assert manager.should_refresh(session)
+
+    def test_should_refresh_true_past_expiry(self, manager: CredentialLifecycleManager):
+        session = manager.create_session("jsmith", "web")
+        session.token_expires_at = time.time() - 60  # already expired
+        assert manager.should_refresh(session)
+
+    def test_refresh_generates_new_token(self, manager: CredentialLifecycleManager):
+        session = manager.create_session("jsmith", "web")
+        old_token = session.bearer_token
+        old_jti = session.token_jti
+        manager.refresh_token(session)
+        assert session.bearer_token != old_token
+        assert session.token_jti != old_jti
+
+    def test_refresh_updates_last_refresh_at(self, manager: CredentialLifecycleManager):
+        session = manager.create_session("jsmith", "web")
+        before = time.time()
+        manager.refresh_token(session)
+        assert session.last_refresh_at is not None
+        assert session.last_refresh_at >= before
+
+    def test_refreshed_token_is_valid_jwt(self, manager: CredentialLifecycleManager):
+        session = manager.create_session("jsmith", "web")
+        manager.refresh_token(session)
+        assert session.bearer_token is not None
+        decoded = jwt.decode(
+            session.bearer_token,
+            _DEFAULT_JWT_SECRET,
+            algorithms=["HS256"],
+            audience="open-range",
+        )
+        assert decoded["sub"] == "jsmith"
+        assert decoded["jti"] == session.token_jti
+
+
+# ===================================================================
+# Session expiry detection
+# ===================================================================
+
+
+class TestSessionExpiry:
+    def test_session_not_expired_initially(self, manager: CredentialLifecycleManager):
+        session = manager.create_session("jsmith", "web")
+        assert session.session_expires_at > time.time()
+
+    def test_session_expired_after_ttl(self, manager: CredentialLifecycleManager):
+        session = manager.create_session("jsmith", "web")
+        # Simulate session having expired
+        session.session_expires_at = time.time() - 1
+        assert session.session_expires_at < time.time()
+
+
+# ===================================================================
+# Predictable session ID weakness
+# ===================================================================
+
+
+class TestPredictableSessionId:
+    def test_predictable_session_ids_are_sequential(
+        self, weak_manager: CredentialLifecycleManager
+    ):
+        s1 = weak_manager.create_session("user1", "web")
+        s2 = weak_manager.create_session("user2", "web")
+        # Should be sequential hex integers
+        id1 = int(s1.session_id, 16)
+        id2 = int(s2.session_id, 16)
+        assert id2 == id1 + 1
+
+    def test_predictable_ids_are_short_hex(
+        self, weak_manager: CredentialLifecycleManager
+    ):
+        session = weak_manager.create_session("user1", "web")
+        assert len(session.session_id) == 8  # 8 hex chars
+        int(session.session_id, 16)  # valid hex
+
+    def test_default_session_ids_are_not_predictable(
+        self, manager: CredentialLifecycleManager
+    ):
+        s1 = manager.create_session("user1", "web")
+        s2 = manager.create_session("user2", "web")
+        # UUIDs should differ in a non-sequential way
+        assert abs(int(s1.session_id, 16) - int(s2.session_id, 16)) > 1
+
+
+# ===================================================================
+# No token expiry weakness
+# ===================================================================
+
+
+class TestNoTokenExpiry:
+    def test_no_expiry_means_no_exp_claim(
+        self, weak_manager: CredentialLifecycleManager
+    ):
+        session = weak_manager.create_session("jsmith", "web")
+        assert session.token_expires_at is None
+        assert session.bearer_token is not None
+        decoded = jwt.decode(
+            session.bearer_token,
+            _DEFAULT_JWT_SECRET,
+            algorithms=["HS256"],
+            audience="open-range",
+            options={"verify_exp": False},
+        )
+        assert "exp" not in decoded
+
+    def test_should_refresh_always_false_without_expiry(
+        self, weak_manager: CredentialLifecycleManager
+    ):
+        session = weak_manager.create_session("jsmith", "web")
+        assert not weak_manager.should_refresh(session)
+
+
+# ===================================================================
+# Reusable token weakness
+# ===================================================================
+
+
+class TestReusableToken:
+    def test_reusable_token_keeps_jti_on_refresh(
+        self, weak_manager: CredentialLifecycleManager
+    ):
+        session = weak_manager.create_session("jsmith", "web")
+        original_jti = session.token_jti
+        weak_manager.refresh_token(session)
+        assert session.token_jti == original_jti
+
+
+# ===================================================================
+# Plaintext session storage weakness
+# ===================================================================
+
+
+class TestPlaintextSessionStorage:
+    def test_password_stored_in_session_when_weakness_active(
+        self, weak_manager: CredentialLifecycleManager
+    ):
+        weak_manager.set_initial_password("jsmith", "P@ssw0rd!")
+        session = weak_manager.create_session("jsmith", "web")
+        assert session.password == "P@ssw0rd!"
+
+    def test_session_file_contains_password(
+        self, weak_manager: CredentialLifecycleManager
+    ):
+        weak_manager.set_initial_password("jsmith", "P@ssw0rd!")
+        session = weak_manager.create_session("jsmith", "web")
+        content = weak_manager.generate_session_file(session)
+        data = json.loads(content)
+        assert data["password"] == "P@ssw0rd!"
+
+
+# ===================================================================
+# Session file generation
+# ===================================================================
+
+
+class TestSessionFileGeneration:
+    def test_session_file_is_valid_json(self, manager: CredentialLifecycleManager):
+        session = manager.create_session("jsmith", "web")
+        content = manager.generate_session_file(session)
+        data = json.loads(content)
+        assert isinstance(data, dict)
+
+    def test_session_file_contains_expected_fields(
+        self, manager: CredentialLifecycleManager
+    ):
+        session = manager.create_session("jsmith", "web")
+        content = manager.generate_session_file(session)
+        data = json.loads(content)
+        assert data["username"] == "jsmith"
+        assert data["session_id"] == session.session_id
+        assert data["token_jti"] == session.token_jti
+        assert "session_created_at" in data
+        assert "session_expires_at" in data
+        assert "last_refresh_at" in data
+        assert "bearer_token" in data
+        assert "token_expires_at" in data
+
+    def test_session_file_no_password_by_default(
+        self, manager: CredentialLifecycleManager
+    ):
+        session = manager.create_session("jsmith", "web")
+        content = manager.generate_session_file(session)
+        data = json.loads(content)
+        assert "password" not in data
+
+
+# ===================================================================
+# Auth headers format
+# ===================================================================
+
+
+class TestAuthHeaders:
+    def test_headers_contain_cookie(self, manager: CredentialLifecycleManager):
+        session = manager.create_session("jsmith", "web")
+        headers = manager.generate_auth_headers(session)
+        assert "Cookie" in headers
+        assert f"session={session.session_id}" == headers["Cookie"]
+
+    def test_headers_contain_authorization(self, manager: CredentialLifecycleManager):
+        session = manager.create_session("jsmith", "web")
+        headers = manager.generate_auth_headers(session)
+        assert "Authorization" in headers
+        assert headers["Authorization"].startswith("Bearer ")
+        assert headers["Authorization"] == f"Bearer {session.bearer_token}"
+
+    def test_headers_without_bearer_token(self, manager: CredentialLifecycleManager):
+        session = manager.create_session("jsmith", "web")
+        session.bearer_token = None
+        headers = manager.generate_auth_headers(session)
+        assert "Cookie" in headers
+        assert "Authorization" not in headers
+
+
+# ===================================================================
+# Traffic log entry with session context
+# ===================================================================
+
+
+class TestTrafficLogEntry:
+    def test_log_entry_includes_session_context(
+        self, manager: CredentialLifecycleManager
+    ):
+        session = manager.create_session("jsmith", "web")
+        entry = manager.get_traffic_log_entry(session, "browse", "http://web/index.php")
+        assert entry["session_id"] == session.session_id
+        assert entry["token_jti"] == session.token_jti
+        assert entry["username"] == "jsmith"
+        assert entry["action"] == "browse"
+        assert entry["target"] == "http://web/index.php"
+        assert "timestamp" in entry
+        assert entry["type"] == "npc_browse"
+        assert entry["label"] == "benign"
+
+    def test_token_in_url_weakness_appends_token(
+        self, weak_manager: CredentialLifecycleManager
+    ):
+        session = weak_manager.create_session("jsmith", "web")
+        entry = weak_manager.get_traffic_log_entry(
+            session, "browse", "http://web/index.php"
+        )
+        assert "token=" in entry["target"]
+        assert session.bearer_token is not None
+        assert session.bearer_token in entry["target"]
+
+    def test_token_in_url_uses_ampersand_when_query_exists(
+        self, weak_manager: CredentialLifecycleManager
+    ):
+        session = weak_manager.create_session("jsmith", "web")
+        entry = weak_manager.get_traffic_log_entry(
+            session, "browse", "http://web/search?q=test"
+        )
+        assert "&token=" in entry["target"]
+
+    def test_no_token_in_url_without_weakness(
+        self, manager: CredentialLifecycleManager
+    ):
+        session = manager.create_session("jsmith", "web")
+        entry = manager.get_traffic_log_entry(session, "browse", "http://web/index.php")
+        assert "token=" not in entry["target"]
+
+
+# ===================================================================
+# Credential rotation
+# ===================================================================
+
+
+class TestCredentialRotation:
+    def test_rotate_returns_old_and_new(self, manager: CredentialLifecycleManager):
+        manager.set_initial_password("jsmith", "OldPass1!")
+        result = manager.rotate_credentials("jsmith")
+        assert result["old_password"] == "OldPass1!"
+        assert result["new_password"] != "OldPass1!"
+        assert len(result["new_password"]) > 0
+
+    def test_rotate_updates_stored_password(self, manager: CredentialLifecycleManager):
+        manager.set_initial_password("jsmith", "OldPass1!")
+        result = manager.rotate_credentials("jsmith")
+        # Rotate again to verify the stored password was updated
+        result2 = manager.rotate_credentials("jsmith")
+        assert result2["old_password"] == result["new_password"]
+
+    def test_rotate_with_no_initial_password(self, manager: CredentialLifecycleManager):
+        result = manager.rotate_credentials("newuser")
+        assert result["old_password"] == ""
+        assert len(result["new_password"]) > 0
+
+
+# ===================================================================
+# Session traffic scripts
+# ===================================================================
+
+
+class TestSessionTrafficScripts:
+    def test_authenticated_http_traffic_script(
+        self, manager: CredentialLifecycleManager
+    ):
+        session = manager.create_session("jsmith", "web")
+        script = generate_authenticated_http_traffic(
+            session, "http://web", ["/index.php", "/dashboard"]
+        )
+        assert "#!/bin/sh" in script
+        assert "curl" in script
+        assert "Cookie: session=" in script
+        assert "Authorization: Bearer" in script
+        assert "/index.php" in script
+        assert "/dashboard" in script
+
+    def test_authenticated_traffic_without_bearer(
+        self, manager: CredentialLifecycleManager
+    ):
+        session = manager.create_session("jsmith", "web")
+        session.bearer_token = None
+        script = generate_authenticated_http_traffic(
+            session, "http://web", ["/index.php"]
+        )
+        assert "Cookie: session=" in script
+        assert "Authorization" not in script
+
+    def test_token_refresh_script(self, default_config: CredentialLifecycleConfig):
+        script = generate_token_refresh_script(default_config, "jsmith")
+        assert "#!/bin/sh" in script
+        assert "jsmith" in script
+        assert "/tmp/sessions/" in script
+        assert "sleep" in script
+        assert "token_jti" in script
+
+    def test_session_cleanup_script(self):
+        script = generate_session_cleanup_script()
+        assert "#!/bin/sh" in script
+        assert "/tmp/sessions" in script
+        assert "session_expires_at" in script
+        assert "rm -f" in script
+
+
+# ===================================================================
+# Config defaults (lifecycle disabled by default)
+# ===================================================================
+
+
+class TestConfigDefaults:
+    def test_disabled_by_default(self):
+        config = CredentialLifecycleConfig()
+        assert config.enabled is False
+
+    def test_default_ttls(self):
+        config = CredentialLifecycleConfig()
+        assert config.session_ttl_minutes == 30
+        assert config.token_ttl_minutes == 5
+        assert config.token_refresh_margin_seconds == 30
+        assert config.credential_rotation_hours == 24
+
+    def test_no_weaknesses_by_default(self):
+        config = CredentialLifecycleConfig()
+        assert config.weaknesses == []

--- a/tests/test_envelope_crypto.py
+++ b/tests/test_envelope_crypto.py
@@ -1,0 +1,467 @@
+"""Tests for the envelope encryption module (Idea 3).
+
+Covers:
+- Encrypt / decrypt roundtrip
+- Different AAD produces different ciphertext
+- Tampered ciphertext is rejected
+- zero_key clears a bytearray
+- EncryptionConfig model validation
+- Canonical AAD building
+- High-level encrypt_flag_content / decrypt_flag_content helpers
+- EncryptionEnforcementCheck validator
+"""
+
+from __future__ import annotations
+
+import base64
+import json
+import os
+
+import pytest
+
+pytest.importorskip("cryptography", reason="cryptography not installed")
+
+from open_range.envelope_crypto import (
+    EncryptedBundle,
+    EncryptionConfig,
+    EnvelopeCrypto,
+    decrypt_flag_content,
+    encrypt_flag_content,
+)
+
+
+# ---------------------------------------------------------------------------
+# Fixtures
+# ---------------------------------------------------------------------------
+
+
+@pytest.fixture
+def master_key() -> bytes:
+    """A deterministic 256-bit master key for reproducible tests."""
+    return EnvelopeCrypto.generate_master_key()
+
+
+@pytest.fixture
+def crypto(master_key: bytes) -> EnvelopeCrypto:
+    return EnvelopeCrypto(master_key)
+
+
+# ---------------------------------------------------------------------------
+# EnvelopeCrypto core
+# ---------------------------------------------------------------------------
+
+
+class TestGenerateMasterKey:
+    def test_length(self):
+        key = EnvelopeCrypto.generate_master_key()
+        assert len(key) == 32
+
+    def test_uniqueness(self):
+        k1 = EnvelopeCrypto.generate_master_key()
+        k2 = EnvelopeCrypto.generate_master_key()
+        assert k1 != k2
+
+
+class TestGenerateDEK:
+    def test_returns_dek_and_wrapped(self, crypto: EnvelopeCrypto):
+        dek, wrapped_b64 = crypto.generate_dek()
+        assert len(dek) == 32
+        assert isinstance(wrapped_b64, str)
+        # Wrapped DEK should be valid base64.
+        decoded = base64.b64decode(wrapped_b64)
+        # At least nonce (12) + ciphertext (32) + GCM tag (16) = 60 bytes
+        assert len(decoded) >= 60
+
+    def test_each_dek_is_unique(self, crypto: EnvelopeCrypto):
+        dek1, _ = crypto.generate_dek()
+        dek2, _ = crypto.generate_dek()
+        assert dek1 != dek2
+
+    def test_no_master_key_raises(self):
+        c = EnvelopeCrypto(master_key=None)
+        with pytest.raises(RuntimeError, match="no master key"):
+            c.generate_dek()
+
+
+class TestEncryptDecryptRoundtrip:
+    def test_string_roundtrip(self, crypto: EnvelopeCrypto):
+        plaintext = "FLAG{envelope_encryption_works_42}"
+        bundle = crypto.encrypt(plaintext)
+        recovered = crypto.decrypt(bundle)
+        assert recovered == plaintext.encode()
+
+    def test_bytes_roundtrip(self, crypto: EnvelopeCrypto):
+        plaintext = b"\x00\x01\x02binary\xfe\xff"
+        bundle = crypto.encrypt(plaintext)
+        recovered = crypto.decrypt(bundle)
+        assert recovered == plaintext
+
+    def test_empty_plaintext(self, crypto: EnvelopeCrypto):
+        bundle = crypto.encrypt(b"")
+        assert crypto.decrypt(bundle) == b""
+
+    def test_large_plaintext(self, crypto: EnvelopeCrypto):
+        plaintext = b"A" * 1_000_000
+        bundle = crypto.encrypt(plaintext)
+        assert crypto.decrypt(bundle) == plaintext
+
+    def test_with_aad(self, crypto: EnvelopeCrypto):
+        aad = EnvelopeCrypto.build_canonical_aad(
+            tenant="test", environment="dev", app="web", name="flag1"
+        )
+        bundle = crypto.encrypt("secret", aad=aad)
+        assert bundle.aad == aad
+        assert crypto.decrypt(bundle) == b"secret"
+
+
+class TestDifferentAAD:
+    def test_different_aad_different_ciphertext(self, crypto: EnvelopeCrypto):
+        plaintext = "same_data"
+        aad1 = EnvelopeCrypto.build_canonical_aad("t", "e", "a", "n1")
+        aad2 = EnvelopeCrypto.build_canonical_aad("t", "e", "a", "n2")
+
+        b1 = crypto.encrypt(plaintext, aad=aad1)
+        b2 = crypto.encrypt(plaintext, aad=aad2)
+
+        # Ciphertexts differ (different DEK + nonce + AAD).
+        assert b1.ciphertext != b2.ciphertext
+
+    def test_wrong_aad_fails_decrypt(self, crypto: EnvelopeCrypto):
+        aad_correct = EnvelopeCrypto.build_canonical_aad("t", "e", "a", "n1")
+        bundle = crypto.encrypt("secret", aad=aad_correct)
+
+        # Tamper with the AAD in the bundle.
+        wrong_aad = EnvelopeCrypto.build_canonical_aad("t", "e", "a", "WRONG")
+        tampered = bundle.model_copy(update={"aad": wrong_aad})
+
+        with pytest.raises(Exception):
+            crypto.decrypt(tampered)
+
+
+class TestTamperedCiphertext:
+    def test_bit_flip_detected(self, crypto: EnvelopeCrypto):
+        bundle = crypto.encrypt("FLAG{tamper_me}")
+        ct_bytes = bytearray(base64.b64decode(bundle.ciphertext))
+        # Flip a bit in the middle of the ciphertext.
+        ct_bytes[len(ct_bytes) // 2] ^= 0xFF
+        tampered = bundle.model_copy(
+            update={"ciphertext": base64.b64encode(bytes(ct_bytes)).decode()}
+        )
+        with pytest.raises(Exception):
+            crypto.decrypt(tampered)
+
+    def test_truncated_ciphertext_fails(self, crypto: EnvelopeCrypto):
+        bundle = crypto.encrypt("FLAG{truncate}")
+        ct_bytes = base64.b64decode(bundle.ciphertext)
+        truncated = bundle.model_copy(
+            update={"ciphertext": base64.b64encode(ct_bytes[:8]).decode()}
+        )
+        with pytest.raises(Exception):
+            crypto.decrypt(truncated)
+
+    def test_wrong_master_key_fails(self, master_key: bytes):
+        crypto1 = EnvelopeCrypto(master_key)
+        bundle = crypto1.encrypt("FLAG{wrong_key}")
+
+        other_key = EnvelopeCrypto.generate_master_key()
+        crypto2 = EnvelopeCrypto(other_key)
+        with pytest.raises(Exception):
+            crypto2.decrypt(bundle)
+
+
+class TestZeroKey:
+    def test_zeroes_bytearray(self):
+        key = bytearray(b"\xab" * 32)
+        EnvelopeCrypto.zero_key(key)
+        assert key == bytearray(32)
+
+    def test_empty_bytearray(self):
+        key = bytearray()
+        EnvelopeCrypto.zero_key(key)
+        assert key == bytearray()
+
+    def test_single_byte(self):
+        key = bytearray(b"\xff")
+        EnvelopeCrypto.zero_key(key)
+        assert key == bytearray(1)
+
+
+# ---------------------------------------------------------------------------
+# Canonical AAD
+# ---------------------------------------------------------------------------
+
+
+class TestCanonicalAAD:
+    def test_structure(self):
+        aad = EnvelopeCrypto.build_canonical_aad(
+            tenant="acme", environment="prod", app="web", name="db_password", version=3
+        )
+        parsed = json.loads(aad)
+        assert parsed == {
+            "app": "web",
+            "environment": "prod",
+            "name": "db_password",
+            "tenant": "acme",
+            "version": 3,
+        }
+
+    def test_default_version(self):
+        aad = EnvelopeCrypto.build_canonical_aad("t", "e", "a", "n")
+        parsed = json.loads(aad)
+        assert parsed["version"] == 1
+
+    def test_deterministic(self):
+        """Same inputs always produce the same AAD string."""
+        a1 = EnvelopeCrypto.build_canonical_aad("t", "e", "a", "n", 1)
+        a2 = EnvelopeCrypto.build_canonical_aad("t", "e", "a", "n", 1)
+        assert a1 == a2
+
+    def test_compact_json(self):
+        """AAD uses compact separators (no spaces)."""
+        aad = EnvelopeCrypto.build_canonical_aad("t", "e", "a", "n")
+        assert " " not in aad
+
+
+# ---------------------------------------------------------------------------
+# EncryptionConfig model
+# ---------------------------------------------------------------------------
+
+
+class TestEncryptionConfig:
+    def test_defaults(self):
+        cfg = EncryptionConfig()
+        assert cfg.enabled is False
+        assert cfg.encrypted_paths == []
+        assert cfg.master_key_source == "env_var"
+        assert cfg.master_key_env_var == "OPENRANGE_MASTER_KEY"
+        assert cfg.dek_storage_path == "/etc/openrange/wrapped_dek.json"
+
+    def test_custom_values(self):
+        cfg = EncryptionConfig(
+            enabled=True,
+            encrypted_paths=["files:/srv/flag.txt", "db:flags.secrets.value"],
+            master_key_source="vault_transit",
+            dek_storage_path="/tmp/dek.json",
+        )
+        assert cfg.enabled is True
+        assert len(cfg.encrypted_paths) == 2
+        assert cfg.master_key_source == "vault_transit"
+
+    def test_json_roundtrip(self):
+        cfg = EncryptionConfig(
+            enabled=True,
+            encrypted_paths=["files:/data/secret.bin"],
+        )
+        js = cfg.model_dump_json()
+        cfg2 = EncryptionConfig.model_validate_json(js)
+        assert cfg2.enabled is True
+        assert cfg2.encrypted_paths == ["files:/data/secret.bin"]
+
+
+# ---------------------------------------------------------------------------
+# EncryptedBundle model
+# ---------------------------------------------------------------------------
+
+
+class TestEncryptedBundle:
+    def test_from_dict(self):
+        b = EncryptedBundle(
+            ciphertext="AAAA",
+            nonce="BBBB",
+            wrapped_dek="CCCC",
+            aad="{}",
+            key_version=2,
+        )
+        assert b.key_version == 2
+
+    def test_json_roundtrip(self, crypto: EnvelopeCrypto):
+        bundle = crypto.encrypt("FLAG{bundle_test}")
+        js = bundle.model_dump_json()
+        bundle2 = EncryptedBundle.model_validate_json(js)
+        assert crypto.decrypt(bundle2) == b"FLAG{bundle_test}"
+
+
+# ---------------------------------------------------------------------------
+# High-level flag helpers
+# ---------------------------------------------------------------------------
+
+
+class TestFlagHelpers:
+    def test_encrypt_decrypt_flag(self, master_key: bytes):
+        b64_key = base64.b64encode(master_key).decode()
+        os.environ["OPENRANGE_MASTER_KEY"] = b64_key
+        try:
+            config = EncryptionConfig(
+                enabled=True,
+                encrypted_paths=["files:/var/flags/flag1.txt"],
+            )
+            encrypted, metadata = encrypt_flag_content(
+                "FLAG{helpers_work}",
+                config,
+                host="db",
+                path="/var/flags/flag1.txt",
+            )
+
+            # encrypted should be valid JSON.
+            parsed = json.loads(encrypted)
+            assert "ciphertext" in parsed
+            assert "wrapped_dek" in parsed
+
+            # metadata should contain routing info.
+            assert metadata["host"] == "db"
+            assert metadata["path"] == "/var/flags/flag1.txt"
+            assert "wrapped_dek" in metadata
+
+            # Roundtrip.
+            recovered = decrypt_flag_content(encrypted, metadata, master_key)
+            assert recovered == "FLAG{helpers_work}"
+        finally:
+            os.environ.pop("OPENRANGE_MASTER_KEY", None)
+
+    def test_missing_env_var_raises(self):
+        os.environ.pop("OPENRANGE_MASTER_KEY", None)
+        config = EncryptionConfig(enabled=True)
+        with pytest.raises(RuntimeError, match="not set"):
+            encrypt_flag_content("FLAG{fail}", config, host="h", path="/p")
+
+    def test_hex_encoded_master_key(self, master_key: bytes):
+        hex_key = master_key.hex()
+        os.environ["OPENRANGE_MASTER_KEY"] = hex_key
+        try:
+            config = EncryptionConfig(enabled=True)
+            encrypted, _ = encrypt_flag_content(
+                "FLAG{hex_key}", config, host="h", path="/p"
+            )
+            recovered = decrypt_flag_content(encrypted, {}, master_key)
+            assert recovered == "FLAG{hex_key}"
+        finally:
+            os.environ.pop("OPENRANGE_MASTER_KEY", None)
+
+
+# ---------------------------------------------------------------------------
+# EnvelopeCrypto edge cases
+# ---------------------------------------------------------------------------
+
+
+class TestEdgeCases:
+    def test_invalid_master_key_length(self):
+        with pytest.raises(ValueError, match="32 bytes"):
+            EnvelopeCrypto(master_key=b"tooshort")
+
+    def test_unicode_plaintext(self, crypto: EnvelopeCrypto):
+        text = "FLAG{unicode_\u2603_\U0001f512}"
+        bundle = crypto.encrypt(text)
+        assert crypto.decrypt(bundle) == text.encode()
+
+    def test_per_write_dek_isolation(self, crypto: EnvelopeCrypto):
+        """Each encrypt() call uses a different DEK (different wrapped_dek)."""
+        b1 = crypto.encrypt("same")
+        b2 = crypto.encrypt("same")
+        assert b1.wrapped_dek != b2.wrapped_dek
+        assert b1.nonce != b2.nonce
+
+
+# ---------------------------------------------------------------------------
+# Encryption enforcement check (v1 CheckFunc pattern)
+# ---------------------------------------------------------------------------
+
+
+def test_enforcement_no_config_passes(tmp_path):
+    """No security/encryption dir → vacuously passes."""
+    from open_range.encryption_enforcement import check_encryption_enforcement
+    from open_range.snapshot import KindArtifacts
+
+    artifacts = KindArtifacts(
+        render_dir=str(tmp_path),
+        chart_dir=str(tmp_path / "chart"),
+        values_path=str(tmp_path / "values.yaml"),
+        kind_config_path=str(tmp_path / "kind-config.yaml"),
+        manifest_summary_path=str(tmp_path / "summary.json"),
+    )
+    # WorldIR is not used by this check when no config exists
+    result = check_encryption_enforcement(None, artifacts)  # type: ignore[arg-type]
+    assert result.passed is True
+    assert result.advisory is True
+
+
+def test_enforcement_disabled_passes(tmp_path):
+    from open_range.encryption_enforcement import check_encryption_enforcement
+    from open_range.snapshot import KindArtifacts
+
+    enc_dir = tmp_path / "security" / "encryption"
+    enc_dir.mkdir(parents=True)
+    (enc_dir / "config.json").write_text(json.dumps({"enabled": False}))
+
+    artifacts = KindArtifacts(
+        render_dir=str(tmp_path),
+        chart_dir=str(tmp_path / "chart"),
+        values_path=str(tmp_path / "values.yaml"),
+        kind_config_path=str(tmp_path / "kind-config.yaml"),
+        manifest_summary_path=str(tmp_path / "summary.json"),
+    )
+    result = check_encryption_enforcement(None, artifacts)  # type: ignore[arg-type]
+    assert result.passed is True
+
+
+def test_enforcement_missing_dek_file(tmp_path):
+    from open_range.encryption_enforcement import check_encryption_enforcement
+    from open_range.snapshot import KindArtifacts
+
+    enc_dir = tmp_path / "security" / "encryption"
+    enc_dir.mkdir(parents=True)
+    (enc_dir / "config.json").write_text(
+        json.dumps(
+            {
+                "enabled": True,
+                "encrypted_paths": ["cred_admin"],
+            }
+        )
+    )
+    # No wrapped_dek.json → should flag it
+
+    artifacts = KindArtifacts(
+        render_dir=str(tmp_path),
+        chart_dir=str(tmp_path / "chart"),
+        values_path=str(tmp_path / "values.yaml"),
+        kind_config_path=str(tmp_path / "kind-config.yaml"),
+        manifest_summary_path=str(tmp_path / "summary.json"),
+    )
+    result = check_encryption_enforcement(None, artifacts)  # type: ignore[arg-type]
+    assert result.passed is False
+
+
+def test_enforcement_passes_with_valid_bundle(tmp_path):
+    from open_range.encryption_enforcement import check_encryption_enforcement
+    from open_range.snapshot import KindArtifacts
+
+    mk = EnvelopeCrypto.generate_master_key()
+    crypto_obj = EnvelopeCrypto(mk)
+    bundle = crypto_obj.encrypt("FLAG{test_sqli_123}", aad="test")
+
+    enc_dir = tmp_path / "security" / "encryption"
+    enc_dir.mkdir(parents=True)
+    (enc_dir / "config.json").write_text(
+        json.dumps(
+            {
+                "enabled": True,
+                "encrypted_paths": ["cred_admin"],
+            }
+        )
+    )
+    (enc_dir / "wrapped_dek.json").write_text(
+        json.dumps(
+            {
+                "cred_admin": bundle.model_dump(),
+            }
+        )
+    )
+
+    artifacts = KindArtifacts(
+        render_dir=str(tmp_path),
+        chart_dir=str(tmp_path / "chart"),
+        values_path=str(tmp_path / "values.yaml"),
+        kind_config_path=str(tmp_path / "kind-config.yaml"),
+        manifest_summary_path=str(tmp_path / "summary.json"),
+    )
+    result = check_encryption_enforcement(None, artifacts)  # type: ignore[arg-type]
+    assert result.passed is True

--- a/tests/test_mtls_sim.py
+++ b/tests/test_mtls_sim.py
@@ -1,0 +1,640 @@
+"""Tests for mTLS simulation — CA generation, service certs, weaknesses, and payloads."""
+
+from __future__ import annotations
+
+import datetime
+
+import pytest
+
+pytest.importorskip("cryptography", reason="cryptography not installed")
+
+from cryptography import x509  # noqa: E402
+from cryptography.hazmat.primitives.asymmetric import rsa  # noqa: E402
+from cryptography.hazmat.primitives.serialization import load_pem_private_key  # noqa: E402
+from cryptography.x509.oid import ExtendedKeyUsageOID  # noqa: E402
+
+from open_range.mtls_sim import (  # noqa: E402
+    SUPPORTED_WEAKNESSES,
+    CertificateBundle,
+    MTLSConfig,
+    MTLSSimulator,
+)
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+
+def _parse_cert(pem: str) -> x509.Certificate:
+    """Parse a PEM-encoded certificate string."""
+    return x509.load_pem_x509_certificate(pem.encode())
+
+
+def _parse_key(pem: str) -> rsa.RSAPrivateKey:
+    """Parse a PEM-encoded RSA private key string."""
+    return load_pem_private_key(pem.encode(), password=None)
+
+
+# ---------------------------------------------------------------------------
+# MTLSConfig model validation
+# ---------------------------------------------------------------------------
+
+
+class TestMTLSConfig:
+    def test_defaults(self):
+        config = MTLSConfig()
+        assert config.enabled is False
+        assert config.ca_common_name == "OpenRange Internal CA"
+        assert config.cert_validity_days == 365
+        assert config.key_size == 2048
+        assert config.mtls_services == []
+        assert config.weaknesses == {}
+
+    def test_custom_values(self):
+        config = MTLSConfig(
+            enabled=True,
+            ca_common_name="Test CA",
+            cert_validity_days=30,
+            key_size=4096,
+            mtls_services=["db", "ldap"],
+            weaknesses={"db": ["expired_cert"], "ldap": ["no_client_verify"]},
+        )
+        assert config.enabled is True
+        assert config.ca_common_name == "Test CA"
+        assert config.key_size == 4096
+        assert "db" in config.mtls_services
+        assert config.weaknesses["db"] == ["expired_cert"]
+
+    def test_model_serialization_roundtrip(self):
+        config = MTLSConfig(
+            enabled=True,
+            mtls_services=["web"],
+            weaknesses={"web": ["wrong_san"]},
+        )
+        data = config.model_dump()
+        restored = MTLSConfig(**data)
+        assert restored == config
+
+
+# ---------------------------------------------------------------------------
+# CA generation
+# ---------------------------------------------------------------------------
+
+
+class TestCAGeneration:
+    def test_generates_valid_x509_ca(self):
+        sim = MTLSSimulator(MTLSConfig())
+        ca_cert_pem, ca_key_pem = sim.generate_ca()
+
+        assert b"BEGIN CERTIFICATE" in ca_cert_pem
+        assert b"BEGIN RSA PRIVATE KEY" in ca_key_pem
+
+        cert = x509.load_pem_x509_certificate(ca_cert_pem)
+        assert cert.subject.get_attributes_for_oid(x509.oid.NameOID.COMMON_NAME)[
+            0
+        ].value == ("OpenRange Internal CA")
+
+    def test_ca_has_basic_constraints(self):
+        sim = MTLSSimulator(MTLSConfig())
+        ca_cert_pem, _ = sim.generate_ca()
+        cert = x509.load_pem_x509_certificate(ca_cert_pem)
+
+        bc = cert.extensions.get_extension_for_class(x509.BasicConstraints)
+        assert bc.value.ca is True
+
+    def test_ca_uses_configured_common_name(self):
+        config = MTLSConfig(ca_common_name="My Custom CA")
+        sim = MTLSSimulator(config)
+        ca_cert_pem, _ = sim.generate_ca()
+        cert = x509.load_pem_x509_certificate(ca_cert_pem)
+
+        cn = cert.subject.get_attributes_for_oid(x509.oid.NameOID.COMMON_NAME)[0].value
+        assert cn == "My Custom CA"
+
+    def test_ca_key_size_matches_config(self):
+        config = MTLSConfig(key_size=4096)
+        sim = MTLSSimulator(config)
+        _, ca_key_pem = sim.generate_ca()
+        key = load_pem_private_key(ca_key_pem, password=None)
+        assert key.key_size == 4096
+
+    def test_ca_is_cached_on_instance(self):
+        sim = MTLSSimulator(MTLSConfig())
+        ca_cert_pem_1, _ = sim.generate_ca()
+        # After first call, internal state is set.
+        assert sim._ca_cert is not None
+        assert sim._ca_key is not None
+
+
+# ---------------------------------------------------------------------------
+# Service certificate generation
+# ---------------------------------------------------------------------------
+
+
+class TestServiceCert:
+    def test_basic_service_cert_has_correct_sans(self):
+        sim = MTLSSimulator(MTLSConfig())
+        sim.generate_ca()
+
+        bundle = sim.generate_service_cert("db", zone="internal")
+
+        cert = _parse_cert(bundle.cert_pem)
+        san = cert.extensions.get_extension_for_class(x509.SubjectAlternativeName)
+        dns_names = san.value.get_values_for_type(x509.DNSName)
+
+        assert "db.internal.svc.cluster.local" in dns_names
+        assert "db.internal" in dns_names
+
+    def test_service_cert_has_server_and_client_auth(self):
+        sim = MTLSSimulator(MTLSConfig())
+        sim.generate_ca()
+        bundle = sim.generate_service_cert("web", zone="dmz")
+
+        cert = _parse_cert(bundle.cert_pem)
+        eku = cert.extensions.get_extension_for_class(x509.ExtendedKeyUsage)
+        oid_list = list(eku.value)
+
+        assert ExtendedKeyUsageOID.SERVER_AUTH in oid_list
+        assert ExtendedKeyUsageOID.CLIENT_AUTH in oid_list
+
+    def test_service_cert_common_name(self):
+        sim = MTLSSimulator(MTLSConfig())
+        sim.generate_ca()
+        bundle = sim.generate_service_cert(
+            "ldap", zone="management", domain="acme.local"
+        )
+
+        cert = _parse_cert(bundle.cert_pem)
+        cn = cert.subject.get_attributes_for_oid(x509.oid.NameOID.COMMON_NAME)[0].value
+        assert cn == "ldap.acme.local"
+
+    def test_service_cert_not_ca(self):
+        sim = MTLSSimulator(MTLSConfig())
+        sim.generate_ca()
+        bundle = sim.generate_service_cert("web", zone="dmz")
+
+        cert = _parse_cert(bundle.cert_pem)
+        bc = cert.extensions.get_extension_for_class(x509.BasicConstraints)
+        assert bc.value.ca is False
+
+    def test_service_cert_auto_generates_ca(self):
+        """If generate_ca() was not called, generate_service_cert() does it."""
+        sim = MTLSSimulator(MTLSConfig())
+        bundle = sim.generate_service_cert("db", zone="internal")
+        assert bundle.ca_cert_pem
+        assert bundle.cert_pem
+        assert sim._ca_cert is not None
+
+    def test_bundle_fields(self):
+        sim = MTLSSimulator(MTLSConfig())
+        bundle = sim.generate_service_cert("db", zone="internal")
+        assert bundle.service_name == "db"
+        assert bundle.weakness is None
+        assert isinstance(bundle, CertificateBundle)
+
+
+# ---------------------------------------------------------------------------
+# Weakness: expired_cert
+# ---------------------------------------------------------------------------
+
+
+class TestWeaknessExpiredCert:
+    def test_expired_cert_has_past_not_after(self):
+        sim = MTLSSimulator(MTLSConfig())
+        sim.generate_ca()
+        bundle = sim.generate_service_cert(
+            "db", zone="internal", weakness="expired_cert"
+        )
+
+        cert = _parse_cert(bundle.cert_pem)
+        now = datetime.datetime.now(datetime.timezone.utc)
+        assert cert.not_valid_after_utc < now
+
+    def test_expired_cert_recorded_in_bundle(self):
+        sim = MTLSSimulator(MTLSConfig())
+        bundle = sim.generate_service_cert(
+            "db", zone="internal", weakness="expired_cert"
+        )
+        assert bundle.weakness == "expired_cert"
+
+
+# ---------------------------------------------------------------------------
+# Weakness: weak_key_1024
+# ---------------------------------------------------------------------------
+
+
+class TestWeaknessWeakKey:
+    def test_weak_key_1024_produces_1024_bit_key(self):
+        sim = MTLSSimulator(MTLSConfig())
+        sim.generate_ca()
+        bundle = sim.generate_service_cert(
+            "files", zone="internal", weakness="weak_key_1024"
+        )
+
+        key = _parse_key(bundle.key_pem)
+        assert key.key_size == 1024
+
+    def test_weak_key_1024_cert_still_valid_x509(self):
+        sim = MTLSSimulator(MTLSConfig())
+        sim.generate_ca()
+        bundle = sim.generate_service_cert(
+            "files", zone="internal", weakness="weak_key_1024"
+        )
+
+        # Should still parse as valid X.509
+        cert = _parse_cert(bundle.cert_pem)
+        assert cert.subject is not None
+
+
+# ---------------------------------------------------------------------------
+# Weakness: no_client_verify
+# ---------------------------------------------------------------------------
+
+
+class TestWeaknessNoClientVerify:
+    def test_no_client_verify_omits_client_auth_eku(self):
+        sim = MTLSSimulator(MTLSConfig())
+        sim.generate_ca()
+        bundle = sim.generate_service_cert(
+            "ldap", zone="management", weakness="no_client_verify"
+        )
+
+        cert = _parse_cert(bundle.cert_pem)
+        eku = cert.extensions.get_extension_for_class(x509.ExtendedKeyUsage)
+        oid_list = list(eku.value)
+
+        assert ExtendedKeyUsageOID.SERVER_AUTH in oid_list
+        assert ExtendedKeyUsageOID.CLIENT_AUTH not in oid_list
+
+
+# ---------------------------------------------------------------------------
+# Weakness: wrong_san
+# ---------------------------------------------------------------------------
+
+
+class TestWeaknessWrongSAN:
+    def test_wrong_san_does_not_match_service_name(self):
+        sim = MTLSSimulator(MTLSConfig())
+        sim.generate_ca()
+        bundle = sim.generate_service_cert("web", zone="dmz", weakness="wrong_san")
+
+        cert = _parse_cert(bundle.cert_pem)
+        san = cert.extensions.get_extension_for_class(x509.SubjectAlternativeName)
+        dns_names = san.value.get_values_for_type(x509.DNSName)
+
+        assert "web.dmz.svc.cluster.local" not in dns_names
+        assert "web.dmz" not in dns_names
+        # Should contain the "wrong" service name instead
+        assert any("wrong-service" in n for n in dns_names)
+
+
+# ---------------------------------------------------------------------------
+# Weakness: self_signed
+# ---------------------------------------------------------------------------
+
+
+class TestWeaknessSelfSigned:
+    def test_self_signed_uses_different_ca(self):
+        sim = MTLSSimulator(MTLSConfig())
+        sim.generate_ca()
+
+        normal_bundle = sim.generate_service_cert("db", zone="internal")
+        rogue_bundle = sim.generate_service_cert(
+            "files", zone="internal", weakness="self_signed"
+        )
+
+        # The CA certs should differ
+        assert normal_bundle.ca_cert_pem != rogue_bundle.ca_cert_pem
+
+        # The rogue cert should be signed by a "Rogue CA"
+        rogue_ca = _parse_cert(rogue_bundle.ca_cert_pem)
+        cn = rogue_ca.subject.get_attributes_for_oid(x509.oid.NameOID.COMMON_NAME)[
+            0
+        ].value
+        assert cn == "Rogue CA"
+
+
+# ---------------------------------------------------------------------------
+# Weakness: unknown weakness raises
+# ---------------------------------------------------------------------------
+
+
+class TestWeaknessValidation:
+    def test_unknown_weakness_raises_value_error(self):
+        sim = MTLSSimulator(MTLSConfig())
+        sim.generate_ca()
+        with pytest.raises(ValueError, match="Unknown weakness"):
+            sim.generate_service_cert("db", zone="internal", weakness="totally_fake")
+
+    def test_supported_weaknesses_constant(self):
+        assert "expired_cert" in SUPPORTED_WEAKNESSES
+        assert "weak_key_1024" in SUPPORTED_WEAKNESSES
+        assert "no_client_verify" in SUPPORTED_WEAKNESSES
+        assert "wrong_san" in SUPPORTED_WEAKNESSES
+        assert "self_signed" in SUPPORTED_WEAKNESSES
+        assert len(SUPPORTED_WEAKNESSES) == 5
+
+
+# ---------------------------------------------------------------------------
+# Payload file generation
+# ---------------------------------------------------------------------------
+
+
+class TestPayloadFiles:
+    def test_payload_files_structure(self):
+        sim = MTLSSimulator(MTLSConfig())
+        bundle = sim.generate_service_cert("db", zone="internal")
+
+        payloads = MTLSSimulator.get_payload_files(bundle)
+
+        assert len(payloads) == 3
+        keys = {p["key"] for p in payloads}
+        assert keys == {"ca.pem", "cert.pem", "key.pem"}
+
+        mount_paths = {p["mountPath"] for p in payloads}
+        assert mount_paths == {
+            "/etc/mtls/ca.pem",
+            "/etc/mtls/cert.pem",
+            "/etc/mtls/key.pem",
+        }
+
+    def test_payload_content_matches_bundle(self):
+        sim = MTLSSimulator(MTLSConfig())
+        bundle = sim.generate_service_cert("web", zone="dmz")
+
+        payloads = MTLSSimulator.get_payload_files(bundle)
+        by_key = {p["key"]: p["content"] for p in payloads}
+
+        assert by_key["ca.pem"] == bundle.ca_cert_pem
+        assert by_key["cert.pem"] == bundle.cert_pem
+        assert by_key["key.pem"] == bundle.key_pem
+
+    def test_payload_files_contain_pem_markers(self):
+        sim = MTLSSimulator(MTLSConfig())
+        bundle = sim.generate_service_cert("db", zone="internal")
+
+        payloads = MTLSSimulator.get_payload_files(bundle)
+        by_key = {p["key"]: p["content"] for p in payloads}
+
+        assert "BEGIN CERTIFICATE" in by_key["ca.pem"]
+        assert "BEGIN CERTIFICATE" in by_key["cert.pem"]
+        assert "BEGIN RSA PRIVATE KEY" in by_key["key.pem"]
+
+
+# ---------------------------------------------------------------------------
+# TLS environment variables
+# ---------------------------------------------------------------------------
+
+
+class TestServiceTLSEnv:
+    def test_mysql_env(self):
+        env = MTLSSimulator.get_service_tls_env("db")
+        assert env["SSL_CERT"] == "/etc/mtls/cert.pem"
+        assert env["SSL_KEY"] == "/etc/mtls/key.pem"
+        assert env["SSL_CA"] == "/etc/mtls/ca.pem"
+        assert env["require_secure_transport"] == "ON"
+
+    def test_nginx_env(self):
+        env = MTLSSimulator.get_service_tls_env("web")
+        assert "ssl_certificate" in env
+        assert "ssl_certificate_key" in env
+        assert "ssl_client_certificate" in env
+
+    def test_ldap_env(self):
+        env = MTLSSimulator.get_service_tls_env("ldap")
+        assert env["LDAP_TLS_CRT_FILENAME"] == "/etc/mtls/cert.pem"
+        assert env["LDAP_TLS_VERIFY_CLIENT"] == "demand"
+
+    def test_unknown_service_returns_empty(self):
+        env = MTLSSimulator.get_service_tls_env("unknown_service")
+        assert env == {}
+
+    def test_returns_copy_not_reference(self):
+        env1 = MTLSSimulator.get_service_tls_env("db")
+        env2 = MTLSSimulator.get_service_tls_env("db")
+        assert env1 == env2
+        env1["extra"] = "mutated"
+        assert "extra" not in env2
+
+
+# ---------------------------------------------------------------------------
+# Bulk generation (generate_all_certs)
+# ---------------------------------------------------------------------------
+
+
+class TestGenerateAllCerts:
+    def test_disabled_returns_empty(self):
+        config = MTLSConfig(enabled=False, mtls_services=["db"])
+        sim = MTLSSimulator(config)
+        result = sim.generate_all_certs(
+            services={"db": {}, "web": {}},
+            zones={"internal": ["db"], "dmz": ["web"]},
+        )
+        assert result == {}
+
+    def test_generates_for_mtls_services_only(self):
+        config = MTLSConfig(enabled=True, mtls_services=["db", "ldap"])
+        sim = MTLSSimulator(config)
+        result = sim.generate_all_certs(
+            services={"db": {}, "web": {}, "ldap": {}},
+            zones={"internal": ["db"], "dmz": ["web"], "management": ["ldap"]},
+        )
+        assert "db" in result
+        assert "ldap" in result
+        assert "web" not in result
+
+    def test_applies_configured_weaknesses(self):
+        config = MTLSConfig(
+            enabled=True,
+            mtls_services=["db", "ldap"],
+            weaknesses={"db": ["expired_cert"], "ldap": ["weak_key_1024"]},
+        )
+        sim = MTLSSimulator(config)
+        result = sim.generate_all_certs(
+            services={"db": {}, "ldap": {}},
+            zones={"internal": ["db"], "management": ["ldap"]},
+        )
+        assert result["db"].weakness == "expired_cert"
+        assert result["ldap"].weakness == "weak_key_1024"
+
+    def test_no_weakness_when_not_configured(self):
+        config = MTLSConfig(enabled=True, mtls_services=["web"])
+        sim = MTLSSimulator(config)
+        result = sim.generate_all_certs(
+            services={"web": {}},
+            zones={"dmz": ["web"]},
+        )
+        assert result["web"].weakness is None
+
+    def test_all_services_when_mtls_services_empty(self):
+        config = MTLSConfig(enabled=True, mtls_services=[])
+        sim = MTLSSimulator(config)
+        result = sim.generate_all_certs(
+            services={"db": {}, "web": {}},
+            zones={"internal": ["db"], "dmz": ["web"]},
+        )
+        # When mtls_services is empty, all services in the services dict get certs.
+        assert "db" in result
+        assert "web" in result
+
+
+# ---------------------------------------------------------------------------
+# CertificateBundle model
+# ---------------------------------------------------------------------------
+
+
+class TestCertificateBundle:
+    def test_bundle_model_fields(self):
+        bundle = CertificateBundle(
+            service_name="test",
+            ca_cert_pem="ca",
+            cert_pem="cert",
+            key_pem="key",
+            weakness="expired_cert",
+        )
+        assert bundle.service_name == "test"
+        assert bundle.weakness == "expired_cert"
+
+    def test_bundle_weakness_optional(self):
+        bundle = CertificateBundle(
+            service_name="test",
+            ca_cert_pem="ca",
+            cert_pem="cert",
+            key_pem="key",
+        )
+        assert bundle.weakness is None
+
+    def test_bundle_serialization_roundtrip(self):
+        sim = MTLSSimulator(MTLSConfig())
+        bundle = sim.generate_service_cert("db", zone="internal")
+        data = bundle.model_dump()
+        restored = CertificateBundle(**data)
+        assert restored.cert_pem == bundle.cert_pem
+        assert restored.service_name == bundle.service_name
+
+
+# ---------------------------------------------------------------------------
+# Validator check (v1 CheckFunc pattern)
+# ---------------------------------------------------------------------------
+
+
+def test_mtls_enforcement_passes_when_disabled(tmp_path):
+
+    from open_range.mtls_enforcement import check_mtls_enforcement
+    from open_range.snapshot import KindArtifacts
+
+    # No security/mtls dir → passes immediately
+    artifacts = KindArtifacts(
+        render_dir=str(tmp_path),
+        chart_dir=str(tmp_path / "chart"),
+        values_path=str(tmp_path / "values.yaml"),
+        kind_config_path=str(tmp_path / "kind-config.yaml"),
+        manifest_summary_path=str(tmp_path / "summary.json"),
+    )
+    result = check_mtls_enforcement(None, artifacts)  # type: ignore[arg-type]
+    assert result.passed is True
+
+
+def test_mtls_enforcement_fails_missing_files(tmp_path):
+    import json
+
+    from open_range.mtls_enforcement import check_mtls_enforcement
+    from open_range.snapshot import KindArtifacts
+
+    mtls_dir = tmp_path / "security" / "mtls"
+    mtls_dir.mkdir(parents=True)
+    (mtls_dir / "config.json").write_text(
+        json.dumps(
+            {
+                "enabled": True,
+                "mtls_services": ["db"],
+                "weaknesses": {"db": ["expired_cert"]},
+            }
+        )
+    )
+    # No cert files for db → should fail
+
+    artifacts = KindArtifacts(
+        render_dir=str(tmp_path),
+        chart_dir=str(tmp_path / "chart"),
+        values_path=str(tmp_path / "values.yaml"),
+        kind_config_path=str(tmp_path / "kind-config.yaml"),
+        manifest_summary_path=str(tmp_path / "summary.json"),
+    )
+    result = check_mtls_enforcement(None, artifacts)  # type: ignore[arg-type]
+    assert result.passed is False
+
+
+def test_mtls_enforcement_fails_no_weaknesses(tmp_path):
+    import json
+
+    from open_range.mtls_enforcement import check_mtls_enforcement
+    from open_range.snapshot import KindArtifacts
+
+    sim = MTLSSimulator(MTLSConfig())
+    bundle = sim.generate_service_cert("db", zone="internal")
+
+    mtls_dir = tmp_path / "security" / "mtls"
+    mtls_dir.mkdir(parents=True)
+    (mtls_dir / "config.json").write_text(
+        json.dumps(
+            {
+                "enabled": True,
+                "mtls_services": ["db"],
+                "weaknesses": {},
+            }
+        )
+    )
+    svc_dir = mtls_dir / "db"
+    svc_dir.mkdir()
+    (svc_dir / "ca.pem").write_text(bundle.ca_cert_pem)
+    (svc_dir / "cert.pem").write_text(bundle.cert_pem)
+    (svc_dir / "key.pem").write_text(bundle.key_pem)
+
+    artifacts = KindArtifacts(
+        render_dir=str(tmp_path),
+        chart_dir=str(tmp_path / "chart"),
+        values_path=str(tmp_path / "values.yaml"),
+        kind_config_path=str(tmp_path / "kind-config.yaml"),
+        manifest_summary_path=str(tmp_path / "summary.json"),
+    )
+    result = check_mtls_enforcement(None, artifacts)  # type: ignore[arg-type]
+    assert result.passed is False
+
+
+def test_mtls_enforcement_passes_with_valid_config(tmp_path):
+    import json
+
+    from open_range.mtls_enforcement import check_mtls_enforcement
+    from open_range.snapshot import KindArtifacts
+
+    sim = MTLSSimulator(MTLSConfig())
+    bundle = sim.generate_service_cert("db", zone="internal", weakness="expired_cert")
+
+    mtls_dir = tmp_path / "security" / "mtls"
+    mtls_dir.mkdir(parents=True)
+    (mtls_dir / "config.json").write_text(
+        json.dumps(
+            {
+                "enabled": True,
+                "mtls_services": ["db"],
+                "weaknesses": {"db": ["expired_cert"]},
+            }
+        )
+    )
+    svc_dir = mtls_dir / "db"
+    svc_dir.mkdir()
+    (svc_dir / "ca.pem").write_text(bundle.ca_cert_pem)
+    (svc_dir / "cert.pem").write_text(bundle.cert_pem)
+    (svc_dir / "key.pem").write_text(bundle.key_pem)
+
+    artifacts = KindArtifacts(
+        render_dir=str(tmp_path),
+        chart_dir=str(tmp_path / "chart"),
+        values_path=str(tmp_path / "values.yaml"),
+        kind_config_path=str(tmp_path / "kind-config.yaml"),
+        manifest_summary_path=str(tmp_path / "summary.json"),
+    )
+    result = check_mtls_enforcement(None, artifacts)  # type: ignore[arg-type]
+    assert result.passed is True

--- a/tests/test_security_integrator.py
+++ b/tests/test_security_integrator.py
@@ -1,0 +1,271 @@
+"""Tests for the SecurityIntegrator builder integration module (v1)."""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+import pytest
+
+from open_range.security_integrator import (
+    DEFAULT_TIER_MAP,
+    SecurityIntegrator,
+    SecurityIntegratorConfig,
+    _default_scopes_for_service,
+)
+
+
+def _has_cryptography() -> bool:
+    try:
+        import cryptography  # noqa: F401
+
+        return True
+    except ImportError:
+        return False
+
+
+# ---------------------------------------------------------------------------
+# Fixtures
+# ---------------------------------------------------------------------------
+
+
+@pytest.fixture
+def sample_world():
+    """Minimal WorldIR for testing."""
+    from tests.support import manifest_payload
+
+    from open_range.pipeline import BuildPipeline
+
+    pipeline = BuildPipeline()
+    candidate = pipeline.build(manifest_payload(), Path("/tmp/test-integrator"))
+    return candidate.world
+
+
+@pytest.fixture
+def render_dir(tmp_path: Path) -> Path:
+    """Temporary render directory."""
+    return tmp_path / "render"
+
+
+# ---------------------------------------------------------------------------
+# Config tests
+# ---------------------------------------------------------------------------
+
+
+class TestSecurityIntegratorConfig:
+    def test_defaults_disabled(self):
+        config = SecurityIntegratorConfig()
+        assert config.enabled is False
+
+    def test_from_env_disabled(self, monkeypatch):
+        monkeypatch.delenv("OPENRANGE_SECURITY_INTEGRATION", raising=False)
+        config = SecurityIntegratorConfig.from_env()
+        assert config.enabled is False
+
+    def test_from_env_enabled(self, monkeypatch):
+        monkeypatch.setenv("OPENRANGE_SECURITY_INTEGRATION", "true")
+        config = SecurityIntegratorConfig.from_env()
+        assert config.enabled is True
+
+    def test_tier_map_defaults(self):
+        config = SecurityIntegratorConfig()
+        assert config.tier_map[1].identity_provider is False
+        assert config.tier_map[2].identity_provider is True
+        assert config.tier_map[2].mtls is False
+        assert config.tier_map[3].mtls is True
+        assert config.tier_map[3].npc_credential_lifecycle is True
+
+
+class TestSecurityTierConfig:
+    def test_tier1_no_features(self):
+        cfg = DEFAULT_TIER_MAP[1]
+        assert not cfg.identity_provider
+        assert not cfg.envelope_encryption
+        assert not cfg.mtls
+        assert not cfg.npc_credential_lifecycle
+
+    def test_tier3_all_features(self):
+        cfg = DEFAULT_TIER_MAP[3]
+        assert cfg.identity_provider
+        assert cfg.envelope_encryption
+        assert cfg.mtls
+        assert cfg.npc_credential_lifecycle
+
+
+# ---------------------------------------------------------------------------
+# Integrator tests -- disabled
+# ---------------------------------------------------------------------------
+
+
+class TestIntegratorDisabled:
+    def test_noop_when_disabled(self, sample_world, render_dir):
+        integrator = SecurityIntegrator(SecurityIntegratorConfig(enabled=False))
+        ctx = integrator.integrate(sample_world, render_dir=render_dir, tier=3)
+        assert ctx.tier == 3
+        assert not ctx.identity_provider
+        assert not ctx.encryption
+        assert not ctx.generated_files
+
+    def test_noop_for_tier1(self, sample_world, render_dir):
+        integrator = SecurityIntegrator(SecurityIntegratorConfig(enabled=True))
+        ctx = integrator.integrate(sample_world, render_dir=render_dir, tier=1)
+        # Tier 1 has no security features
+        assert not ctx.identity_provider
+        assert not ctx.encryption
+
+
+# ---------------------------------------------------------------------------
+# Identity provider integration
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.skipif(
+    not _has_cryptography(), reason="cryptography library not available"
+)
+class TestIdentityIntegration:
+    def test_identity_provider_added_for_tier2(self, sample_world, render_dir):
+        integrator = SecurityIntegrator(SecurityIntegratorConfig(enabled=True))
+        ctx = integrator.integrate(sample_world, render_dir=render_dir, tier=2)
+
+        assert ctx.identity_provider
+        assert ctx.identity_provider["enabled"] is True
+        assert "service_identities" in ctx.identity_provider
+
+    def test_idp_config_written(self, sample_world, render_dir):
+        integrator = SecurityIntegrator(SecurityIntegratorConfig(enabled=True))
+        integrator.integrate(sample_world, render_dir=render_dir, tier=2)
+
+        idp_config_path = render_dir / "security" / "idp" / "config.json"
+        assert idp_config_path.exists()
+        data = json.loads(idp_config_path.read_text())
+        assert data["enabled"] is True
+
+    def test_spiffe_ids_in_identities(self, sample_world, render_dir):
+        integrator = SecurityIntegrator(SecurityIntegratorConfig(enabled=True))
+        ctx = integrator.integrate(sample_world, render_dir=render_dir, tier=2)
+
+        for svc_name, identity in ctx.identity_provider["service_identities"].items():
+            assert identity["identity_uri"].startswith("spiffe://range.local/")
+
+
+# ---------------------------------------------------------------------------
+# Encryption integration
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.skipif(
+    not _has_cryptography(), reason="cryptography library not available"
+)
+class TestEncryptionIntegration:
+    def test_encryption_for_tier2(self, sample_world, render_dir):
+        integrator = SecurityIntegrator(
+            SecurityIntegratorConfig(enabled=True, encryption_fraction=1.0)
+        )
+        ctx = integrator.integrate(sample_world, render_dir=render_dir, tier=2)
+
+        assert ctx.encryption
+        assert ctx.encryption["enabled"] is True
+
+    def test_wrapped_dek_written(self, sample_world, render_dir):
+        integrator = SecurityIntegrator(
+            SecurityIntegratorConfig(enabled=True, encryption_fraction=1.0)
+        )
+        integrator.integrate(sample_world, render_dir=render_dir, tier=2)
+
+        dek_path = render_dir / "security" / "encryption" / "wrapped_dek.json"
+        assert dek_path.exists()
+        data = json.loads(dek_path.read_text())
+        assert isinstance(data, dict)
+        assert len(data) >= 1
+
+
+# ---------------------------------------------------------------------------
+# mTLS integration
+# ---------------------------------------------------------------------------
+
+
+class TestMTLSIntegration:
+    @pytest.mark.skipif(
+        not _has_cryptography(), reason="cryptography library not available"
+    )
+    def test_mtls_certs_generated_for_tier3(self, sample_world, render_dir):
+        integrator = SecurityIntegrator(SecurityIntegratorConfig(enabled=True))
+        ctx = integrator.integrate(sample_world, render_dir=render_dir, tier=3)
+
+        assert ctx.mtls
+        assert ctx.mtls["enabled"] is True
+        # Cert files should exist
+        mtls_dir = render_dir / "security" / "mtls"
+        assert mtls_dir.exists()
+        cert_files = list(mtls_dir.rglob("*.pem"))
+        assert len(cert_files) >= 3
+
+    @pytest.mark.skipif(
+        not _has_cryptography(), reason="cryptography library not available"
+    )
+    def test_mtls_not_for_tier2(self, sample_world, render_dir):
+        integrator = SecurityIntegrator(SecurityIntegratorConfig(enabled=True))
+        ctx = integrator.integrate(sample_world, render_dir=render_dir, tier=2)
+        assert not ctx.mtls
+
+
+# ---------------------------------------------------------------------------
+# NPC credential lifecycle integration
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.skipif(
+    not _has_cryptography(), reason="cryptography library not available"
+)
+class TestNPCLifecycleIntegration:
+    def test_npc_lifecycle_configured_for_tier3(self, sample_world, render_dir):
+        integrator = SecurityIntegrator(SecurityIntegratorConfig(enabled=True))
+        ctx = integrator.integrate(sample_world, render_dir=render_dir, tier=3)
+
+        assert ctx.npc_credential_lifecycle
+        assert ctx.npc_credential_lifecycle["enabled"] is True
+        assert ctx.npc_credential_lifecycle["token_ttl_minutes"] == 5
+
+    def test_npc_lifecycle_not_for_tier2(self, sample_world, render_dir):
+        integrator = SecurityIntegrator(SecurityIntegratorConfig(enabled=True))
+        ctx = integrator.integrate(sample_world, render_dir=render_dir, tier=2)
+        assert not ctx.npc_credential_lifecycle
+
+
+# ---------------------------------------------------------------------------
+# Helper tests
+# ---------------------------------------------------------------------------
+
+
+class TestHelpers:
+    def test_default_scopes_for_known_service(self):
+        scopes = _default_scopes_for_service("web")
+        assert any("patients" in s for s in scopes)
+
+    def test_default_scopes_for_unknown_service(self):
+        scopes = _default_scopes_for_service("custom_svc")
+        assert scopes == ["service:access:custom_svc"]
+
+
+# ---------------------------------------------------------------------------
+# Full integration test
+# ---------------------------------------------------------------------------
+
+
+class TestFullIntegration:
+    @pytest.mark.skipif(
+        not _has_cryptography(), reason="cryptography library not available"
+    )
+    def test_tier3_full_stack(self, sample_world, render_dir):
+        """Tier 3 should integrate all security modules."""
+        integrator = SecurityIntegrator(SecurityIntegratorConfig(enabled=True))
+        ctx = integrator.integrate(sample_world, render_dir=render_dir, tier=3)
+
+        assert ctx.identity_provider
+        assert ctx.encryption
+        assert ctx.mtls
+        assert ctx.npc_credential_lifecycle
+
+        # Security context file should exist
+        ctx_path = render_dir / "security" / "security-context.json"
+        assert ctx_path.exists()


### PR DESCRIPTION
## Summary

Two commits contributing production infrastructure and enterprise security training capabilities from [k3s-istio-vault-platform](https://github.com/antojoseph/k3s-istio-vault-platform) to open-range.

### Commit 1: Infrastructure Layer (5 components)

- **k3d multi-node cluster bootstrap** — replaces single-node Kind with configurable multi-agent k3d clusters
- **Vault secrets management** — optional Transit encryption and KV v2 for credentials
- **Argo CD GitOps pipeline** — automated snapshot-to-live-range deployment
- **Prometheus observability** — kube-prometheus-stack with Blue agent reward signals
- **Cilium + Hubble networking** — eBPF-enforced zone segmentation with network flow visibility

### Commit 2: Training Layer (4 components)

- **Simulated Identity Provider** (`identity_provider.py`) — OAuth token service with RS256 JWTs, SPIFFE-style service identities, JWKS endpoint, and 6 plantable weaknesses (jwt_forgery, token_theft, scope_escalation)
- **Envelope Encryption** (`envelope_crypto.py`) — AES-256-GCM envelope encryption for flags at rest with per-write DEKs, canonical AAD, and memory zeroing. Red must find the DEK to decrypt.
- **mTLS Simulation** (`mtls_sim.py`) — Self-signed CA and per-service TLS certificates with 5 plantable weaknesses (expired_cert, weak_key, no_client_verify, wrong_san, self_signed)
- **NPC Credential Lifecycle** (`credential_lifecycle.py`) — Session tokens, bearer JWTs, auto-refresh, and credential rotation for NPCs. Creates token theft/replay attack surfaces.

All components are **fully optional** with `enabled=False` defaults. No existing behavior is changed.

### CLI additions (Commit 1)

- `--cluster-type k3d` flag on `render` and `deploy` commands
- `openrange platform` command group: `k3d-up`, `k3d-down`, `vault`, `argocd`, `cilium`, `monitoring`, `all`

### New validators (Commit 2)

- `IdentityEnforcementCheck` — validates identity provider config and token issuance
- `EncryptionEnforcementCheck` — validates encrypted paths contain ciphertext, not plaintext
- `MTLSEnforcementCheck` — validates mTLS cert deployment and weakness planting

### Files summary

| Area | Files | Lines |
|------|-------|-------|
| Infrastructure (deploy scripts, Python modules) | 29 files | ~5,200 |
| Training (security modules, validators, tests) | 12 files | ~4,650 |
| **Total** | **41 files** | **~9,850** |

## Test plan

- [x] All new Python modules pass syntax validation and import cleanly
- [x] 937 existing + new tests pass (74 skipped, 0 failures)
- [x] Pre-existing test failure (`test_web_interface_does_not_double_mount_web`) confirmed on main
- [ ] `openrange render -s snapshot.json --cluster-type k3d` produces valid k3d config
- [ ] `openrange platform all` sets up full infrastructure stack
- [ ] Identity provider issues valid RS256 JWTs with configurable weaknesses
- [ ] Envelope encryption round-trips: encrypt → decrypt recovers plaintext
- [ ] mTLS simulator generates valid X.509 certs with weakness injection
- [ ] NPC credential lifecycle creates/refreshes session tokens