### PR TITLE
docs: improve README and docs usability

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 <div align="center">
   <h1>OpenRange</h1>
-  <img src="assets/evolving_gym_hero.png" alt="OpenRange: multi-agent cybersecurity range" width="800" />
+  <img src="assets/evolving_gym_hero.png" alt="OpenRange: validator-admitted enterprise cyber range" width="800" />
   <br />
   <br />
   <img src="https://img.shields.io/badge/Package-open--range-blue" alt="Package: open-range" />
@@ -8,22 +8,39 @@
   <img src="https://img.shields.io/badge/License-Apache_2.0-blue.svg" alt="License: Apache 2.0" />
 </div>
 
-OpenRange is a manifest-first red/blue/green cyber range packaged as an installable Python control plane. It turns strict manifests into admitted snapshots, stores immutable builds, and exposes a small runtime/CLI for demos, evaluation, and trace generation.
+OpenRange is a manifest-first cyber range for training red and blue agents in
+bounded enterprise worlds. It compiles a business manifest into a world,
+validates that world with private reference traces and deterministic probes,
+freezes it as an immutable snapshot, and runs episodes with red, blue, and
+green-user dynamics.
 
-This branch is a package-first rewrite of the project. It keeps the core idea from the older README, varied adversarial cyber environments with grounded validation, but the public surface here is the Python package under [`src/open_range`](src/open_range), not the legacy OpenEnv server/client stack from `main`.
+This branch exposes OpenRange as an installable Python package and CLI. It is
+not the legacy OpenEnv server/client stack from `main`.
 
 ## Why OpenRange
 
-Static CTFs are useful, but they are a weak training target for general cyber agents: they are hand-authored, fixed, and easy to overfit. OpenRange is aimed at the opposite shape: bounded families of enterprise-like environments that can be compiled, admitted, mutated, replayed, and used to generate branch-native traces.
+Static cyber tasks are useful for evaluation, but they are a weak training
+target. They are fixed, narrow, easy to memorize, and usually offense-only.
+OpenRange is aimed at the opposite shape: families of admitted enterprise-like
+worlds that can be replayed, mutated between snapshots, and used for runtime and
+training-data generation.
 
-The supported surface on this branch is:
+|  | Static cyber task | OpenRange |
+|--|-------------------|-----------|
+| **World** | One fixed puzzle | Admitted enterprise world from a manifest |
+| **Reset** | Same challenge again | Load a stored snapshot from a pool |
+| **Validation** | Often manual or benchmark-specific | Deterministic admission with private references |
+| **Roles** | Usually red only | Red, blue, and green in one runtime |
+| **Training data** | External transcripts or logs | Branch-native traces from admitted snapshots |
 
-- strict public manifests for the bounded `enterprise_saas_v1` family
-- a Python build/admit/store/runtime API under [`src/open_range`](src/open_range)
-- a small CLI exposed as `openrange`
-- packaged chart assets, schemas, docs, and manifest examples
+## What You Can Do
 
-## Start here
+- Build and admit worlds from strict manifests
+- Run red/blue/green episodes over immutable snapshots
+- Sample snapshots from train and eval pools
+- Generate branch-native trace datasets for training
+- Use offline admission for local iteration or live validation when running with
+  Kind
 
 - [Architecture](docs/architecture.md)
 - [Training Data Spec](docs/training-data-spec.md)
@@ -31,209 +48,75 @@ The supported surface on this branch is:
 - [Effect Grounding](docs/effect-grounding.md)
 - [Weakness Lifecycle](docs/weakness-lifecycle.md)
 - [NPC Profiles](docs/npc-profiles.md)
+## Quick Start
 
-## Package shape
+### 1. Install
 
-```text
-src/open_range/      importable runtime, compiler, renderer, admission, store
-manifests/           checked-in strict manifest examples
-schemas/             generated JSON schemas
-examples/            small runnable demos against the current API
-data/                repo-only training artifacts
-docs/                current package documentation
+```bash
+uv sync
+uv run openrange --help
 ```
 
-## Installation
+Or install the package directly:
 
 ```bash
 pip install .
 openrange --help
-openrange-demo
-openrange-bootstrap-demo
 ```
 
-## Training Dependencies
+### 2. Run the Small Demo
 
-The base package does not install model-training dependencies by default.
-Use the training extra explicitly:
+This is the fastest way to see the package working end to end without setting up
+Kind:
 
 ```bash
-uv sync --extra training
+uv run openrange-demo
 ```
 
-This installs the small training stack used by the current branch:
-PyTorch, Transformers, Datasets, Accelerate, PEFT, and TRL.
-
-## Admission profiles
-
-Admission strength is explicit:
-
-- `full`: requires live Kind validation
-- `graph_plus_live`: requires live Kind validation without necessity probes
-- `no_necessity`: strongest offline profile, including reference, shortcut, and determinism checks
-- `graph_only`: offline structural validation only
-
-For offline workflows, pass the profile deliberately instead of relying on a silent fallback.
-
-## Tiny Train/Eval Path
-
-The branch includes a branch-native tiny LoRA warmup path.
-It now starts from generated decision traces over admitted snapshots rather than
-from the older mixed bootstrap chat file.
-
-Generate branch-native traces first:
+You can also point it at a checked-in manifest:
 
 ```bash
-PYTHONPATH=src .venv/bin/python scripts/generate_traces.py \
-  --manifest manifests/tier1_basic.yaml \
+uv run openrange-demo --manifest manifests/tier1_basic.yaml
+```
+
+### 3. Admit a Snapshot Locally
+
+For a local first run, use the explicit offline profile:
+
+```bash
+uv run openrange admit \
+  -m manifests/tier1_basic.yaml \
+  -o /tmp/openrange-build \
+  --store-dir /tmp/openrange-snapshots \
+  --validation-profile graph_only
+```
+
+Then reset the runtime onto an admitted snapshot:
+
+```bash
+uv run openrange reset \
+  --store-dir /tmp/openrange-snapshots \
+  --mode blue_only_live \
+  --sample-seed 7
+```
+
+`graph_only` is the cheapest offline path. `full` and `graph_plus_live` require
+a live Kind-backed setup.
+
+### 4. Generate Trace Data
+
+```bash
+uv run openrange traces \
+  -m manifests/tier1_basic.yaml \
+  -o /tmp/openrange-traces \
   --roots 3 \
-  --mutations 1 \
-  --outdir /tmp/openrange-traces
+  --mutations 1
 ```
 
-This writes:
+This writes raw decision rows, SFT-ready rows, and a small dataset report tied
+to admitted snapshots.
 
-- raw decision rows: `/tmp/openrange-traces/trace_rows.jsonl`
-- branch-native decision SFT rows: `/tmp/openrange-traces/decision_sft.jsonl`
-- red runtime shard: `/tmp/openrange-traces/sft_red_runtime.jsonl`
-- blue runtime shard: `/tmp/openrange-traces/sft_blue_runtime.jsonl`
-- dataset report: `/tmp/openrange-traces/report.json`
-
-The tiny SFT path can also generate a small branch-native dataset on the fly if
-`--data` is omitted.
-
-The tiny train/eval scripts are role-correct by default:
-- `--roles red`
-- `--trace-sources runtime`
-
-That keeps the small adapter aligned with the current red-only model probe
-instead of mixing red and blue decision rows into one tiny run.
-If `--data` is omitted, the tiny train/eval scripts regenerate a fresh
-runtime-only corpus under `/tmp/openrange-trace-train-data-runtime/seed-<seed>`
-instead of reusing a stale cached dataset.
-
-Train:
-
-```bash
-uv sync --extra dev --extra training
-HF_HOME=/tmp/hf-home TOKENIZERS_PARALLELISM=false \
-python scripts/train_tiny_sft.py \
-  --data /tmp/openrange-traces/decision_sft.jsonl \
-  --roles red \
-  --outdir /tmp/openrange-sft-tiny \
-  --max-samples 64 \
-  --max-length 1024 \
-  --max-steps 8 \
-  --grad-accum 4 \
-  --batch-size 1 \
-  --eval-ratio 0.25 \
-  --min-eval-samples 8
-```
-
-Evaluate the saved adapter on the held-out split:
-
-```bash
-HF_HOME=/tmp/hf-home TOKENIZERS_PARALLELISM=false \
-python scripts/eval_tiny_sft.py \
-  --data /tmp/openrange-traces/decision_sft.jsonl \
-  --adapter /tmp/openrange-sft-tiny/adapter \
-  --roles red \
-  --max-samples 64 \
-  --eval-ratio 0.25 \
-  --min-eval-samples 8 \
-  --max-length 1024 \
-  --out /tmp/openrange-sft-eval.json
-```
-
-Current default tiny model:
-- `HuggingFaceTB/SmolLM2-360M-Instruct`
-
-## Training Data
-
-OpenRange training data is now treated as a first-class artifact of admitted
-snapshots.
-
-The canonical contract is documented in:
-
-- [docs/training-data-spec.md](docs/training-data-spec.md)
-
-Key rules:
-
-- raw data comes from executed traces over admitted snapshots
-- `sim` and `runtime` traces stay explicitly separated
-- rows carry snapshot, world, world hash, lineage, mode, role, observation, candidates, chosen action, emitted events, reward delta, winner, and terminal reason
-- default decision prompts mirror the runtime observation surface and do not include hidden weakness inventory, benchmark tags, snapshot ids, lineage ids, or evaluator-only metadata
-- dataset splits are assigned by lineage root, not random row
-- derived SFT rows preserve `split` and lineage metadata
-- trace export writes clean role/source shards for red, blue, runtime, and sim subsets
-- train/eval filtering happens before row caps, so role-correct subsets are not starved by mixed trace distributions
-
-## Benchmark-Aligned Offensive Coverage
-
-The offensive slice is documented separately in:
-
-- [docs/benchmark-offensive-coverage.md](docs/benchmark-offensive-coverage.md)
-- [docs/effect-grounding.md](docs/effect-grounding.md)
-
-Current implementation points:
-
-- exact `code_web` flaws carry benchmark tags plus benchmark-aligned `objective_tags`
-- red objectives compile with derived offensive objective tags where applicable
-- admission now executes service-native grader checks during red reference validation for grounded red objectives
-- admin, privilege, and outbound-service objectives are grounded by service-local effect artifacts or sink-side canary hits
-- `EpisodeConfig.prompt_mode` supports `zero_day` and `one_day`
-- runtime first observations expose prompt-mode-specific briefings without leaking private references or exact flaw inventories
-
-## Current pipeline
-
-```text
-manifest
-  -> validate_manifest
-  -> ManifestCompiler
-  -> WorldSynthesizer
-  -> WeaknessSeeder
-  -> KindRenderer
-  -> AdmissionController
-  -> SnapshotStore
-  -> OpenRange runtime
-```
-
-## What is implemented
-
-- strict manifest, `WorldIR`, `ReferenceBundle`, and `ValidatorReport` models
-- deterministic `enterprise_saas_v1` compiler
-- deterministic bounded synthesis for seeded business artifacts
-- deterministic weakness seeding from an allowed-family catalog, including the full required non-code kind set for `config_identity`, `secret_exposure`, `workflow_abuse`, and `telemetry_blindspot`
-- exact `code_web` flaw templates for the required web exploit kinds, rendered as concrete PHP handlers and referenceable routes
-- benchmark-aligned offensive objective library and service-native grader specs for the supported web-first objective slice
-- exact config/workflow/mailbox realizations for the required non-code weakness kinds, including mailbox-borne phishing and token leakage cases
-- representative service-native mitigations for exact web flaws plus bounded config/file mitigations for non-code weaknesses
-- Kind renderer with service payloads, firewall rules, and red/blue/green sandboxes
-- deterministic admission with optional live Kind checks
-- public immutable `Snapshot` records plus explicit runtime hydration into `RuntimeSnapshot` only when internal execution needs exact world structure and private references
-- shared predicate engine used by both admission and runtime terminal/objective reasoning
-- immutable snapshot store with train/eval splits
-- simulated-time runtime with `EpisodeConfig`, actor-specific observations, and `next_decision()`
-- live pod execution bridge and typed event flow
-- deterministic curriculum and tandem episode driver, including persistent weakness patch/remove and alternate-route hardening
-- checked-in manifest examples that validate and compile against the rewritten package
-
-## Current gaps
-
-- there is no production OpenEnv HTTP/WebSocket layer on this branch
-- live remediation is a hybrid: exact web flaws use service-native route guards and some config/file weaknesses use direct artifact rewrites, but full remediation engineering is still out of scope
-- admission now checks for public-surface secret leakage, obvious unguarded web routes, and missing service-local telemetry on critical weakness targets, but shortcut discovery is still intentionally non-exhaustive
-- green reactive behavior is deterministic and bounded, not policy-rich
-
-## CLI
-
-```bash
-openrange build  -m manifests/tier1_basic.yaml -o /tmp/openrange-build
-openrange admit  -m manifests/tier1_basic.yaml -o /tmp/openrange-build --store-dir snapshots --validation-profile graph_only
-openrange reset  --store-dir snapshots --sample-seed 7 --mode joint_pool
-```
-
-## Python usage
+## Python API
 
 ```python
 from open_range import BuildConfig, BuildPipeline, EpisodeConfig, OpenRange, load_bundled_manifest
@@ -246,33 +129,54 @@ candidate = pipeline.build(
 )
 snapshot = pipeline.admit(candidate)
 
-service = OpenRange()
-state = service.reset(snapshot.snapshot_id, EpisodeConfig(mode="joint_pool"))
-decision = service.next_decision()
+env = OpenRange()
+state = env.reset(snapshot.snapshot_id, EpisodeConfig(mode="blue_only_live"))
+decision = env.next_decision()
+
+print(state.snapshot_id)
+print(decision.actor, decision.obs.sim_time)
 ```
 
-The public `Snapshot` model intentionally excludes exact world structure and private reference traces. Runtime/admission code hydrates those internally through the store/service path rather than exposing them on the public snapshot contract.
+## Start Here
 
-## Demo
+- [How an Episode Works](docs/how-an-episode-works.md): practical runtime walkthrough
+- [Architecture](docs/architecture.md): package layers and runtime boundaries
+- [V1 Scope](docs/v1-paper-scope.md): product and claim boundary
+- [Training Data Spec](docs/training-data-spec.md): canonical trace/export contract
+- [Weakness Lifecycle](docs/weakness-lifecycle.md): weakness realization, admission, and mutation
+- [Benchmark Offensive Coverage](docs/benchmark-offensive-coverage.md): web-offensive slice and objective grounding
+- [Effect Grounding](docs/effect-grounding.md): grounded effect and mitigation semantics
+
+## Scope
+
+The current branch focuses on a validator-admitted enterprise web-security
+training slice:
+
+- exact web flaws plus config, secret, workflow, and telemetry weaknesses
+- private reference attack and defense traces
+- immutable snapshots and mutation between snapshots
+- red exploit-to-objective behavior
+- blue detection, containment, and continuity under green-user noise
+
+It does not expose the old public golden-path architecture or the legacy
+OpenEnv HTTP server surface from `main`.
+
+## Extras
+
+Training dependencies are optional:
 
 ```bash
-PYTHONPATH=src .venv/bin/python examples/demo.py --manifest manifests/tier1_basic.yaml
-PYTHONPATH=src .venv/bin/python -m open_range.examples.demo
-openrange-demo
+uv sync --extra training
 ```
 
-## Bootstrap Example
-
-The package also includes an explicit warmup/bootstrap example. This keeps the
-old synthetic warm-start idea separate from the environment contract by using
-the optional sim plane rather than modifying the runtime itself.
+The package also ships a bootstrap example that compares a cheap sim-plane trace
+with a runtime episode:
 
 ```bash
-PYTHONPATH=src .venv/bin/python -m open_range.examples.bootstrap
-openrange-bootstrap-demo
+uv run openrange-bootstrap-demo
 ```
 
-## Rollout Evaluation
+## License
 
 For environment-side evaluation over admitted snapshots and sequential mutations:
 
@@ -355,3 +259,4 @@ uv run pytest
 uv run pre-commit install
 uv run pre-commit run --all-files
 ```
+Apache 2.0

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -2,6 +2,10 @@
 
 OpenRange is organized as a Python control plane with bundled assets.
 
+If you want the concrete runtime story first, start with
+[`How an Episode Works`](how-an-episode-works.md) and then come back to this
+document for the package-level view.
+
 ## Layers
 
 ```text

--- a/docs/benchmark-offensive-coverage.md
+++ b/docs/benchmark-offensive-coverage.md
@@ -1,8 +1,8 @@
-## Benchmark-Aligned Offensive Coverage
+# Benchmark-Aligned Offensive Coverage
 
 OpenRange V1 keeps its enterprise world model, blue role, and green-user dynamics, but it imports a narrower set of CVE-Bench-style offensive guarantees for the web slice.
 
-### Scope
+## Scope
 
 OpenRange does not become a red-only benchmark. It remains:
 
@@ -14,7 +14,7 @@ OpenRange does not become a red-only benchmark. It remains:
 
 What it borrows directly is offensive grounding quality.
 
-### Standard Attack Objectives
+## Standard Attack Objectives
 
 OpenRange exposes a first-class offensive objective library:
 
@@ -38,7 +38,7 @@ These tags are not a replacement for public objective predicates. They are the b
 - service-native objective graders
 - held-out offensive evaluation
 
-### Exact Code Flaw Packs
+## Exact Code Flaw Packs
 
 For `code_web`, OpenRange must use exact vulnerable behavior rather than generic weak routes. Each exact code flaw must have:
 
@@ -47,7 +47,7 @@ For `code_web`, OpenRange must use exact vulnerable behavior rather than generic
 - at least one private exploit reference
 - at least one standard attack objective tag
 
-### Objective Tags
+## Objective Tags
 
 Each concrete `WeaknessSpec` must carry:
 
@@ -58,7 +58,7 @@ Each concrete `WeaknessSpec` must carry:
 
 This lets the validator and the training-data layer reason about why a world is offensively interesting, not just where a weakness is planted.
 
-### Service-Native Graders
+## Service-Native Graders
 
 Each benchmark-aligned offensive objective must map to a real checker shape:
 
@@ -71,7 +71,7 @@ Each benchmark-aligned offensive objective must map to a real checker shape:
 - `privilege_escalation` -> privilege-bearing event or equivalent state change
 - `outbound_service` -> outbound request or equivalent egress effect
 
-For the remaining non-file/db effect types, V1 now prefers grounded live effects:
+For the remaining non-file/db effect types, V1 uses grounded live effects:
 
 - admin-only or privileged service-local effect artifacts
 - sink-side canary hits for outbound-service objectives
@@ -79,7 +79,7 @@ For the remaining non-file/db effect types, V1 now prefers grounded live effects
 In V1, these graders are represented as deterministic `ObjectiveGraderSpec`s owned by the predicate/admission stack.
 They are not report-only metadata: reference validation executes them against frozen snapshot state plus emitted runtime events.
 
-### Prompt Modes
+## Prompt Modes
 
 Episode-time prompt exposure must support:
 
@@ -92,7 +92,7 @@ PromptMode = Literal["zero_day", "one_day"]
 
 This is an evaluation and training split, not a change to the admitted snapshot itself.
 
-### What This Changes
+## What This Changes
 
 This does not replace OpenRange's existing enterprise objective predicates or private reference bundle. It adds a stronger offensive contract:
 

--- a/docs/effect-grounding.md
+++ b/docs/effect-grounding.md
@@ -1,11 +1,13 @@
 # Effect Grounding
 
-This note tightens the V1 realism contract for the remaining benchmark-aligned objective types.
+This document defines the V1 grounding contract for the remaining
+benchmark-aligned objective types.
 
 ## Goal
 
-OpenRange V1 already grounds file and database effects against concrete seeded state.
-The remaining objective types must now be grounded with equally concrete live effects:
+OpenRange V1 already grounds file and database effects against concrete seeded
+state. The remaining objective types are grounded through equally concrete live
+effects:
 
 - `unauthorized_admin_login`
 - `privilege_escalation`
@@ -13,7 +15,7 @@ The remaining objective types must now be grounded with equally concrete live ef
 
 ## Acceptance Bar
 
-For this phase, V1 requires:
+V1 requires:
 
 - admin login only scores if an admin-only effect artifact is observed
 - privilege escalation only scores if a privileged effect artifact is observed
@@ -42,7 +44,7 @@ Live grading prefers:
 
 `outbound_service` is grounded by a sink-side SIEM canary hit.
 
-The exact-code SSRF slice now uses:
+The exact-code SSRF slice uses:
 
 - a real outbound HTTP request from the vulnerable web handler
 - a dedicated canary listener on `svc-siem`
@@ -52,7 +54,7 @@ Live grading only passes when the sink-side artifact shows the canary hit.
 
 ## Mitigation Semantics
 
-V1 still uses bounded mitigation rather than full repair engineering.
+V1 uses bounded mitigation rather than full repair engineering.
 But for these effect types, mitigation must break the grounded effect for the right reason:
 
 - disable a vulnerable route or admin surface
@@ -64,7 +66,7 @@ Only truly service-native behavior changes should be described as `patch`.
 
 ## Training Data
 
-Branch-native trace rows now include:
+Branch-native trace rows include:
 
 - `grounded_effects`
 - `mitigation_effects`

--- a/docs/how-an-episode-works.md
+++ b/docs/how-an-episode-works.md
@@ -1,0 +1,344 @@
+# How an Episode Works
+
+This document is the practical runtime walkthrough for OpenRange V1.
+
+If the other docs describe the contract, this one describes the actual flow:
+
+1. build a world
+2. admit it with private references
+3. freeze it as a snapshot
+4. reset an episode onto that snapshot
+5. let red, blue, and green interact until a terminal condition is reached
+6. export one training row per external decision
+
+## The Short Version
+
+An OpenRange episode runs on one admitted snapshot.
+
+That snapshot is frozen before the episode starts. The environment does not
+mutate the world during `reset()` or invent a new exploit path on the fly.
+Instead, it loads an already admitted world plus a private `ReferenceBundle`
+that proves the world is trainable.
+
+During the episode:
+
+- green runs internally as background business activity
+- red tries to progress toward offensive objectives
+- blue tries to detect and break that path while preserving continuity
+
+The runtime advances internal time until the next externally controlled actor
+must decide. Training data is recorded from those external decisions.
+
+## What Is Frozen
+
+The frozen unit is the admitted snapshot.
+
+That snapshot contains the world state, validation outputs, and private
+reference material needed by runtime and admission. The public snapshot surface
+keeps the private reference data hidden, but runtime hydrates it internally when
+an episode starts.
+
+What freezing means in practice:
+
+- the world layout is fixed for the episode
+- the seeded weaknesses are fixed for the episode
+- the hidden reference attack and defense traces are fixed for the episode
+- the validator report is fixed for the episode
+
+What freezing does not mean:
+
+- no events happen
+- no services degrade
+- no containment or mitigation occurs
+- no green-user activity occurs
+
+The episode state changes. The admitted world definition does not.
+
+## What Admission Does Before Runtime
+
+Before a snapshot can be used for training, admission builds a private
+`ReferenceBundle`.
+
+That bundle contains:
+
+- `reference_attack_traces`
+- `reference_defense_traces`
+- `smoke_tests`
+- `shortcut_probes`
+- `necessity_probes`
+- `determinism_probes`
+
+Admission uses those private references to prove the world is worth training
+on.
+
+The validator is checking things like:
+
+- a real red path exists
+- a real blue detect-and-contain path exists
+- required telemetry reaches blue-observable surfaces
+- obvious shortcuts do not trivially bypass the intended challenge
+- replay is stable
+
+This is the private oracle. It is not a public golden path and not an LLM
+judge.
+
+## Where Red Paths Come From
+
+Red paths come from the seeded weaknesses in `WorldIR`.
+
+The planner looks at the active weaknesses in the world and turns one or more of
+them into private reference attack traces. For the web slice, it prioritizes
+exact `code_web` weaknesses when possible. For other worlds, the reference path
+may use:
+
+- exact web flaws
+- config and identity weaknesses
+- secret exposure
+- workflow abuse or phishing
+- telemetry blind spots
+
+Those traces are not just "pop a box" scripts. They continue until the red
+objective predicates are satisfied, such as:
+
+- file or database access
+- unauthorized admin login
+- privilege escalation
+- outbound effect
+
+So the red-side shape is closer to exploit-to-objective behavior than to a
+single-step CTF flag submission.
+
+## Where Blue Paths Come From
+
+Blue reference traces are built from the red traces.
+
+The planner identifies the first red step that should be visible to blue,
+constructs the observation path to it, then builds a minimal defense trace:
+
+1. observe enough telemetry
+2. submit a finding
+3. contain the relevant target
+
+This means admission is not only proving that the world is exploitable. It is
+also proving that the world is defensible under its declared telemetry and
+continuity constraints.
+
+## Who Controls Red And Blue
+
+There are always two possible controllers for red and blue:
+
+- external: your policy controls that actor
+- internal: the runtime controls that actor
+
+"Internal" does not mean the actor disappears. It means `next_decision()` will
+not hand that actor to your policy. The runtime will choose actions for that
+actor itself.
+
+## Training Modes
+
+The mode decides which actors are external.
+
+| Mode | Red | Blue | Typical use |
+| --- | --- | --- | --- |
+| `red_only` | external | internal | train the attacker |
+| `blue_only_live` | internal | external | train the defender against a live attacking red |
+| `blue_only_from_prefix` | prefix replay, then inactive | external | train defender recovery from a compromised state |
+| `joint_pool` | external | external | train both sides against opponent pools |
+
+Internal red is usually reference-driven or scripted.
+Internal blue is usually reference-driven or a simple heuristic.
+
+That is a training-stability choice, not a claim that the built-in opponent is
+as realistic as a human or a mature learned policy.
+
+## What "Internal" Actually Means
+
+When the scheduler decides that an actor is due:
+
+- if that actor is externally controlled, `next_decision()` returns a decision
+  for that actor
+- if that actor is internally controlled, runtime picks the action itself and
+  keeps advancing
+
+That is why a blue-only episode can still have an active red attacker. Red is
+present in the same episode, but the environment is controlling it.
+
+Likewise, in a red-only episode, blue is still present as a defender. The
+environment is just handling its actions internally.
+
+## Runtime Flow
+
+The runtime contract is small:
+
+```python
+snapshot = build_and_admit(...)
+env.reset(snapshot_id, episode_config)
+
+while not env.state().done:
+    decision = env.next_decision()
+    action = policy[decision.actor].act(decision.obs)
+    env.act(decision.actor, action)
+
+score = env.score()
+```
+
+What `reset()` does:
+
+- load a chosen or sampled admitted snapshot
+- optionally boot the live Kind-backed artifacts
+- hydrate the private runtime snapshot
+- initialize red, blue, and green state
+- apply any prefix start for `blue_only_from_prefix`
+- advance time until the first external decision is due
+
+What `next_decision()` does:
+
+- keep advancing simulated time
+- run green activity that becomes due
+- let internal red or blue act when they are due
+- stop only when an externally controlled actor must decide
+
+So `next_decision()` is not a simple alternating turn API. It is the public
+surface of an asynchronous event loop.
+
+## What Red Does During The Episode
+
+Red tries to move forward on the offensive path and satisfy terminal objectives.
+
+If red is internal, runtime usually follows the next reference attack step.
+If red is external, your policy chooses from the public decision surface.
+
+Red progress is grounded by the hidden reference path and by objective/event
+checks. The red side is not rewarded for nice prose or for merely naming an
+attack category. It has to cause the right state changes and effects.
+
+## What Blue Does During The Episode
+
+Blue tries to:
+
+- observe malicious activity
+- submit valid findings
+- contain or mitigate the path before red completes
+- preserve service continuity
+
+If blue is internal, runtime either follows the reference defense path or uses a
+simple built-in heuristic:
+
+- detect a malicious event
+- submit a finding
+- contain a remaining red target
+
+If blue is external, your policy receives blue observations and acts through the
+same public decision surface.
+
+## Does Blue Really Patch Things
+
+Sometimes, but not always in the same way.
+
+Blue runtime actions can include containment, patching, mitigation, and
+recovery. The exact effect depends on the weakness family.
+
+For exact `code_web` weaknesses, patching is relatively concrete:
+
+- the remediation changes the live service behavior
+- the vulnerable route stops acting exploitable
+
+For config, secret, workflow, identity, and telemetry weaknesses, blue
+"patching" is more often bounded path-breaking mitigation:
+
+- rewrite a config
+- revoke or replace exposed material
+- disable a workflow abuse path
+- restore visibility or logging
+
+That is why V1 should treat many blue-side patch actions as mitigation or
+containment unless the service behavior really changes in a service-native way.
+
+## What Green Does
+
+Green is environment-owned business activity.
+
+Green is not usually a trainer-stepped policy in V1. Instead, runtime advances
+green internally to create:
+
+- benign traffic
+- workflow pressure
+- email and phishing surface
+- continuity pressure
+- background noise for detection
+
+This is part of what makes the world feel like an enterprise range rather than
+a sterile red-only benchmark.
+
+## When The Episode Ends
+
+The episode ends when one of three things happens:
+
+- red satisfies its terminal objectives
+- blue detects and contains before red completes, while preserving continuity if
+  continuity enforcement is enabled
+- the episode times out
+
+The runtime then records:
+
+- winner
+- terminal reason
+- reward totals
+- objective satisfaction state
+- emitted event history
+
+## Where Training Rows Come From
+
+The canonical training export is one row per external actor decision.
+
+That means:
+
+- internal actions still shape the world
+- green still changes what is visible
+- red and blue may both act in the same episode
+- but the dataset records the moments where an external controller had to decide
+
+Each row can include:
+
+- observation
+- candidate actions
+- chosen action
+- emitted events
+- reward delta
+- winner
+- terminal reason
+- snapshot metadata
+- lineage metadata
+
+This keeps the training surface aligned with the actual runtime API.
+
+## A Concrete Episode Timeline
+
+Here is the simplest mental model for one blue-training episode:
+
+1. build a world with a seeded web weakness
+2. admission proves a private red exploit path and a private blue defense path
+3. the snapshot is frozen and stored
+4. `env.reset()` loads that snapshot in `blue_only_live`
+5. red is internal, so runtime starts advancing red and green automatically
+6. red triggers a malicious event that reaches a blue-visible surface
+7. `next_decision()` returns a blue observation
+8. blue submits a finding or applies containment/mitigation
+9. runtime advances again and checks whether the remaining red path is broken
+10. the episode ends with `red`, `blue`, or `timeout`
+
+The same world can instead be used for `red_only`, where blue remains present
+but is internally controlled by the environment.
+
+## What This Document Is Trying To Clarify
+
+OpenRange V1 is easiest to understand if you keep four ideas separate:
+
+- admission proves a world is trainable
+- snapshots freeze admitted worlds between episodes
+- runtime still changes episode state inside that frozen world
+- internal vs external control is about who chooses an action, not whether that
+  actor exists
+
+If those four ideas are clear, most of the rest of the docs become much easier
+to read.

--- a/docs/training-data-spec.md
+++ b/docs/training-data-spec.md
@@ -1,6 +1,7 @@
 # OpenRange Training Data Spec
 
-This document defines the branch-native training-data contract for OpenRange V1.
+This document defines the branch-native training-data contract for OpenRange
+V1.
 
 ## Purpose
 
@@ -73,7 +74,7 @@ Training should happen on the actual OpenRange decision surface:
 
 - candidate action selection
 - ranked next-action preference
-- later preference / reranking over counterfactuals
+- preference / reranking over counterfactuals
 
 OpenRange V1 should not treat unconstrained free-form generation as the primary learning objective.
 
@@ -134,7 +135,7 @@ over claiming a full `patch`.
 The canonical trace rows may be transformed into training views, including:
 
 - `decision_sft.jsonl` for small causal-LM warmup
-- later ranking/preference datasets
+- ranking/preference datasets
 
 Derived views must preserve snapshot and lineage metadata.
 
@@ -145,15 +146,15 @@ The default export should also write clean shards for:
 - role-only all-source views such as `sft_red_all.jsonl`
 - role-and-source views such as `sft_blue_runtime.jsonl`
 
-## Initial Sequence
+## Default Training Sequence
 
-The immediate branch-native learning path is:
+The default branch-native learning sequence is:
 
 1. generate raw trace rows from admitted snapshots
 2. generate branch-native decision SFT rows
 3. train small models on that branch-native data
 4. evaluate in-loop on admitted snapshots and mutations
-5. only then consider larger-scale RL
+5. use larger-scale RL only after those stages
 
 Default tiny-train behavior:
 

--- a/docs/v1-paper-scope.md
+++ b/docs/v1-paper-scope.md
@@ -1,114 +1,242 @@
-# OpenRange V1 Paper Scope
+# OpenRange V1 Scope
 
-This note freezes the intended V1 claim boundary for the branch so it does not drift after future refactors or context compaction.
+OpenRange V1 is a validator-admitted enterprise cyber training environment.
+
+If you want the runtime mechanics first, read
+[`How an Episode Works`](how-an-episode-works.md) before this scope document.
+
+## One-line definition
+
+OpenRange V1 is a manifest-driven enterprise cyber training environment that
+builds a business world, validates it with private reference traces and
+deterministic probes, runs episodes on immutable live snapshots, and trains red
+and blue agents against realistic green-user dynamics and operational
+constraints.
 
 ## Position
 
-OpenRange V1 is strong enough for a serious V1 and paper if it is presented as:
+OpenRange V1 is not a red-only benchmark and not a full enterprise autonomy
+claim. It is a mutable world-based training system with:
 
-**a validator-admitted, mutable enterprise web-security training environment that combines exact code-level web flaws with configuration, workflow, and telemetry weaknesses, and trains red for exploit-to-objective behavior and blue for detection/containment under realistic green-user noise**
+- public manifests
+- a private oracle
+- deterministic admission
+- immutable admitted snapshots
+- async red/blue runtime decisions
+- environment-owned green-user activity
 
-It should not be presented as full enterprise remediation automation or broad real-world cyber autonomy.
+## Public Manifest, Private Oracle
 
-## V1 Claims
+The public manifest defines the legal business world:
 
-V1 should claim strength on:
+- topology
+- services
+- users
+- workflows
+- assets
+- observability requirements
+- allowed weakness families
+- mutation bounds
 
-- red: web exploit workflow, recon-to-objective planning, adaptation across bounded weakness families
-- blue: alert triage, detection timing, containment timing, continuity tradeoffs under benign user noise
-- green realism: phishing/workflow surface, normal traffic, false-positive pressure
-- world quality: validator-admitted, replayable, non-trivial snapshots
-- curriculum: worlds mutate across generations instead of staying static
+The manifest does not expose exploit steps, literal attack commands, or a public
+answer key.
 
-## Non-Claims
+The internal oracle is a private `ReferenceBundle` containing:
 
-V1 should not claim:
+- `reference_attack_traces`
+- `reference_defense_traces`
+- `smoke_tests`
+- `shortcut_probes`
+- `necessity_probes`
+- `determinism_probes`
 
-- full enterprise remediation engineering
+This keeps the execution and validation artifact hidden while preserving a
+concrete mechanical notion of what the world is supposed to support.
+
+## Canonical World Model
+
+The manifest compiles into `WorldIR`, which is the canonical internal world
+model.
+
+`WorldIR` is the single source of truth for:
+
+- hosts
+- services
+- users and credentials
+- business assets
+- workflows
+- observability edges
+- exact weakness instances
+- red and blue objective predicates
+
+Both the live range and the optional sim plane are derived from `WorldIR`.
+
+## Deterministic Admission
+
+A world is trainable only if admission proves all of the following:
+
+- at least one real red path exists
+- at least one real blue detect-and-contain path exists
+- required telemetry reaches blue-observable surfaces
+- no obvious accidental shortcut exists under the configured probe set
+- reference execution is replayable and stable
+
+Admission is deterministic and validator-grounded. V1 does not use an LLM judge
+for admission, reward, or outcome scoring.
+
+Necessity matters: if removing a claimed weakness or remediation point does not
+break the corresponding reference path, that weakness was never a real
+prerequisite.
+
+## Immutable Snapshots
+
+Training always runs on admitted snapshots, not mutable build outputs.
+
+That snapshot boundary exists for:
+
+- replayability
+- fair comparison
+- stable curriculum
+- validator correctness
+
+Runtime `reset()` binds an episode to a stored admitted snapshot. Mutation
+happens between snapshots, not during a live episode.
+
+## Weakness Model
+
+OpenRange V1 does not treat the offensive surface as only CVEs or only abstract
+weakness families. It uses a mixed weakness library:
+
+- exact code flaws for the offensive web slice
+- config and identity weaknesses
+- secret exposure weaknesses
+- workflow and phishing weaknesses
+- telemetry and observability weaknesses
+
+The public manifest defines the allowed weakness space. Exact instantiated
+weaknesses live in `WorldIR` and the admitted snapshot.
+
+## Offensive Objective Layer
+
+The V1 offensive slice is aligned to the benchmark-style web exploit surface
+where that mapping is meaningful. Standard offensive objective types are:
+
+- `dos`
+- `file_access`
+- `file_creation`
+- `db_modification`
+- `db_access`
+- `unauthorized_admin_login`
+- `privilege_escalation`
+- `outbound_service`
+
+OpenRange reuses those as standard offensive objective types and adds blue-side
+objectives around detection, containment, and continuity.
+
+## Runtime Model
+
+OpenRange runtime is asynchronous, event-driven, and simulated-time.
+
+Red and blue may act in the same episode on the same frozen admitted world.
+Green remains environment-owned unless a research ablation chooses to expose it.
+
+Important runtime rules:
+
+- `next_decision()` returns only externally controlled actors
+- green activity advances internally between external decisions
+- red and blue always keep separate session state and memory
+- weight sharing is allowed; memory sharing is not
+
+The episode ends when:
+
+- red satisfies terminal objectives
+- blue detects and contains before red completes while preserving continuity
+- or the episode times out
+
+## Control Surfaces
+
+V1 exposes two main feature-control objects.
+
+`BuildConfig` controls what gets built and admitted:
+
+- phishing surface on or off
+- allowed weakness families
+- exact code flaw kinds
+- observability surfaces
+- green artifacts
+- topology scale
+- validation strength
+
+`EpisodeConfig` controls runtime behavior:
+
+- training mode
+- scheduler mode
+- green routine and branch behavior
+- telemetry delay
+- continuity enforcement
+- reward shaping
+- opponent controller
+- prefix starts
+
+If a realism feature cannot be toggled from `BuildConfig` or `EpisodeConfig`, it
+is not part of the V1 contract.
+
+## Training Modes
+
+V1 supports staged training modes rather than fully joint training from
+scratch:
+
+- `red_only`
+- `blue_only_live`
+- `blue_only_from_prefix`
+- `joint_pool`
+
+This is a stability choice. Red and blue can share a world, but V1 does not
+require unstable latest-checkpoint self-play every episode.
+
+## Training Data Contract
+
+Training data comes from admitted snapshots and executed traces over those
+snapshots.
+
+The intended pattern is:
+
+1. build and admit a snapshot
+2. execute runtime or sim traces on that snapshot
+3. record observations, actions, events, rewards, winner, terminal reason, `snapshot_id`, and `world_hash`
+4. freeze those traces into replayable datasets
+
+The canonical export is one decision row per external actor decision.
+
+## What V1 Covers
+
+OpenRange V1 covers:
+
+- web exploit tasks
+- credential abuse
+- workflow compromise
+- enterprise detection and containment
+- phishing-driven paths
+
+OpenRange V1 does not claim:
+
+- full pwn, reverse, crypto, or forensics coverage
+- CTI-only reasoning
 - exhaustive shortcut elimination
-- full SOC/IR automation depth
-- all-benchmark cyber coverage
-- general real-world-ready offensive or defensive autonomy
+- full enterprise remediation engineering
+- general real-world-ready cyber autonomy
 
-## Current Branch Status
+## Honesty Rules
 
-Already in place:
+The V1 surface keeps a few explicit honesty constraints:
 
-- exact `code_web` flaw library with concrete handlers and referenceable routes
-- exact weakness instances with `kind`, `benchmark_tags`, and instantiation metadata
-- exact non-code weakness catalog coverage for the required `config_identity`, `secret_exposure`, `workflow_abuse`, and `telemetry_blindspot` kinds, with distinct config/file/workflow/mailbox realizations
-- private reference bundle and validator-gated admission
-- blue terminal win condition
-- runtime-owned green activity
-- async-capable runtime with separate red/blue session state
-- `BuildConfig` and `EpisodeConfig` as the main ablation surfaces
-- service-native route guards for exact web flaws, with bounded file/config mitigations for representative non-code weaknesses
-- broader shortcut probes for direct reachability, obvious unguarded web routes, public asset exposure, public-surface secret leakage, and missing service-local telemetry on critical weakness targets
+- no public golden path
+- no LLM judge
+- no trainer-stepped green actions
+- no reward for prose evidence quality
+- no reward simply because an action was named `patch`
+- no claim of universal service-native remediation realism
 
-Still weak relative to the strongest realism claim:
-
-- blue `patch` is still only partly service-native; it is stronger than pure marker toggles, but still not full remediation engineering
-- live necessity now proves real route-guard breakage for exact web flaws, but other weakness families still lean on bounded mitigations
-- shortcut and observability checks catch more obvious accidental solves and logging gaps, but they are still intentionally non-exhaustive
-
-## Required Before Paper Freeze
-
-These are the remaining high-value changes if the branch is going to be written up:
-
-1. Clean up terminology around blue remediation.
-   If an action is not truly service-native, describe it as `mitigate`, `contain`, or `break_path`, not full patching.
-
-2. Extend the service-native mitigation set.
-   Already landed:
-   - disable a vulnerable route through a service-native guard for exact web flaws
-   - rewrite representative secret/config artifacts in-place for bounded non-code mitigations
-
-   Still desirable:
-   - disable or revoke a credential or token
-   - quarantine a service through policy/state change
-
-3. Keep broadening shortcut probing enough to rule out obvious accidental solves.
-   Already landed:
-   - obvious unguarded web-route checks
-   - public asset exposure checks on public web surfaces
-   - public-surface secret leakage checks across synthesized payloads and mailboxes
-   - direct reachability checks for protected services
-   - service-local telemetry checks for critical weakness targets
-
-   Still desirable:
-   - seeded secret leakage checks across files, mailboxes, and configs
-   - unintended trust and zone pivots beyond the current probe set
-   - critical-action logging checks
-
-4. Keep the benchmark coverage statement explicit.
-   `enterprise_saas_v1` covers:
-   - web exploit and web objective tasks
-   - workflow compromise
-   - enterprise detection and containment
-
-   It does not cover:
-   - pwn
-   - reverse
-   - crypto
-   - CTI-only reasoning
-   - all CTF families
-
-5. Evaluate the claims against the right external slices.
-   - red: at least one external held-out web/offensive slice
-   - blue: held-out admitted worlds, held-out flaw mixes, held-out green profiles, prefix-start scenarios
-
-## Recommended Paper Framing
-
-Recommended claim sentence:
-
-> OpenRange V1 improves training realism for enterprise web-security tasks by combining exact web flaws, workflow compromise, green-user dynamics, and validator-admitted mutable worlds.
-
-Avoid stronger language about:
-
-- full remediation realism
-- exhaustive enterprise fidelity
-- all-category cyber coverage
-
-## V1 Release Rule
-
-If no further realism work lands before paper freeze, the release is still valid provided the written claim stays inside the scope above.
+Blue remediation in V1 is primarily containment or path-breaking mitigation.
+Service-native remediation is implemented for selected weakness families and may
+expand over time, but it is not assumed universally across the environment.

--- a/docs/weakness-lifecycle.md
+++ b/docs/weakness-lifecycle.md
@@ -1,13 +1,16 @@
 # Weakness Lifecycle Spec
 
-This document defines how OpenRange represents, realizes, validates, and mutates security weaknesses under the `spec_final.md` contract.
+This document defines how OpenRange represents, realizes, validates, and
+mutates security weaknesses under the OpenRange V1 contract.
 
 ## Goals
 
 - The public manifest defines the allowed compromise space.
 - The built `WorldIR` defines the exact exploitable weakness instances.
 - Admission proves that at least one red path exists and that blue has enough observability and control to respond.
-- Runtime blue `contain` and blue `patch` are distinct actions.
+- Runtime blue `contain` and blue `patch` are distinct actions, even when
+  exported training views may rename non-service-native patching as
+  `mitigate`.
 - Mutation may add, move, or remove weaknesses, but every child must still pass admission.
 
 ## Public Manifest Contract


### PR DESCRIPTION
## Summary

- Improve README structure and usability while keeping v1-oriented runtime/docs guidance\n- Add quick-start and docs links cleanup alignment from local v1-based docs updates
