### PR TITLE
docs: remove stale branch-era wording

### DIFF
--- a/README.md
+++ b/README.md
@@ -149,7 +149,7 @@ print(decision.actor, decision.obs.sim_time)
 
 ## Scope
 
-The current branch focuses on a validator-admitted enterprise web-security
+OpenRange currently focuses on a validator-admitted enterprise web-security
 training slice:
 
 - exact web flaws plus config, secret, workflow, and telemetry weaknesses
@@ -159,7 +159,7 @@ training slice:
 - blue detection, containment, and continuity under green-user noise
 
 It does not expose the old public golden-path architecture or the legacy
-OpenEnv HTTP server surface from `main`.
+OpenEnv HTTP server surface.
 
 ## Optional extras
 

--- a/src/open_range/cli.py
+++ b/src/open_range/cli.py
@@ -1,4 +1,4 @@
-"""Standalone OpenRange CLI for the rewritten branch."""
+"""Standalone OpenRange CLI."""
 
 from __future__ import annotations
 


### PR DESCRIPTION
Closes #

## Summary

- remove stale branch-era wording from the README scope section
- remove the stale rewrite-branch wording from the CLI module docstring

## Testing

- Not run
