### PR TITLE
docs: tighten PR testing guidance

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -17,12 +17,11 @@ Closes #
 Keep verification terse:
 - do not list routine Ruff / format / generic unit-test commands when CI already runs them
 - list only manual or non-routine verification that reviewers would not otherwise see
-- if there was no special verification beyond CI-covered lint/unit checks, say that plainly and stop there
+- if there was no special verification beyond CI-covered lint/unit checks, do not call that out
 - do not add meta-commentary about omitted routine checks
+- leave this section empty or delete it when there was no special verification to report
 - do not paste long terminal transcripts
 -->
-
-- Not run
 
 ## Review Notes
 

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -17,7 +17,8 @@ Closes #
 Keep verification terse:
 - do not list routine Ruff / format / generic unit-test commands when CI already runs them
 - list only manual or non-routine verification that reviewers would not otherwise see
-- if there was no special verification beyond CI-covered lint/unit checks, say that plainly
+- if there was no special verification beyond CI-covered lint/unit checks, say that plainly and stop there
+- do not add meta-commentary about omitted routine checks
 - do not paste long terminal transcripts
 -->
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -162,8 +162,8 @@ Prefer `uv run -m ...` for Python commands in this repo.
 - keep the `Testing` section terse and factual
 - do not list routine Ruff, formatting, or generic unit-test commands in the PR body when CI already runs them
 - reserve the `Testing` section for manual verification, integration checks, Kind/admission runs, training/eval smoke tests, or anything else the workflow does not already cover
-- if there was no special verification beyond CI-covered lint/unit checks, say that plainly and stop there
-- do not add meta-commentary about omitted routine checks; either list non-routine verification only, or say there was no special verification
+- if there was no special verification beyond CI-covered lint/unit checks, do not call that out in the PR body
+- do not add meta-commentary about omitted routine checks; either list non-routine verification only, or leave the `Testing` section empty / omit it
 - do not paste long verification logs or terminal transcripts into the PR body
 - include the exact verification commands used in the PR description for admission, runtime, Kind-backed, training, or other non-routine validation
 - use `Review Notes` only for reviewer-relevant context such as risks, tradeoffs, or follow-up work

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -162,7 +162,8 @@ Prefer `uv run -m ...` for Python commands in this repo.
 - keep the `Testing` section terse and factual
 - do not list routine Ruff, formatting, or generic unit-test commands in the PR body when CI already runs them
 - reserve the `Testing` section for manual verification, integration checks, Kind/admission runs, training/eval smoke tests, or anything else the workflow does not already cover
-- if there was no special verification beyond CI-covered lint/unit checks, say that plainly instead of pasting the commands
+- if there was no special verification beyond CI-covered lint/unit checks, say that plainly and stop there
+- do not add meta-commentary about omitted routine checks; either list non-routine verification only, or say there was no special verification
 - do not paste long verification logs or terminal transcripts into the PR body
 - include the exact verification commands used in the PR description for admission, runtime, Kind-backed, training, or other non-routine validation
 - use `Review Notes` only for reviewer-relevant context such as risks, tradeoffs, or follow-up work


### PR DESCRIPTION
## Summary

Clarify the repo PR guidance so the `Testing` section lists non-routine verification only.

This also makes it explicit that PR bodies should not add meta-commentary about omitted CI-covered checks, and should leave `Testing` empty or omit it when there is nothing special to report.
