### PR TITLE
fix: align k3s platform add-ons with v1 surfaces

### DIFF
--- a/deploy/argocd/README.md
+++ b/deploy/argocd/README.md
@@ -84,7 +84,7 @@ export OPENRANGE_GITOPS_COMMIT_AUTHOR_EMAIL=open-range@localhost
 From Python (e.g. in a training loop):
 
 ```python
-from open_range.server.gitops_publisher import GitOpsConfig, GitOpsPublisher
+from open_range.gitops_publisher import GitOpsConfig, GitOpsPublisher
 
 config = GitOpsConfig.from_env()
 publisher = GitOpsPublisher.from_config(config)
@@ -106,7 +106,7 @@ await publisher.unpublish("tier1-web-app-abc123")
 | `bootstrap-argocd.sh` | Installs Argo CD via Helm into the cluster |
 | `argocd-values.yaml` | Helm values optimised for local dev (minimal resources, no HA) |
 | `snapshot-application.yaml.tpl` | Argo CD Application template for a single snapshot (envsubst) |
-| `src/open_range/server/gitops_publisher.py` | Python module for publishing snapshots to the GitOps repo |
+| `src/open_range/gitops_publisher.py` | Python module for publishing snapshots to the GitOps repo |
 
 ## Environment variables reference
 
@@ -136,14 +136,14 @@ await publisher.unpublish("tier1-web-app-abc123")
 
 ## Integration with the training pipeline
 
-The `GitOpsPublisher` is designed to slot into the `ManagedSnapshotRuntime`
-training loop.  A typical integration:
+The `GitOpsPublisher` is designed to slot into the standalone
+build/render/admit flow. A typical integration:
 
-1. The runtime calls `builder.build()` to generate a snapshot spec.
+1. `BuildPipeline.build()` renders a candidate world into a local artifact directory.
 2. The renderer produces Helm chart artifacts in a local directory.
 3. If `OPENRANGE_GITOPS_ENABLED=true`, the publisher commits the artifacts
    to the GitOps repo and waits for Argo CD to reconcile.
-4. The environment runs the training episode against the live range.
+4. `OpenRange.reset()` can then run the episode against the admitted snapshot.
 5. After the episode, the publisher removes the snapshot from the GitOps
    repo, and Argo CD prunes the resources.
 

--- a/deploy/cilium/README.md
+++ b/deploy/cilium/README.md
@@ -71,7 +71,7 @@ Without Hubble, the Blue agent relies on application-level logs (syslog, web ser
 The `hubble_observer.py` module provides an async Python API:
 
 ```python
-from open_range.server.hubble_observer import HubbleObserver, HubbleConfig
+from open_range.hubble_observer import HubbleObserver, HubbleConfig
 
 observer = HubbleObserver(config=HubbleConfig(
     hubble_addr="localhost:4245",
@@ -107,7 +107,7 @@ When Hubble is not available, all methods return empty results rather than raisi
 The `cilium_policies.py` module generates CiliumNetworkPolicy resources from the same zone/firewall configuration used for standard NetworkPolicy:
 
 ```python
-from open_range.server.cilium_policies import CiliumPolicyGenerator
+from open_range.cilium_policies import CiliumPolicyGenerator
 
 gen = CiliumPolicyGenerator(name_prefix="or-my-range")
 policies = gen.generate_zone_policies(zones, firewall_rules)
@@ -145,7 +145,7 @@ cilium connectivity test
 ### Using the Python API
 
 ```python
-from open_range.server.hubble_observer import HubbleObserver
+from open_range.hubble_observer import HubbleObserver
 
 observer = HubbleObserver()
 

--- a/deploy/monitoring/README.md
+++ b/deploy/monitoring/README.md
@@ -78,14 +78,14 @@ The `PrometheusRewardDataSource` class in `src/open_range/server/prometheus_rewa
 
 ### Integration with training
 
-The data source is designed to complement `CompositeBlueReward` in `src/open_range/server/rewards.py`. A training harness can combine signals:
+The data source is designed to complement OpenRange's objective/event-grounded
+scoring or feed an external training harness. For example:
 
 ```python
-from open_range.server.prometheus_rewards import (
+from open_range.prometheus_rewards import (
     PrometheusConfig,
     PrometheusRewardDataSource,
 )
-from open_range.server.rewards import CompositeBlueReward
 
 source = PrometheusRewardDataSource(config=PrometheusConfig(
     url="http://localhost:9090",
@@ -93,9 +93,6 @@ source = PrometheusRewardDataSource(config=PrometheusConfig(
 
 availability = await source.service_availability("web")
 detection = await source.detection_score()
-
-# Feed into composite reward or use independently
-blue_reward = CompositeBlueReward()
 ```
 
 When Prometheus is unavailable, all methods return safe defaults (configurable via `PrometheusConfig`) so training is never blocked.

--- a/deploy/vault/README.md
+++ b/deploy/vault/README.md
@@ -118,7 +118,7 @@ export OPENRANGE_VAULT_K8S_ROLE=openrange
 ## Python API
 
 ```python
-from open_range.server.vault_client import VaultCredentialProvider
+from open_range.vault_client import VaultCredentialProvider
 
 provider = VaultCredentialProvider.from_env()
 
@@ -129,7 +129,7 @@ key = provider.get_llm_api_key("OPENAI_API_KEY")
 mysql_pw = provider.get_mysql_root_password()
 
 # Direct Vault client access
-from open_range.server.vault_client import get_vault_client
+from open_range.vault_client import get_vault_client
 
 client = get_vault_client()  # None if Vault is not configured
 if client:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -10,6 +10,9 @@ requires-python = ">=3.11"
 license = { text = "Apache-2.0" }
 dependencies = [
     "click>=8.1",
+    "cryptography>=44.0",
+    "httpx>=0.27",
+    "PyJWT>=2.10",
     "pydantic>=2.0.0",
     "pyyaml>=6.0",
 ]
@@ -42,7 +45,7 @@ openrange-bootstrap-demo = "open_range.examples.bootstrap:main"
 [tool.setuptools]
 include-package-data = true
 package-dir = { "" = "src" }
-package-data = { "open_range" = ["**/*.yaml", "**/*.yml", "**/*.json", "**/*.md"] }
+package-data = { "open_range" = ["**/*.yaml", "**/*.yml", "**/*.json", "**/*.md", "**/*.tpl"] }
 
 [tool.setuptools.packages.find]
 where = ["src"]

--- a/src/open_range/admission_plan.py
+++ b/src/open_range/admission_plan.py
@@ -25,6 +25,14 @@ def admission_stages(build_config: BuildConfig) -> tuple[AdmissionStagePlan, ...
             "topology_workflow_consistency",
         ),
     )
+    security_stage = AdmissionStagePlan(
+        "security",
+        (
+            "identity_enforcement",
+            "encryption_enforcement",
+            "mtls_enforcement",
+        ),
+    )
     live_stage = AdmissionStagePlan(
         "live",
         (
@@ -48,14 +56,16 @@ def admission_stages(build_config: BuildConfig) -> tuple[AdmissionStagePlan, ...
         AdmissionStagePlan("shortcut", ("shortcut_probes",), requires_references=True),
         AdmissionStagePlan("determinism", ("determinism",), requires_references=True),
     )
+    security_stages = (security_stage,) if build_config.security_enabled else ()
 
     if build_config.validation_profile == "graph_only":
-        return (static_stage,)
+        return (static_stage, *security_stages)
     if build_config.validation_profile == "graph_plus_live":
-        return (static_stage, live_stage) + reference_stages
+        return (static_stage, *security_stages, live_stage) + reference_stages
     if build_config.validation_profile == "no_necessity":
         return (
             static_stage,
+            *security_stages,
             live_stage,
             *reference_stages,
             AdmissionStagePlan(
@@ -65,7 +75,13 @@ def admission_stages(build_config: BuildConfig) -> tuple[AdmissionStagePlan, ...
                 "determinism", ("determinism",), requires_references=True
             ),
         )
-    return (static_stage, live_stage, *reference_stages, *advanced_stages)
+    return (
+        static_stage,
+        *security_stages,
+        live_stage,
+        *reference_stages,
+        *advanced_stages,
+    )
 
 
 def profile_requires_live(build_config: BuildConfig) -> bool:

--- a/src/open_range/admit.py
+++ b/src/open_range/admit.py
@@ -22,7 +22,11 @@ from open_range.async_utils import run_async
 from open_range.build_config import BuildConfig, DEFAULT_BUILD_CONFIG
 from open_range.cluster import KindBackend, LiveBackend
 from open_range.counterfactuals import clear_runtime_markers, remediation_command
+from open_range.encryption_enforcement import check_encryption_enforcement
 from open_range.execution import PodActionBackend
+from open_range.identity_enforcement import check_identity_enforcement
+from open_range.k3d_runner import K3dBackend
+from open_range.mtls_enforcement import check_mtls_enforcement
 from open_range.objectives import evaluate_objective_grader_live
 from open_range.predicates import PredicateEngine
 from open_range.probe_planner import build_reference_bundle
@@ -163,6 +167,9 @@ class LocalAdmissionController:
             "path_solvability": _check_path_solvability,
             "objective_grounding": _check_objective_grounding,
             "topology_workflow_consistency": _check_workflow_consistency,
+            "identity_enforcement": check_identity_enforcement,
+            "encryption_enforcement": check_encryption_enforcement,
+            "mtls_enforcement": check_mtls_enforcement,
             "render_outputs": _check_render_outputs,
             "service_health": _check_service_health_contract,
             "siem_ingest": _check_siem_ingest,
@@ -273,6 +280,22 @@ class LocalAdmissionController:
             return None
         if not shutil.which("helm"):
             return None
+        if build_config.cluster_backend == "k3d":
+            if not (shutil.which("k3d") and shutil.which("docker")):
+                return None
+            clusters = subprocess.run(
+                ["k3d", "cluster", "list", "-o", "json"],
+                capture_output=True,
+                text=True,
+                check=False,
+            )
+            if clusters.returncode != 0 or '"name":"openrange"' not in clusters.stdout:
+                return None
+            return K3dBackend(
+                kind_cluster="openrange",
+                k3d_agents=build_config.k3d_agents,
+                k3d_subnet=build_config.k3d_subnet,
+            )
         if not (shutil.which("kind") and shutil.which("docker")):
             return None
         clusters = subprocess.run(

--- a/src/open_range/build_config.py
+++ b/src/open_range/build_config.py
@@ -15,6 +15,8 @@ class BuildConfig(BaseModel):
     model_config = ConfigDict(extra="forbid", frozen=True)
 
     world_family: str = "enterprise_saas_v1"
+    cluster_backend: Literal["kind", "k3d"] = "kind"
+    network_policy_backend: Literal["kubernetes", "cilium"] = "kubernetes"
     services_enabled: tuple[str, ...] = Field(default_factory=tuple)
     workflows_enabled: tuple[str, ...] = Field(default_factory=tuple)
     weakness_families_enabled: tuple[WeaknessFamily, ...] = Field(default_factory=tuple)
@@ -22,12 +24,20 @@ class BuildConfig(BaseModel):
     observability_surfaces_enabled: tuple[str, ...] = Field(default_factory=tuple)
     phishing_surface_enabled: bool = True
     green_artifacts_enabled: bool = True
+    security_integration_enabled: bool = False
+    security_tier: int = Field(default=1, ge=1, le=5)
+    k3d_agents: int = Field(default=2, ge=0, le=16)
+    k3d_subnet: str = "172.29.0.0/16"
     topology_scale: Literal["small", "medium", "large"] = "medium"
     validation_profile: Literal[
         "full", "no_necessity", "graph_plus_live", "graph_only"
     ] = "full"
     red_reference_count: int = Field(default=1, ge=1)
     blue_reference_count: int = Field(default=1, ge=1)
+
+    @property
+    def security_enabled(self) -> bool:
+        return self.security_integration_enabled and self.security_tier > 1
 
 
 DEFAULT_BUILD_CONFIG = BuildConfig()

--- a/src/open_range/cli.py
+++ b/src/open_range/cli.py
@@ -13,7 +13,9 @@ import click
 import yaml
 
 from open_range.build_config import BuildConfig
+from open_range.cluster import KindBackend
 from open_range.episode_config import EpisodeConfig
+from open_range.k3d_runner import K3dBackend
 from open_range.pipeline import BuildPipeline
 from open_range.service import OpenRange
 from open_range.store import FileSnapshotStore
@@ -63,6 +65,34 @@ def _repo_script(script_name: str) -> Path:
     return script_path
 
 
+def _build_config_from_options(
+    *,
+    validation_profile: str = "full",
+    security_tier: int = 1,
+    cluster_backend: str = "kind",
+    network_policy_backend: str = "kubernetes",
+    k3d_agents: int = 2,
+    k3d_subnet: str = "172.29.0.0/16",
+) -> BuildConfig:
+    return BuildConfig(
+        validation_profile=validation_profile,  # type: ignore[arg-type]
+        security_integration_enabled=security_tier > 1,
+        security_tier=security_tier,
+        cluster_backend=cluster_backend,  # type: ignore[arg-type]
+        network_policy_backend=network_policy_backend,  # type: ignore[arg-type]
+        k3d_agents=k3d_agents,
+        k3d_subnet=k3d_subnet,
+    )
+
+
+def _live_backend_for_option(cluster_backend: str) -> KindBackend | K3dBackend | None:
+    if cluster_backend == "none":
+        return None
+    if cluster_backend == "k3d":
+        return K3dBackend()
+    return KindBackend()
+
+
 @click.group()
 @click.option(
     "-v", "--verbose", is_flag=True, default=False, help="Enable debug logging."
@@ -88,10 +118,63 @@ def cli(verbose: bool) -> None:
     type=click.Path(),
     help="Output directory for rendered candidate artifacts.",
 )
-def build_cmd(manifest: str, output: str) -> None:
+@click.option(
+    "--security-tier",
+    default=1,
+    show_default=True,
+    type=click.IntRange(1, 5),
+    help="Optional security integration tier. Tier 1 keeps the core surface only.",
+)
+@click.option(
+    "--cluster-backend",
+    default="kind",
+    show_default=True,
+    type=click.Choice(["kind", "k3d"]),
+    help="Cluster backend used when rendering install artifacts.",
+)
+@click.option(
+    "--network-policy-backend",
+    default="kubernetes",
+    show_default=True,
+    type=click.Choice(["kubernetes", "cilium"]),
+    help="Network policy surface to render into the chart.",
+)
+@click.option(
+    "--k3d-agents",
+    default=2,
+    show_default=True,
+    type=click.IntRange(0, 16),
+    help="Agent node count when --cluster-backend k3d is selected.",
+)
+@click.option(
+    "--k3d-subnet",
+    default="172.29.0.0/16",
+    show_default=True,
+    help="Cluster subnet when --cluster-backend k3d is selected.",
+)
+def build_cmd(
+    manifest: str,
+    output: str,
+    security_tier: int,
+    cluster_backend: str,
+    network_policy_backend: str,
+    k3d_agents: int,
+    k3d_subnet: str,
+) -> None:
     """Compile and render a candidate world from a manifest."""
     output_dir = Path(output)
-    candidate = BuildPipeline().build(_load_manifest(manifest), output_dir)
+    candidate = BuildPipeline().build(
+        _load_manifest(manifest),
+        output_dir,
+        _build_config_from_options(
+            validation_profile="graph_only",
+            security_tier=security_tier,
+            cluster_backend=cluster_backend,
+            network_policy_backend=network_policy_backend,
+            k3d_agents=k3d_agents,
+            k3d_subnet=k3d_subnet,
+        ),
+    )
     world_path = _write_json(
         candidate.world.model_dump(mode="json"), output_dir / "candidate-world.json"
     )
@@ -136,15 +219,65 @@ def build_cmd(manifest: str, output: str) -> None:
     type=click.Choice(["full", "no_necessity", "graph_plus_live", "graph_only"]),
     help="Admission strictness. Use graph_only for explicit offline admission.",
 )
+@click.option(
+    "--security-tier",
+    default=1,
+    show_default=True,
+    type=click.IntRange(1, 5),
+    help="Optional security integration tier. Tier 1 keeps the core surface only.",
+)
+@click.option(
+    "--cluster-backend",
+    default="kind",
+    show_default=True,
+    type=click.Choice(["kind", "k3d"]),
+    help="Cluster backend used when rendering install artifacts and live checks.",
+)
+@click.option(
+    "--network-policy-backend",
+    default="kubernetes",
+    show_default=True,
+    type=click.Choice(["kubernetes", "cilium"]),
+    help="Network policy surface to render into the chart.",
+)
+@click.option(
+    "--k3d-agents",
+    default=2,
+    show_default=True,
+    type=click.IntRange(0, 16),
+    help="Agent node count when --cluster-backend k3d is selected.",
+)
+@click.option(
+    "--k3d-subnet",
+    default="172.29.0.0/16",
+    show_default=True,
+    help="Cluster subnet when --cluster-backend k3d is selected.",
+)
 def admit_cmd(
-    manifest: str, output: str, store_dir: str, split: str, validation_profile: str
+    manifest: str,
+    output: str,
+    store_dir: str,
+    split: str,
+    validation_profile: str,
+    security_tier: int,
+    cluster_backend: str,
+    network_policy_backend: str,
+    k3d_agents: int,
+    k3d_subnet: str,
 ) -> None:
     """Build and admit a snapshot into the snapshot store."""
     pipeline = BuildPipeline(store=FileSnapshotStore(store_dir))
     candidate = pipeline.build(
         _load_manifest(manifest),
         Path(output),
-        BuildConfig(validation_profile=validation_profile),
+        _build_config_from_options(
+            validation_profile=validation_profile,
+            security_tier=security_tier,
+            cluster_backend=cluster_backend,
+            network_policy_backend=network_policy_backend,
+            k3d_agents=k3d_agents,
+            k3d_subnet=k3d_subnet,
+        ),
     )
     snapshot = pipeline.admit(candidate, split=split)
     snapshot_path = Path(store_dir) / snapshot.snapshot_id / "snapshot.json"
@@ -197,6 +330,13 @@ def admit_cmd(
 @click.option(
     "--horizon", default=25.0, type=float, help="Simulated-time episode horizon."
 )
+@click.option(
+    "--live-cluster-backend",
+    default="none",
+    show_default=True,
+    type=click.Choice(["none", "kind", "k3d"]),
+    help="Optionally boot the admitted snapshot onto a live cluster backend.",
+)
 def reset_cmd(
     store_dir: str,
     snapshot_id: str | None,
@@ -205,9 +345,13 @@ def reset_cmd(
     sample_seed: int,
     mode: str,
     horizon: float,
+    live_cluster_backend: str,
 ) -> None:
     """Reset the runtime against an admitted snapshot and print the initial state."""
-    service = OpenRange(store=FileSnapshotStore(store_dir))
+    service = OpenRange(
+        store=FileSnapshotStore(store_dir),
+        live_backend=_live_backend_for_option(live_cluster_backend),
+    )
     state = service.reset(
         snapshot_id,
         EpisodeConfig(mode=mode, episode_horizon_minutes=horizon),
@@ -260,6 +404,13 @@ def reset_cmd(
 @click.option(
     "--no-sim", is_flag=True, default=False, help="Skip sim-plane bootstrap traces."
 )
+@click.option(
+    "--security-tier",
+    default=1,
+    show_default=True,
+    type=click.IntRange(1, 5),
+    help="Optional security integration tier for the rendered roots and mutations.",
+)
 def traces_cmd(
     manifest: str,
     output: str,
@@ -267,6 +418,7 @@ def traces_cmd(
     mutations: int,
     include_joint_pool: bool,
     no_sim: bool,
+    security_tier: int,
 ) -> None:
     """Generate branch-native trace datasets from admitted snapshots."""
     output_dir = Path(output)
@@ -274,6 +426,10 @@ def traces_cmd(
         _load_manifest(manifest),
         output_dir,
         manifest_source=manifest,
+        build_config=_build_config_from_options(
+            validation_profile="graph_only",
+            security_tier=security_tier,
+        ),
         roots=roots,
         mutations_per_root=mutations,
         include_sim=not no_sim,
@@ -288,6 +444,7 @@ def traces_cmd(
     click.echo(f"  Raw Rows: {report.raw_path}")
     click.echo(f"  Decision SFT: {report.decision_sft_path}")
     click.echo(f"  Report: {report_path}")
+
 
 @cli.command("grpo")
 @click.option(
@@ -387,6 +544,7 @@ def grpo_cmd(
     result = subprocess.run(command, check=False)
     if result.returncode != 0:
         raise SystemExit(result.returncode)
+
 
 if __name__ == "__main__":
     cli()

--- a/src/open_range/pipeline.py
+++ b/src/open_range/pipeline.py
@@ -2,16 +2,22 @@
 
 from __future__ import annotations
 
+import hashlib
+import json
 from pathlib import Path
 from typing import Any
 
 from pydantic import BaseModel, ConfigDict
+import yaml
 
 from open_range.admit import LocalAdmissionController
 from open_range.build_config import BuildConfig, DEFAULT_BUILD_CONFIG
+from open_range.cilium_policies import CiliumPolicyGenerator
 from open_range.compiler import EnterpriseSaaSManifestCompiler
+from open_range.k3d_renderer import K3dRenderer
 from open_range.manifest import EnterpriseSaaSManifest, validate_manifest
 from open_range.render import EnterpriseSaaSKindRenderer
+from open_range.security_integrator import SecurityIntegrator, SecurityIntegratorConfig
 from open_range.snapshot import KindArtifacts, Snapshot
 from open_range.store import FileSnapshotStore, PoolSplit
 from open_range.synth import EnterpriseSaaSWorldSynthesizer, SynthArtifacts
@@ -38,6 +44,7 @@ class BuildPipeline:
         seeder: CatalogWeaknessSeeder | None = None,
         synthesizer: EnterpriseSaaSWorldSynthesizer | None = None,
         renderer: EnterpriseSaaSKindRenderer | None = None,
+        security_integrator: SecurityIntegrator | None = None,
         admission: LocalAdmissionController | None = None,
         store: FileSnapshotStore | None = None,
     ) -> None:
@@ -45,6 +52,7 @@ class BuildPipeline:
         self.seeder = seeder or CatalogWeaknessSeeder()
         self.synthesizer = synthesizer or EnterpriseSaaSWorldSynthesizer()
         self.renderer = renderer or EnterpriseSaaSKindRenderer()
+        self.security_integrator = security_integrator
         self.admission = admission or LocalAdmissionController(mode="fail_fast")
         self.store = store or FileSnapshotStore()
 
@@ -56,7 +64,9 @@ class BuildPipeline:
     ) -> CandidateWorld:
         world = self._prepare_world(source, build_config)
         synth = self.synthesizer.synthesize(world, Path(outdir) / "synth")
-        artifacts = self.renderer.render(world, synth, Path(outdir))
+        artifacts = self._renderer_for(build_config).render(world, synth, Path(outdir))
+        artifacts = self._integrate_security(world, artifacts, build_config)
+        artifacts = self._integrate_network_policies(artifacts, build_config)
         return CandidateWorld(
             world=world, synth=synth, artifacts=artifacts, build_config=build_config
         )
@@ -106,6 +116,117 @@ class BuildPipeline:
         )
         world = self.compiler.compile(parsed, build_config)
         return self.seeder.apply(world)
+
+    def _renderer_for(self, build_config: BuildConfig) -> EnterpriseSaaSKindRenderer:
+        if self.renderer is not None and not isinstance(
+            self.renderer, EnterpriseSaaSKindRenderer
+        ):
+            return self.renderer
+        if build_config.cluster_backend == "k3d":
+            return K3dRenderer(
+                agents=build_config.k3d_agents,
+                subnet=build_config.k3d_subnet,
+            )
+        return self.renderer
+
+    def _integrate_security(
+        self,
+        world: WorldIR,
+        artifacts: KindArtifacts,
+        build_config: BuildConfig,
+    ) -> KindArtifacts:
+        if not build_config.security_enabled:
+            return artifacts
+        integrator = self.security_integrator or SecurityIntegrator(
+            SecurityIntegratorConfig(enabled=True)
+        )
+        context = integrator.integrate(
+            world,
+            render_dir=Path(artifacts.render_dir),
+            tier=build_config.security_tier,
+        )
+        if not context.generated_files:
+            return artifacts
+        chart_values = dict(artifacts.chart_values)
+        chart_values["security"] = context.model_dump(mode="json")
+        return self._sync_artifacts(
+            artifacts,
+            chart_values=chart_values,
+            rendered_files=context.generated_files,
+            summary_updates={
+                "security_tier": build_config.security_tier,
+                "security_integration_enabled": True,
+            },
+        )
+
+    def _integrate_network_policies(
+        self,
+        artifacts: KindArtifacts,
+        build_config: BuildConfig,
+    ) -> KindArtifacts:
+        if build_config.network_policy_backend != "cilium":
+            return artifacts
+        chart_values = dict(artifacts.chart_values)
+        generator = CiliumPolicyGenerator(
+            name_prefix=chart_values["global"]["namePrefix"]
+        )
+        policies = generator.generate_zone_policies(
+            chart_values["zones"],
+            chart_values["firewallRules"],
+        )
+        cilium_path = Path(artifacts.chart_dir) / "templates" / "cilium-policies.yaml"
+        cilium_path.write_text(
+            yaml.safe_dump_all(policies, sort_keys=False),
+            encoding="utf-8",
+        )
+        chart_values["cilium"] = {
+            "enabled": True,
+            "policyCount": len(policies),
+        }
+        return self._sync_artifacts(
+            artifacts,
+            chart_values=chart_values,
+            rendered_files=[str(cilium_path)],
+            summary_updates={
+                "network_policy_backend": build_config.network_policy_backend,
+            },
+        )
+
+    def _sync_artifacts(
+        self,
+        artifacts: KindArtifacts,
+        *,
+        chart_values: dict[str, Any],
+        rendered_files: list[str] | tuple[str, ...] = (),
+        summary_updates: dict[str, Any] | None = None,
+    ) -> KindArtifacts:
+        values_path = Path(artifacts.values_path)
+        values_path.write_text(
+            yaml.safe_dump(chart_values, sort_keys=False),
+            encoding="utf-8",
+        )
+
+        summary_path = Path(artifacts.manifest_summary_path)
+        summary = json.loads(summary_path.read_text(encoding="utf-8"))
+        summary["values_hash"] = hashlib.sha256(
+            json.dumps(chart_values, sort_keys=True, separators=(",", ":")).encode(
+                "utf-8"
+            )
+        ).hexdigest()
+        if summary_updates:
+            summary.update(summary_updates)
+        summary_path.write_text(
+            json.dumps(summary, indent=2, sort_keys=True) + "\n",
+            encoding="utf-8",
+        )
+
+        next_files = tuple(dict.fromkeys((*artifacts.rendered_files, *rendered_files)))
+        return artifacts.model_copy(
+            update={
+                "rendered_files": next_files,
+                "chart_values": chart_values,
+            }
+        )
 
 
 def build(

--- a/src/open_range/prometheus_rewards.py
+++ b/src/open_range/prometheus_rewards.py
@@ -2,8 +2,8 @@
 
 Provides a ``PrometheusRewardDataSource`` that queries a Prometheus server
 for metrics used to compute supplementary reward signals.  These signals
-feed into (but do not replace) the existing ``CompositeBlueReward`` in
-``open_range.server.rewards``.
+can complement OpenRange's objective/event-grounded scoring or feed into an
+external training harness.
 
 The module is entirely optional.  When Prometheus is unreachable, every
 method returns a safe default value so training can proceed without the

--- a/src/open_range/security_integrator.py
+++ b/src/open_range/security_integrator.py
@@ -27,7 +27,9 @@ from __future__ import annotations
 import json
 import logging
 import os
+import random
 from copy import deepcopy
+from importlib.resources import files
 from pathlib import Path
 from typing import Any
 
@@ -177,6 +179,7 @@ class SecurityIntegrator:
         if not self.config.enabled:
             return ctx
 
+        rng = random.Random(f"{world.world_id}:{world.seed}:{tier}")
         tier_cfg = self.config.tier_map.get(
             tier,
             self.config.tier_map.get(max(self.config.tier_map), SecurityTierConfig()),
@@ -197,10 +200,10 @@ class SecurityIntegrator:
             self._integrate_identity(ctx, services, domain, security_dir)
 
         if tier_cfg.envelope_encryption:
-            self._integrate_encryption(ctx, world, security_dir)
+            self._integrate_encryption(ctx, world, security_dir, rng)
 
         if tier_cfg.mtls:
-            self._integrate_mtls(ctx, services, domain, security_dir)
+            self._integrate_mtls(ctx, services, domain, security_dir, rng)
 
         if tier_cfg.npc_credential_lifecycle:
             self._integrate_npc_lifecycle(ctx, security_dir)
@@ -272,6 +275,12 @@ class SecurityIntegrator:
         # Generate startup script
         idp = SimulatedIdentityProvider(idp_config)
         startup_script = idp.generate_startup_script()
+        server_template = (
+            files("open_range")
+            .joinpath("templates")
+            .joinpath("identity_provider_server.py.tpl")
+            .read_text(encoding="utf-8")
+        )
 
         # Write IdP artifacts
         idp_dir = security_dir / "idp"
@@ -279,9 +288,17 @@ class SecurityIntegrator:
         (idp_dir / "config.json").write_text(
             json.dumps(idp_config.model_dump(), indent=2) + "\n", encoding="utf-8"
         )
-        (idp_dir / "server.py").write_text(startup_script, encoding="utf-8")
+        (idp_dir / "startup.sh").write_text(startup_script, encoding="utf-8")
+        (idp_dir / "identity_provider_server.py").write_text(
+            server_template,
+            encoding="utf-8",
+        )
         ctx.generated_files.extend(
-            [str(idp_dir / "config.json"), str(idp_dir / "server.py")]
+            [
+                str(idp_dir / "config.json"),
+                str(idp_dir / "startup.sh"),
+                str(idp_dir / "identity_provider_server.py"),
+            ]
         )
 
         logger.debug(
@@ -297,6 +314,7 @@ class SecurityIntegrator:
         ctx: SecurityContext,
         world: WorldIR,
         security_dir: Path,
+        rng: random.Random,
     ) -> None:
         """Generate envelope encryption config for credential secrets."""
         try:
@@ -312,7 +330,6 @@ class SecurityIntegrator:
 
         # Encrypt a subset of credential secret_refs
         import math
-        import random as _random
 
         credentials = list(world.credentials)
         if not credentials:
@@ -321,7 +338,7 @@ class SecurityIntegrator:
         n_encrypt = max(
             1, math.ceil(len(credentials) * self.config.encryption_fraction)
         )
-        indices = _random.sample(
+        indices = rng.sample(
             list(range(len(credentials))),
             min(n_encrypt, len(credentials)),
         )
@@ -389,6 +406,7 @@ class SecurityIntegrator:
         services: dict[str, str],
         domain: str,
         security_dir: Path,
+        rng: random.Random,
     ) -> None:
         """Generate TLS certificates for service-to-service mTLS."""
         try:
@@ -401,12 +419,10 @@ class SecurityIntegrator:
         if not mtls_services:
             return
 
-        import random as _random
-
         weaknesses: dict[str, list[str]] = {}
         if mtls_services and self.config.mtls_weakness_pool:
-            target_svc = _random.choice(mtls_services)
-            weakness = _random.choice(self.config.mtls_weakness_pool)
+            target_svc = rng.choice(mtls_services)
+            weakness = rng.choice(self.config.mtls_weakness_pool)
             weaknesses[target_svc] = [weakness]
 
         mtls_config = MTLSConfig(
@@ -492,6 +508,7 @@ class SecurityIntegrator:
 
 def _default_scopes_for_service(service_name: str) -> list[str]:
     """Return default authorization scopes for a service."""
+    normalized = service_name.removeprefix("svc-").removeprefix("sandbox-")
     scope_map: dict[str, list[str]] = {
         "web": ["data:read:patients/*", "data:read:referrals/*", "api:access:portal"],
         "db": ["data:read:*", "data:write:*"],
@@ -500,4 +517,4 @@ def _default_scopes_for_service(service_name: str) -> list[str]:
         "files": ["file:read:general/*", "file:read:hr/*"],
         "siem": ["log:read:*", "log:write:*", "alert:read:*"],
     }
-    return scope_map.get(service_name, [f"service:access:{service_name}"])
+    return scope_map.get(normalized, [f"service:access:{normalized}"])

--- a/tests/test_configs.py
+++ b/tests/test_configs.py
@@ -76,6 +76,47 @@ def test_build_config_can_filter_services_without_touching_manifest_schema(
     assert candidate.world.allowed_service_kinds == ("web_app", "idp", "siem")
 
 
+def test_build_config_can_enable_security_integration(tmp_path: Path):
+    pipeline = BuildPipeline(store=FileSnapshotStore(tmp_path / "snapshots"))
+    build_config = BuildConfig(
+        validation_profile="graph_only",
+        security_integration_enabled=True,
+        security_tier=3,
+    )
+
+    candidate = pipeline.build(
+        _manifest_payload(),
+        tmp_path / "rendered-security",
+        build_config,
+    )
+
+    assert candidate.build_config == build_config
+    assert candidate.artifacts.chart_values["security"]["tier"] == 3
+    assert any(
+        path.endswith("security/security-context.json")
+        for path in candidate.artifacts.rendered_files
+    )
+
+
+def test_build_config_can_select_k3d_and_cilium_outputs(tmp_path: Path):
+    pipeline = BuildPipeline(store=FileSnapshotStore(tmp_path / "snapshots"))
+    candidate = pipeline.build(
+        _manifest_payload(),
+        tmp_path / "rendered-k3d",
+        BuildConfig(
+            validation_profile="graph_only",
+            cluster_backend="k3d",
+            network_policy_backend="cilium",
+        ),
+    )
+
+    assert Path(candidate.artifacts.kind_config_path).name == "k3d-config.yaml"
+    assert candidate.artifacts.chart_values["cilium"]["enabled"] is True
+    assert (
+        Path(candidate.artifacts.chart_dir) / "templates" / "cilium-policies.yaml"
+    ).exists()
+
+
 def test_build_pipeline_threads_manifest_npc_profiles_into_personas(tmp_path: Path):
     pipeline = BuildPipeline(store=FileSnapshotStore(tmp_path / "snapshots"))
     payload = _manifest_payload()

--- a/tests/test_render_admission.py
+++ b/tests/test_render_admission.py
@@ -7,9 +7,11 @@ from types import SimpleNamespace
 from open_range._runtime_store import load_runtime_snapshot
 from open_range.cluster import ExecResult
 from open_range.admit import LocalAdmissionController
+from open_range.build_config import BuildConfig
 from open_range.code_web import code_web_payload
 from open_range.compiler import EnterpriseSaaSManifestCompiler
 from open_range.curriculum import FrontierMutationPolicy, PopulationStats
+from open_range.pipeline import BuildPipeline
 from open_range.predicates import PredicateEngine
 from open_range.render import EnterpriseSaaSKindRenderer
 from open_range.store import FileSnapshotStore
@@ -164,6 +166,33 @@ def test_admission_controller_admits_seeded_world(tmp_path: Path):
     )
     assert reference_bundle.reference_attack_traces
     assert reference_bundle.reference_defense_traces
+
+
+def test_admission_controller_registers_security_stage_when_enabled(tmp_path: Path):
+    pipeline = BuildPipeline(store=FileSnapshotStore(tmp_path / "snapshots"))
+    candidate = pipeline.build(
+        _manifest_payload(),
+        tmp_path / "rendered-security",
+        BuildConfig(
+            validation_profile="graph_only",
+            security_integration_enabled=True,
+            security_tier=3,
+        ),
+    )
+
+    _reference_bundle, report = LocalAdmissionController(mode="fail_fast").admit(
+        candidate.world,
+        candidate.artifacts,
+        candidate.build_config,
+    )
+
+    security_stage = next(stage for stage in report.stages if stage.name == "security")
+
+    assert {check.name for check in security_stage.checks} == {
+        "identity_enforcement",
+        "encryption_enforcement",
+        "mtls_enforcement",
+    }
 
 
 def test_admission_controller_offline_witness_can_ground_pinned_non_code_weakness(
@@ -371,6 +400,42 @@ def test_no_necessity_profile_skips_auto_live_backend_probe(
     assert all(stage.name != "kind_live" for stage in report.stages)
     assert which_calls == []
     assert run_calls == []
+
+
+def test_k3d_profile_uses_k3d_auto_live_backend(tmp_path: Path, monkeypatch) -> None:
+    _world = _build_seeded_world()
+    _ = EnterpriseSaaSKindRenderer().render(
+        _world, _synth(_world, tmp_path), tmp_path / "rendered-k3d"
+    )
+    which_calls: list[str] = []
+    run_calls: list[tuple[object, ...]] = []
+
+    def fake_which(cmd: str) -> str:
+        which_calls.append(cmd)
+        return f"/usr/bin/{cmd}"
+
+    def fake_run(*args, **kwargs):
+        del kwargs
+        run_calls.append(args)
+        cmd = args[0]
+        if cmd[:4] == ["k3d", "cluster", "list", "-o"]:
+            return SimpleNamespace(
+                returncode=0, stdout='[{"name":"openrange"}]', stderr=""
+            )
+        return SimpleNamespace(returncode=0, stdout="", stderr="")
+
+    monkeypatch.setattr(admit_mod.shutil, "which", fake_which)
+    monkeypatch.setattr(admit_mod.subprocess, "run", fake_run)
+
+    controller = LocalAdmissionController(mode="analysis")
+    backend = controller._auto_live_backend(
+        BuildConfig(cluster_backend="k3d", validation_profile="graph_plus_live")
+    )
+
+    assert backend is not None
+    assert backend.__class__.__name__ == "K3dBackend"
+    assert which_calls[:3] == ["helm", "k3d", "docker"]
+    assert any(call[0][:4] == ["k3d", "cluster", "list", "-o"] for call in run_calls)
 
 
 def test_live_service_smoke_check_uses_reachable_zone_runners() -> None:

--- a/tests/test_security_integrator.py
+++ b/tests/test_security_integrator.py
@@ -140,6 +140,15 @@ class TestIdentityIntegration:
         data = json.loads(idp_config_path.read_text())
         assert data["enabled"] is True
 
+    def test_idp_runtime_files_written(self, sample_world, render_dir):
+        integrator = SecurityIntegrator(SecurityIntegratorConfig(enabled=True))
+        integrator.integrate(sample_world, render_dir=render_dir, tier=2)
+
+        assert (render_dir / "security" / "idp" / "startup.sh").exists()
+        assert (
+            render_dir / "security" / "idp" / "identity_provider_server.py"
+        ).exists()
+
     def test_spiffe_ids_in_identities(self, sample_world, render_dir):
         integrator = SecurityIntegrator(SecurityIntegratorConfig(enabled=True))
         ctx = integrator.integrate(sample_world, render_dir=render_dir, tier=2)
@@ -240,6 +249,10 @@ class TestNPCLifecycleIntegration:
 class TestHelpers:
     def test_default_scopes_for_known_service(self):
         scopes = _default_scopes_for_service("web")
+        assert any("patients" in s for s in scopes)
+
+    def test_default_scopes_for_service_id_alias(self):
+        scopes = _default_scopes_for_service("svc-web")
         assert any("patients" in s for s in scopes)
 
     def test_default_scopes_for_unknown_service(self):

--- a/uv.lock
+++ b/uv.lock
@@ -208,6 +208,76 @@ wheels = [
 ]
 
 [[package]]
+name = "cffi"
+version = "2.0.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "pycparser", marker = "implementation_name != 'PyPy'" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/eb/56/b1ba7935a17738ae8453301356628e8147c79dbb825bcbc73dc7401f9846/cffi-2.0.0.tar.gz", hash = "sha256:44d1b5909021139fe36001ae048dbdde8214afa20200eda0f64c068cac5d5529", size = 523588, upload-time = "2025-09-08T23:24:04.541Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/12/4a/3dfd5f7850cbf0d06dc84ba9aa00db766b52ca38d8b86e3a38314d52498c/cffi-2.0.0-cp311-cp311-macosx_10_13_x86_64.whl", hash = "sha256:b4c854ef3adc177950a8dfc81a86f5115d2abd545751a304c5bcf2c2c7283cfe", size = 184344, upload-time = "2025-09-08T23:22:26.456Z" },
+    { url = "https://files.pythonhosted.org/packages/4f/8b/f0e4c441227ba756aafbe78f117485b25bb26b1c059d01f137fa6d14896b/cffi-2.0.0-cp311-cp311-macosx_11_0_arm64.whl", hash = "sha256:2de9a304e27f7596cd03d16f1b7c72219bd944e99cc52b84d0145aefb07cbd3c", size = 180560, upload-time = "2025-09-08T23:22:28.197Z" },
+    { url = "https://files.pythonhosted.org/packages/b1/b7/1200d354378ef52ec227395d95c2576330fd22a869f7a70e88e1447eb234/cffi-2.0.0-cp311-cp311-manylinux1_i686.manylinux2014_i686.manylinux_2_17_i686.manylinux_2_5_i686.whl", hash = "sha256:baf5215e0ab74c16e2dd324e8ec067ef59e41125d3eade2b863d294fd5035c92", size = 209613, upload-time = "2025-09-08T23:22:29.475Z" },
+    { url = "https://files.pythonhosted.org/packages/b8/56/6033f5e86e8cc9bb629f0077ba71679508bdf54a9a5e112a3c0b91870332/cffi-2.0.0-cp311-cp311-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:730cacb21e1bdff3ce90babf007d0a0917cc3e6492f336c2f0134101e0944f93", size = 216476, upload-time = "2025-09-08T23:22:31.063Z" },
+    { url = "https://files.pythonhosted.org/packages/dc/7f/55fecd70f7ece178db2f26128ec41430d8720f2d12ca97bf8f0a628207d5/cffi-2.0.0-cp311-cp311-manylinux2014_ppc64le.manylinux_2_17_ppc64le.whl", hash = "sha256:6824f87845e3396029f3820c206e459ccc91760e8fa24422f8b0c3d1731cbec5", size = 203374, upload-time = "2025-09-08T23:22:32.507Z" },
+    { url = "https://files.pythonhosted.org/packages/84/ef/a7b77c8bdc0f77adc3b46888f1ad54be8f3b7821697a7b89126e829e676a/cffi-2.0.0-cp311-cp311-manylinux2014_s390x.manylinux_2_17_s390x.whl", hash = "sha256:9de40a7b0323d889cf8d23d1ef214f565ab154443c42737dfe52ff82cf857664", size = 202597, upload-time = "2025-09-08T23:22:34.132Z" },
+    { url = "https://files.pythonhosted.org/packages/d7/91/500d892b2bf36529a75b77958edfcd5ad8e2ce4064ce2ecfeab2125d72d1/cffi-2.0.0-cp311-cp311-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:8941aaadaf67246224cee8c3803777eed332a19d909b47e29c9842ef1e79ac26", size = 215574, upload-time = "2025-09-08T23:22:35.443Z" },
+    { url = "https://files.pythonhosted.org/packages/44/64/58f6255b62b101093d5df22dcb752596066c7e89dd725e0afaed242a61be/cffi-2.0.0-cp311-cp311-musllinux_1_2_aarch64.whl", hash = "sha256:a05d0c237b3349096d3981b727493e22147f934b20f6f125a3eba8f994bec4a9", size = 218971, upload-time = "2025-09-08T23:22:36.805Z" },
+    { url = "https://files.pythonhosted.org/packages/ab/49/fa72cebe2fd8a55fbe14956f9970fe8eb1ac59e5df042f603ef7c8ba0adc/cffi-2.0.0-cp311-cp311-musllinux_1_2_i686.whl", hash = "sha256:94698a9c5f91f9d138526b48fe26a199609544591f859c870d477351dc7b2414", size = 211972, upload-time = "2025-09-08T23:22:38.436Z" },
+    { url = "https://files.pythonhosted.org/packages/0b/28/dd0967a76aab36731b6ebfe64dec4e981aff7e0608f60c2d46b46982607d/cffi-2.0.0-cp311-cp311-musllinux_1_2_x86_64.whl", hash = "sha256:5fed36fccc0612a53f1d4d9a816b50a36702c28a2aa880cb8a122b3466638743", size = 217078, upload-time = "2025-09-08T23:22:39.776Z" },
+    { url = "https://files.pythonhosted.org/packages/2b/c0/015b25184413d7ab0a410775fdb4a50fca20f5589b5dab1dbbfa3baad8ce/cffi-2.0.0-cp311-cp311-win32.whl", hash = "sha256:c649e3a33450ec82378822b3dad03cc228b8f5963c0c12fc3b1e0ab940f768a5", size = 172076, upload-time = "2025-09-08T23:22:40.95Z" },
+    { url = "https://files.pythonhosted.org/packages/ae/8f/dc5531155e7070361eb1b7e4c1a9d896d0cb21c49f807a6c03fd63fc877e/cffi-2.0.0-cp311-cp311-win_amd64.whl", hash = "sha256:66f011380d0e49ed280c789fbd08ff0d40968ee7b665575489afa95c98196ab5", size = 182820, upload-time = "2025-09-08T23:22:42.463Z" },
+    { url = "https://files.pythonhosted.org/packages/95/5c/1b493356429f9aecfd56bc171285a4c4ac8697f76e9bbbbb105e537853a1/cffi-2.0.0-cp311-cp311-win_arm64.whl", hash = "sha256:c6638687455baf640e37344fe26d37c404db8b80d037c3d29f58fe8d1c3b194d", size = 177635, upload-time = "2025-09-08T23:22:43.623Z" },
+    { url = "https://files.pythonhosted.org/packages/ea/47/4f61023ea636104d4f16ab488e268b93008c3d0bb76893b1b31db1f96802/cffi-2.0.0-cp312-cp312-macosx_10_13_x86_64.whl", hash = "sha256:6d02d6655b0e54f54c4ef0b94eb6be0607b70853c45ce98bd278dc7de718be5d", size = 185271, upload-time = "2025-09-08T23:22:44.795Z" },
+    { url = "https://files.pythonhosted.org/packages/df/a2/781b623f57358e360d62cdd7a8c681f074a71d445418a776eef0aadb4ab4/cffi-2.0.0-cp312-cp312-macosx_11_0_arm64.whl", hash = "sha256:8eca2a813c1cb7ad4fb74d368c2ffbbb4789d377ee5bb8df98373c2cc0dee76c", size = 181048, upload-time = "2025-09-08T23:22:45.938Z" },
+    { url = "https://files.pythonhosted.org/packages/ff/df/a4f0fbd47331ceeba3d37c2e51e9dfc9722498becbeec2bd8bc856c9538a/cffi-2.0.0-cp312-cp312-manylinux1_i686.manylinux2014_i686.manylinux_2_17_i686.manylinux_2_5_i686.whl", hash = "sha256:21d1152871b019407d8ac3985f6775c079416c282e431a4da6afe7aefd2bccbe", size = 212529, upload-time = "2025-09-08T23:22:47.349Z" },
+    { url = "https://files.pythonhosted.org/packages/d5/72/12b5f8d3865bf0f87cf1404d8c374e7487dcf097a1c91c436e72e6badd83/cffi-2.0.0-cp312-cp312-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:b21e08af67b8a103c71a250401c78d5e0893beff75e28c53c98f4de42f774062", size = 220097, upload-time = "2025-09-08T23:22:48.677Z" },
+    { url = "https://files.pythonhosted.org/packages/c2/95/7a135d52a50dfa7c882ab0ac17e8dc11cec9d55d2c18dda414c051c5e69e/cffi-2.0.0-cp312-cp312-manylinux2014_ppc64le.manylinux_2_17_ppc64le.whl", hash = "sha256:1e3a615586f05fc4065a8b22b8152f0c1b00cdbc60596d187c2a74f9e3036e4e", size = 207983, upload-time = "2025-09-08T23:22:50.06Z" },
+    { url = "https://files.pythonhosted.org/packages/3a/c8/15cb9ada8895957ea171c62dc78ff3e99159ee7adb13c0123c001a2546c1/cffi-2.0.0-cp312-cp312-manylinux2014_s390x.manylinux_2_17_s390x.whl", hash = "sha256:81afed14892743bbe14dacb9e36d9e0e504cd204e0b165062c488942b9718037", size = 206519, upload-time = "2025-09-08T23:22:51.364Z" },
+    { url = "https://files.pythonhosted.org/packages/78/2d/7fa73dfa841b5ac06c7b8855cfc18622132e365f5b81d02230333ff26e9e/cffi-2.0.0-cp312-cp312-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:3e17ed538242334bf70832644a32a7aae3d83b57567f9fd60a26257e992b79ba", size = 219572, upload-time = "2025-09-08T23:22:52.902Z" },
+    { url = "https://files.pythonhosted.org/packages/07/e0/267e57e387b4ca276b90f0434ff88b2c2241ad72b16d31836adddfd6031b/cffi-2.0.0-cp312-cp312-musllinux_1_2_aarch64.whl", hash = "sha256:3925dd22fa2b7699ed2617149842d2e6adde22b262fcbfada50e3d195e4b3a94", size = 222963, upload-time = "2025-09-08T23:22:54.518Z" },
+    { url = "https://files.pythonhosted.org/packages/b6/75/1f2747525e06f53efbd878f4d03bac5b859cbc11c633d0fb81432d98a795/cffi-2.0.0-cp312-cp312-musllinux_1_2_x86_64.whl", hash = "sha256:2c8f814d84194c9ea681642fd164267891702542f028a15fc97d4674b6206187", size = 221361, upload-time = "2025-09-08T23:22:55.867Z" },
+    { url = "https://files.pythonhosted.org/packages/7b/2b/2b6435f76bfeb6bbf055596976da087377ede68df465419d192acf00c437/cffi-2.0.0-cp312-cp312-win32.whl", hash = "sha256:da902562c3e9c550df360bfa53c035b2f241fed6d9aef119048073680ace4a18", size = 172932, upload-time = "2025-09-08T23:22:57.188Z" },
+    { url = "https://files.pythonhosted.org/packages/f8/ed/13bd4418627013bec4ed6e54283b1959cf6db888048c7cf4b4c3b5b36002/cffi-2.0.0-cp312-cp312-win_amd64.whl", hash = "sha256:da68248800ad6320861f129cd9c1bf96ca849a2771a59e0344e88681905916f5", size = 183557, upload-time = "2025-09-08T23:22:58.351Z" },
+    { url = "https://files.pythonhosted.org/packages/95/31/9f7f93ad2f8eff1dbc1c3656d7ca5bfd8fb52c9d786b4dcf19b2d02217fa/cffi-2.0.0-cp312-cp312-win_arm64.whl", hash = "sha256:4671d9dd5ec934cb9a73e7ee9676f9362aba54f7f34910956b84d727b0d73fb6", size = 177762, upload-time = "2025-09-08T23:22:59.668Z" },
+    { url = "https://files.pythonhosted.org/packages/4b/8d/a0a47a0c9e413a658623d014e91e74a50cdd2c423f7ccfd44086ef767f90/cffi-2.0.0-cp313-cp313-macosx_10_13_x86_64.whl", hash = "sha256:00bdf7acc5f795150faa6957054fbbca2439db2f775ce831222b66f192f03beb", size = 185230, upload-time = "2025-09-08T23:23:00.879Z" },
+    { url = "https://files.pythonhosted.org/packages/4a/d2/a6c0296814556c68ee32009d9c2ad4f85f2707cdecfd7727951ec228005d/cffi-2.0.0-cp313-cp313-macosx_11_0_arm64.whl", hash = "sha256:45d5e886156860dc35862657e1494b9bae8dfa63bf56796f2fb56e1679fc0bca", size = 181043, upload-time = "2025-09-08T23:23:02.231Z" },
+    { url = "https://files.pythonhosted.org/packages/b0/1e/d22cc63332bd59b06481ceaac49d6c507598642e2230f201649058a7e704/cffi-2.0.0-cp313-cp313-manylinux1_i686.manylinux2014_i686.manylinux_2_17_i686.manylinux_2_5_i686.whl", hash = "sha256:07b271772c100085dd28b74fa0cd81c8fb1a3ba18b21e03d7c27f3436a10606b", size = 212446, upload-time = "2025-09-08T23:23:03.472Z" },
+    { url = "https://files.pythonhosted.org/packages/a9/f5/a2c23eb03b61a0b8747f211eb716446c826ad66818ddc7810cc2cc19b3f2/cffi-2.0.0-cp313-cp313-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:d48a880098c96020b02d5a1f7d9251308510ce8858940e6fa99ece33f610838b", size = 220101, upload-time = "2025-09-08T23:23:04.792Z" },
+    { url = "https://files.pythonhosted.org/packages/f2/7f/e6647792fc5850d634695bc0e6ab4111ae88e89981d35ac269956605feba/cffi-2.0.0-cp313-cp313-manylinux2014_ppc64le.manylinux_2_17_ppc64le.whl", hash = "sha256:f93fd8e5c8c0a4aa1f424d6173f14a892044054871c771f8566e4008eaa359d2", size = 207948, upload-time = "2025-09-08T23:23:06.127Z" },
+    { url = "https://files.pythonhosted.org/packages/cb/1e/a5a1bd6f1fb30f22573f76533de12a00bf274abcdc55c8edab639078abb6/cffi-2.0.0-cp313-cp313-manylinux2014_s390x.manylinux_2_17_s390x.whl", hash = "sha256:dd4f05f54a52fb558f1ba9f528228066954fee3ebe629fc1660d874d040ae5a3", size = 206422, upload-time = "2025-09-08T23:23:07.753Z" },
+    { url = "https://files.pythonhosted.org/packages/98/df/0a1755e750013a2081e863e7cd37e0cdd02664372c754e5560099eb7aa44/cffi-2.0.0-cp313-cp313-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:c8d3b5532fc71b7a77c09192b4a5a200ea992702734a2e9279a37f2478236f26", size = 219499, upload-time = "2025-09-08T23:23:09.648Z" },
+    { url = "https://files.pythonhosted.org/packages/50/e1/a969e687fcf9ea58e6e2a928ad5e2dd88cc12f6f0ab477e9971f2309b57c/cffi-2.0.0-cp313-cp313-musllinux_1_2_aarch64.whl", hash = "sha256:d9b29c1f0ae438d5ee9acb31cadee00a58c46cc9c0b2f9038c6b0b3470877a8c", size = 222928, upload-time = "2025-09-08T23:23:10.928Z" },
+    { url = "https://files.pythonhosted.org/packages/36/54/0362578dd2c9e557a28ac77698ed67323ed5b9775ca9d3fe73fe191bb5d8/cffi-2.0.0-cp313-cp313-musllinux_1_2_x86_64.whl", hash = "sha256:6d50360be4546678fc1b79ffe7a66265e28667840010348dd69a314145807a1b", size = 221302, upload-time = "2025-09-08T23:23:12.42Z" },
+    { url = "https://files.pythonhosted.org/packages/eb/6d/bf9bda840d5f1dfdbf0feca87fbdb64a918a69bca42cfa0ba7b137c48cb8/cffi-2.0.0-cp313-cp313-win32.whl", hash = "sha256:74a03b9698e198d47562765773b4a8309919089150a0bb17d829ad7b44b60d27", size = 172909, upload-time = "2025-09-08T23:23:14.32Z" },
+    { url = "https://files.pythonhosted.org/packages/37/18/6519e1ee6f5a1e579e04b9ddb6f1676c17368a7aba48299c3759bbc3c8b3/cffi-2.0.0-cp313-cp313-win_amd64.whl", hash = "sha256:19f705ada2530c1167abacb171925dd886168931e0a7b78f5bffcae5c6b5be75", size = 183402, upload-time = "2025-09-08T23:23:15.535Z" },
+    { url = "https://files.pythonhosted.org/packages/cb/0e/02ceeec9a7d6ee63bb596121c2c8e9b3a9e150936f4fbef6ca1943e6137c/cffi-2.0.0-cp313-cp313-win_arm64.whl", hash = "sha256:256f80b80ca3853f90c21b23ee78cd008713787b1b1e93eae9f3d6a7134abd91", size = 177780, upload-time = "2025-09-08T23:23:16.761Z" },
+    { url = "https://files.pythonhosted.org/packages/92/c4/3ce07396253a83250ee98564f8d7e9789fab8e58858f35d07a9a2c78de9f/cffi-2.0.0-cp314-cp314-macosx_10_13_x86_64.whl", hash = "sha256:fc33c5141b55ed366cfaad382df24fe7dcbc686de5be719b207bb248e3053dc5", size = 185320, upload-time = "2025-09-08T23:23:18.087Z" },
+    { url = "https://files.pythonhosted.org/packages/59/dd/27e9fa567a23931c838c6b02d0764611c62290062a6d4e8ff7863daf9730/cffi-2.0.0-cp314-cp314-macosx_11_0_arm64.whl", hash = "sha256:c654de545946e0db659b3400168c9ad31b5d29593291482c43e3564effbcee13", size = 181487, upload-time = "2025-09-08T23:23:19.622Z" },
+    { url = "https://files.pythonhosted.org/packages/d6/43/0e822876f87ea8a4ef95442c3d766a06a51fc5298823f884ef87aaad168c/cffi-2.0.0-cp314-cp314-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:24b6f81f1983e6df8db3adc38562c83f7d4a0c36162885ec7f7b77c7dcbec97b", size = 220049, upload-time = "2025-09-08T23:23:20.853Z" },
+    { url = "https://files.pythonhosted.org/packages/b4/89/76799151d9c2d2d1ead63c2429da9ea9d7aac304603de0c6e8764e6e8e70/cffi-2.0.0-cp314-cp314-manylinux2014_ppc64le.manylinux_2_17_ppc64le.whl", hash = "sha256:12873ca6cb9b0f0d3a0da705d6086fe911591737a59f28b7936bdfed27c0d47c", size = 207793, upload-time = "2025-09-08T23:23:22.08Z" },
+    { url = "https://files.pythonhosted.org/packages/bb/dd/3465b14bb9e24ee24cb88c9e3730f6de63111fffe513492bf8c808a3547e/cffi-2.0.0-cp314-cp314-manylinux2014_s390x.manylinux_2_17_s390x.whl", hash = "sha256:d9b97165e8aed9272a6bb17c01e3cc5871a594a446ebedc996e2397a1c1ea8ef", size = 206300, upload-time = "2025-09-08T23:23:23.314Z" },
+    { url = "https://files.pythonhosted.org/packages/47/d9/d83e293854571c877a92da46fdec39158f8d7e68da75bf73581225d28e90/cffi-2.0.0-cp314-cp314-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:afb8db5439b81cf9c9d0c80404b60c3cc9c3add93e114dcae767f1477cb53775", size = 219244, upload-time = "2025-09-08T23:23:24.541Z" },
+    { url = "https://files.pythonhosted.org/packages/2b/0f/1f177e3683aead2bb00f7679a16451d302c436b5cbf2505f0ea8146ef59e/cffi-2.0.0-cp314-cp314-musllinux_1_2_aarch64.whl", hash = "sha256:737fe7d37e1a1bffe70bd5754ea763a62a066dc5913ca57e957824b72a85e205", size = 222828, upload-time = "2025-09-08T23:23:26.143Z" },
+    { url = "https://files.pythonhosted.org/packages/c6/0f/cafacebd4b040e3119dcb32fed8bdef8dfe94da653155f9d0b9dc660166e/cffi-2.0.0-cp314-cp314-musllinux_1_2_x86_64.whl", hash = "sha256:38100abb9d1b1435bc4cc340bb4489635dc2f0da7456590877030c9b3d40b0c1", size = 220926, upload-time = "2025-09-08T23:23:27.873Z" },
+    { url = "https://files.pythonhosted.org/packages/3e/aa/df335faa45b395396fcbc03de2dfcab242cd61a9900e914fe682a59170b1/cffi-2.0.0-cp314-cp314-win32.whl", hash = "sha256:087067fa8953339c723661eda6b54bc98c5625757ea62e95eb4898ad5e776e9f", size = 175328, upload-time = "2025-09-08T23:23:44.61Z" },
+    { url = "https://files.pythonhosted.org/packages/bb/92/882c2d30831744296ce713f0feb4c1cd30f346ef747b530b5318715cc367/cffi-2.0.0-cp314-cp314-win_amd64.whl", hash = "sha256:203a48d1fb583fc7d78a4c6655692963b860a417c0528492a6bc21f1aaefab25", size = 185650, upload-time = "2025-09-08T23:23:45.848Z" },
+    { url = "https://files.pythonhosted.org/packages/9f/2c/98ece204b9d35a7366b5b2c6539c350313ca13932143e79dc133ba757104/cffi-2.0.0-cp314-cp314-win_arm64.whl", hash = "sha256:dbd5c7a25a7cb98f5ca55d258b103a2054f859a46ae11aaf23134f9cc0d356ad", size = 180687, upload-time = "2025-09-08T23:23:47.105Z" },
+    { url = "https://files.pythonhosted.org/packages/3e/61/c768e4d548bfa607abcda77423448df8c471f25dbe64fb2ef6d555eae006/cffi-2.0.0-cp314-cp314t-macosx_10_13_x86_64.whl", hash = "sha256:9a67fc9e8eb39039280526379fb3a70023d77caec1852002b4da7e8b270c4dd9", size = 188773, upload-time = "2025-09-08T23:23:29.347Z" },
+    { url = "https://files.pythonhosted.org/packages/2c/ea/5f76bce7cf6fcd0ab1a1058b5af899bfbef198bea4d5686da88471ea0336/cffi-2.0.0-cp314-cp314t-macosx_11_0_arm64.whl", hash = "sha256:7a66c7204d8869299919db4d5069a82f1561581af12b11b3c9f48c584eb8743d", size = 185013, upload-time = "2025-09-08T23:23:30.63Z" },
+    { url = "https://files.pythonhosted.org/packages/be/b4/c56878d0d1755cf9caa54ba71e5d049479c52f9e4afc230f06822162ab2f/cffi-2.0.0-cp314-cp314t-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:7cc09976e8b56f8cebd752f7113ad07752461f48a58cbba644139015ac24954c", size = 221593, upload-time = "2025-09-08T23:23:31.91Z" },
+    { url = "https://files.pythonhosted.org/packages/e0/0d/eb704606dfe8033e7128df5e90fee946bbcb64a04fcdaa97321309004000/cffi-2.0.0-cp314-cp314t-manylinux2014_ppc64le.manylinux_2_17_ppc64le.whl", hash = "sha256:92b68146a71df78564e4ef48af17551a5ddd142e5190cdf2c5624d0c3ff5b2e8", size = 209354, upload-time = "2025-09-08T23:23:33.214Z" },
+    { url = "https://files.pythonhosted.org/packages/d8/19/3c435d727b368ca475fb8742ab97c9cb13a0de600ce86f62eab7fa3eea60/cffi-2.0.0-cp314-cp314t-manylinux2014_s390x.manylinux_2_17_s390x.whl", hash = "sha256:b1e74d11748e7e98e2f426ab176d4ed720a64412b6a15054378afdb71e0f37dc", size = 208480, upload-time = "2025-09-08T23:23:34.495Z" },
+    { url = "https://files.pythonhosted.org/packages/d0/44/681604464ed9541673e486521497406fadcc15b5217c3e326b061696899a/cffi-2.0.0-cp314-cp314t-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:28a3a209b96630bca57cce802da70c266eb08c6e97e5afd61a75611ee6c64592", size = 221584, upload-time = "2025-09-08T23:23:36.096Z" },
+    { url = "https://files.pythonhosted.org/packages/25/8e/342a504ff018a2825d395d44d63a767dd8ebc927ebda557fecdaca3ac33a/cffi-2.0.0-cp314-cp314t-musllinux_1_2_aarch64.whl", hash = "sha256:7553fb2090d71822f02c629afe6042c299edf91ba1bf94951165613553984512", size = 224443, upload-time = "2025-09-08T23:23:37.328Z" },
+    { url = "https://files.pythonhosted.org/packages/e1/5e/b666bacbbc60fbf415ba9988324a132c9a7a0448a9a8f125074671c0f2c3/cffi-2.0.0-cp314-cp314t-musllinux_1_2_x86_64.whl", hash = "sha256:6c6c373cfc5c83a975506110d17457138c8c63016b563cc9ed6e056a82f13ce4", size = 223437, upload-time = "2025-09-08T23:23:38.945Z" },
+    { url = "https://files.pythonhosted.org/packages/a0/1d/ec1a60bd1a10daa292d3cd6bb0b359a81607154fb8165f3ec95fe003b85c/cffi-2.0.0-cp314-cp314t-win32.whl", hash = "sha256:1fc9ea04857caf665289b7a75923f2c6ed559b8298a1b8c49e59f7dd95c8481e", size = 180487, upload-time = "2025-09-08T23:23:40.423Z" },
+    { url = "https://files.pythonhosted.org/packages/bf/41/4c1168c74fac325c0c8156f04b6749c8b6a8f405bbf91413ba088359f60d/cffi-2.0.0-cp314-cp314t-win_amd64.whl", hash = "sha256:d68b6cef7827e8641e8ef16f4494edda8b36104d79773a334beaa1e3521430f6", size = 191726, upload-time = "2025-09-08T23:23:41.742Z" },
+    { url = "https://files.pythonhosted.org/packages/ae/3a/dbeec9d1ee0844c679f6bb5d6ad4e9f198b1224f4e7a32825f47f6192b0c/cffi-2.0.0-cp314-cp314t-win_arm64.whl", hash = "sha256:0a1527a803f0a659de1af2e1fd700213caba79377e27e4693648c2923da066f9", size = 184195, upload-time = "2025-09-08T23:23:43.004Z" },
+]
+
+[[package]]
 name = "cfgv"
 version = "3.5.0"
 source = { registry = "https://pypi.org/simple" }
@@ -308,6 +378,65 @@ source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/d8/53/6f443c9a4a8358a93a6792e2acffb9d9d5cb0a5cfd8802644b7b1c9a02e4/colorama-0.4.6.tar.gz", hash = "sha256:08695f5cb7ed6e0531a20572697297273c47b8cae5a63ffc6d6ed5c201be6e44", size = 27697, upload-time = "2022-10-25T02:36:22.414Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/d1/d6/3965ed04c63042e047cb6a3e6ed1a63a35087b6a609aa3a15ed8ac56c221/colorama-0.4.6-py2.py3-none-any.whl", hash = "sha256:4f1d9991f5acc0ca119f9d443620b77f9d6b33703e51011c16baf57afb285fc6", size = 25335, upload-time = "2022-10-25T02:36:20.889Z" },
+]
+
+[[package]]
+name = "cryptography"
+version = "46.0.6"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "cffi", marker = "platform_python_implementation != 'PyPy'" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/a4/ba/04b1bd4218cbc58dc90ce967106d51582371b898690f3ae0402876cc4f34/cryptography-46.0.6.tar.gz", hash = "sha256:27550628a518c5c6c903d84f637fbecf287f6cb9ced3804838a1295dc1fd0759", size = 750542, upload-time = "2026-03-25T23:34:53.396Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/47/23/9285e15e3bc57325b0a72e592921983a701efc1ee8f91c06c5f0235d86d9/cryptography-46.0.6-cp311-abi3-macosx_10_9_universal2.whl", hash = "sha256:64235194bad039a10bb6d2d930ab3323baaec67e2ce36215fd0952fad0930ca8", size = 7176401, upload-time = "2026-03-25T23:33:22.096Z" },
+    { url = "https://files.pythonhosted.org/packages/60/f8/e61f8f13950ab6195b31913b42d39f0f9afc7d93f76710f299b5ec286ae6/cryptography-46.0.6-cp311-abi3-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:26031f1e5ca62fcb9d1fcb34b2b60b390d1aacaa15dc8b895a9ed00968b97b30", size = 4275275, upload-time = "2026-03-25T23:33:23.844Z" },
+    { url = "https://files.pythonhosted.org/packages/19/69/732a736d12c2631e140be2348b4ad3d226302df63ef64d30dfdb8db7ad1c/cryptography-46.0.6-cp311-abi3-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:9a693028b9cbe51b5a1136232ee8f2bc242e4e19d456ded3fa7c86e43c713b4a", size = 4425320, upload-time = "2026-03-25T23:33:25.703Z" },
+    { url = "https://files.pythonhosted.org/packages/d4/12/123be7292674abf76b21ac1fc0e1af50661f0e5b8f0ec8285faac18eb99e/cryptography-46.0.6-cp311-abi3-manylinux_2_28_aarch64.whl", hash = "sha256:67177e8a9f421aa2d3a170c3e56eca4e0128883cf52a071a7cbf53297f18b175", size = 4278082, upload-time = "2026-03-25T23:33:27.423Z" },
+    { url = "https://files.pythonhosted.org/packages/5b/ba/d5e27f8d68c24951b0a484924a84c7cdaed7502bac9f18601cd357f8b1d2/cryptography-46.0.6-cp311-abi3-manylinux_2_28_ppc64le.whl", hash = "sha256:d9528b535a6c4f8ff37847144b8986a9a143585f0540fbcb1a98115b543aa463", size = 4926514, upload-time = "2026-03-25T23:33:29.206Z" },
+    { url = "https://files.pythonhosted.org/packages/34/71/1ea5a7352ae516d5512d17babe7e1b87d9db5150b21f794b1377eac1edc0/cryptography-46.0.6-cp311-abi3-manylinux_2_28_x86_64.whl", hash = "sha256:22259338084d6ae497a19bae5d4c66b7ca1387d3264d1c2c0e72d9e9b6a77b97", size = 4457766, upload-time = "2026-03-25T23:33:30.834Z" },
+    { url = "https://files.pythonhosted.org/packages/01/59/562be1e653accee4fdad92c7a2e88fced26b3fdfce144047519bbebc299e/cryptography-46.0.6-cp311-abi3-manylinux_2_31_armv7l.whl", hash = "sha256:760997a4b950ff00d418398ad73fbc91aa2894b5c1db7ccb45b4f68b42a63b3c", size = 3986535, upload-time = "2026-03-25T23:33:33.02Z" },
+    { url = "https://files.pythonhosted.org/packages/d6/8b/b1ebfeb788bf4624d36e45ed2662b8bd43a05ff62157093c1539c1288a18/cryptography-46.0.6-cp311-abi3-manylinux_2_34_aarch64.whl", hash = "sha256:3dfa6567f2e9e4c5dceb8ccb5a708158a2a871052fa75c8b78cb0977063f1507", size = 4277618, upload-time = "2026-03-25T23:33:34.567Z" },
+    { url = "https://files.pythonhosted.org/packages/dd/52/a005f8eabdb28df57c20f84c44d397a755782d6ff6d455f05baa2785bd91/cryptography-46.0.6-cp311-abi3-manylinux_2_34_ppc64le.whl", hash = "sha256:cdcd3edcbc5d55757e5f5f3d330dd00007ae463a7e7aa5bf132d1f22a4b62b19", size = 4890802, upload-time = "2026-03-25T23:33:37.034Z" },
+    { url = "https://files.pythonhosted.org/packages/ec/4d/8e7d7245c79c617d08724e2efa397737715ca0ec830ecb3c91e547302555/cryptography-46.0.6-cp311-abi3-manylinux_2_34_x86_64.whl", hash = "sha256:d4e4aadb7fc1f88687f47ca20bb7227981b03afaae69287029da08096853b738", size = 4457425, upload-time = "2026-03-25T23:33:38.904Z" },
+    { url = "https://files.pythonhosted.org/packages/1d/5c/f6c3596a1430cec6f949085f0e1a970638d76f81c3ea56d93d564d04c340/cryptography-46.0.6-cp311-abi3-musllinux_1_2_aarch64.whl", hash = "sha256:2b417edbe8877cda9022dde3a008e2deb50be9c407eef034aeeb3a8b11d9db3c", size = 4405530, upload-time = "2026-03-25T23:33:40.842Z" },
+    { url = "https://files.pythonhosted.org/packages/7e/c9/9f9cea13ee2dbde070424e0c4f621c091a91ffcc504ffea5e74f0e1daeff/cryptography-46.0.6-cp311-abi3-musllinux_1_2_x86_64.whl", hash = "sha256:380343e0653b1c9d7e1f55b52aaa2dbb2fdf2730088d48c43ca1c7c0abb7cc2f", size = 4667896, upload-time = "2026-03-25T23:33:42.781Z" },
+    { url = "https://files.pythonhosted.org/packages/ad/b5/1895bc0821226f129bc74d00eccfc6a5969e2028f8617c09790bf89c185e/cryptography-46.0.6-cp311-abi3-win32.whl", hash = "sha256:bcb87663e1f7b075e48c3be3ecb5f0b46c8fc50b50a97cf264e7f60242dca3f2", size = 3026348, upload-time = "2026-03-25T23:33:45.021Z" },
+    { url = "https://files.pythonhosted.org/packages/c3/f8/c9bcbf0d3e6ad288b9d9aa0b1dee04b063d19e8c4f871855a03ab3a297ab/cryptography-46.0.6-cp311-abi3-win_amd64.whl", hash = "sha256:6739d56300662c468fddb0e5e291f9b4d084bead381667b9e654c7dd81705124", size = 3483896, upload-time = "2026-03-25T23:33:46.649Z" },
+    { url = "https://files.pythonhosted.org/packages/01/41/3a578f7fd5c70611c0aacba52cd13cb364a5dee895a5c1d467208a9380b0/cryptography-46.0.6-cp314-cp314t-macosx_10_9_universal2.whl", hash = "sha256:2ef9e69886cbb137c2aef9772c2e7138dc581fad4fcbcf13cc181eb5a3ab6275", size = 7117147, upload-time = "2026-03-25T23:33:48.249Z" },
+    { url = "https://files.pythonhosted.org/packages/fa/87/887f35a6fca9dde90cad08e0de0c89263a8e59b2d2ff904fd9fcd8025b6f/cryptography-46.0.6-cp314-cp314t-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:7f417f034f91dcec1cb6c5c35b07cdbb2ef262557f701b4ecd803ee8cefed4f4", size = 4266221, upload-time = "2026-03-25T23:33:49.874Z" },
+    { url = "https://files.pythonhosted.org/packages/aa/a8/0a90c4f0b0871e0e3d1ed126aed101328a8a57fd9fd17f00fb67e82a51ca/cryptography-46.0.6-cp314-cp314t-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:d24c13369e856b94892a89ddf70b332e0b70ad4a5c43cf3e9cb71d6d7ffa1f7b", size = 4408952, upload-time = "2026-03-25T23:33:52.128Z" },
+    { url = "https://files.pythonhosted.org/packages/16/0b/b239701eb946523e4e9f329336e4ff32b1247e109cbab32d1a7b61da8ed7/cryptography-46.0.6-cp314-cp314t-manylinux_2_28_aarch64.whl", hash = "sha256:aad75154a7ac9039936d50cf431719a2f8d4ed3d3c277ac03f3339ded1a5e707", size = 4270141, upload-time = "2026-03-25T23:33:54.11Z" },
+    { url = "https://files.pythonhosted.org/packages/0f/a8/976acdd4f0f30df7b25605f4b9d3d89295351665c2091d18224f7ad5cdbf/cryptography-46.0.6-cp314-cp314t-manylinux_2_28_ppc64le.whl", hash = "sha256:3c21d92ed15e9cfc6eb64c1f5a0326db22ca9c2566ca46d845119b45b4400361", size = 4904178, upload-time = "2026-03-25T23:33:55.725Z" },
+    { url = "https://files.pythonhosted.org/packages/b1/1b/bf0e01a88efd0e59679b69f42d4afd5bced8700bb5e80617b2d63a3741af/cryptography-46.0.6-cp314-cp314t-manylinux_2_28_x86_64.whl", hash = "sha256:4668298aef7cddeaf5c6ecc244c2302a2b8e40f384255505c22875eebb47888b", size = 4441812, upload-time = "2026-03-25T23:33:57.364Z" },
+    { url = "https://files.pythonhosted.org/packages/bb/8b/11df86de2ea389c65aa1806f331cae145f2ed18011f30234cc10ca253de8/cryptography-46.0.6-cp314-cp314t-manylinux_2_31_armv7l.whl", hash = "sha256:8ce35b77aaf02f3b59c90b2c8a05c73bac12cea5b4e8f3fbece1f5fddea5f0ca", size = 3963923, upload-time = "2026-03-25T23:33:59.361Z" },
+    { url = "https://files.pythonhosted.org/packages/91/e0/207fb177c3a9ef6a8108f234208c3e9e76a6aa8cf20d51932916bd43bda0/cryptography-46.0.6-cp314-cp314t-manylinux_2_34_aarch64.whl", hash = "sha256:c89eb37fae9216985d8734c1afd172ba4927f5a05cfd9bf0e4863c6d5465b013", size = 4269695, upload-time = "2026-03-25T23:34:00.909Z" },
+    { url = "https://files.pythonhosted.org/packages/21/5e/19f3260ed1e95bced52ace7501fabcd266df67077eeb382b79c81729d2d3/cryptography-46.0.6-cp314-cp314t-manylinux_2_34_ppc64le.whl", hash = "sha256:ed418c37d095aeddf5336898a132fba01091f0ac5844e3e8018506f014b6d2c4", size = 4869785, upload-time = "2026-03-25T23:34:02.796Z" },
+    { url = "https://files.pythonhosted.org/packages/10/38/cd7864d79aa1d92ef6f1a584281433419b955ad5a5ba8d1eb6c872165bcb/cryptography-46.0.6-cp314-cp314t-manylinux_2_34_x86_64.whl", hash = "sha256:69cf0056d6947edc6e6760e5f17afe4bea06b56a9ac8a06de9d2bd6b532d4f3a", size = 4441404, upload-time = "2026-03-25T23:34:04.35Z" },
+    { url = "https://files.pythonhosted.org/packages/09/0a/4fe7a8d25fed74419f91835cf5829ade6408fd1963c9eae9c4bce390ecbb/cryptography-46.0.6-cp314-cp314t-musllinux_1_2_aarch64.whl", hash = "sha256:8e7304c4f4e9490e11efe56af6713983460ee0780f16c63f219984dab3af9d2d", size = 4397549, upload-time = "2026-03-25T23:34:06.342Z" },
+    { url = "https://files.pythonhosted.org/packages/5f/a0/7d738944eac6513cd60a8da98b65951f4a3b279b93479a7e8926d9cd730b/cryptography-46.0.6-cp314-cp314t-musllinux_1_2_x86_64.whl", hash = "sha256:b928a3ca837c77a10e81a814a693f2295200adb3352395fad024559b7be7a736", size = 4651874, upload-time = "2026-03-25T23:34:07.916Z" },
+    { url = "https://files.pythonhosted.org/packages/cb/f1/c2326781ca05208845efca38bf714f76939ae446cd492d7613808badedf1/cryptography-46.0.6-cp314-cp314t-win32.whl", hash = "sha256:97c8115b27e19e592a05c45d0dd89c57f81f841cc9880e353e0d3bf25b2139ed", size = 3001511, upload-time = "2026-03-25T23:34:09.892Z" },
+    { url = "https://files.pythonhosted.org/packages/c9/57/fe4a23eb549ac9d903bd4698ffda13383808ef0876cc912bcb2838799ece/cryptography-46.0.6-cp314-cp314t-win_amd64.whl", hash = "sha256:c797e2517cb7880f8297e2c0f43bb910e91381339336f75d2c1c2cbf811b70b4", size = 3471692, upload-time = "2026-03-25T23:34:11.613Z" },
+    { url = "https://files.pythonhosted.org/packages/c4/cc/f330e982852403da79008552de9906804568ae9230da8432f7496ce02b71/cryptography-46.0.6-cp38-abi3-macosx_10_9_universal2.whl", hash = "sha256:12cae594e9473bca1a7aceb90536060643128bb274fcea0fc459ab90f7d1ae7a", size = 7162776, upload-time = "2026-03-25T23:34:13.308Z" },
+    { url = "https://files.pythonhosted.org/packages/49/b3/dc27efd8dcc4bff583b3f01d4a3943cd8b5821777a58b3a6a5f054d61b79/cryptography-46.0.6-cp38-abi3-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:639301950939d844a9e1c4464d7e07f902fe9a7f6b215bb0d4f28584729935d8", size = 4270529, upload-time = "2026-03-25T23:34:15.019Z" },
+    { url = "https://files.pythonhosted.org/packages/e6/05/e8d0e6eb4f0d83365b3cb0e00eb3c484f7348db0266652ccd84632a3d58d/cryptography-46.0.6-cp38-abi3-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:ed3775295fb91f70b4027aeba878d79b3e55c0b3e97eaa4de71f8f23a9f2eb77", size = 4414827, upload-time = "2026-03-25T23:34:16.604Z" },
+    { url = "https://files.pythonhosted.org/packages/2f/97/daba0f5d2dc6d855e2dcb70733c812558a7977a55dd4a6722756628c44d1/cryptography-46.0.6-cp38-abi3-manylinux_2_28_aarch64.whl", hash = "sha256:8927ccfbe967c7df312ade694f987e7e9e22b2425976ddbf28271d7e58845290", size = 4271265, upload-time = "2026-03-25T23:34:18.586Z" },
+    { url = "https://files.pythonhosted.org/packages/89/06/fe1fce39a37ac452e58d04b43b0855261dac320a2ebf8f5260dd55b201a9/cryptography-46.0.6-cp38-abi3-manylinux_2_28_ppc64le.whl", hash = "sha256:b12c6b1e1651e42ab5de8b1e00dc3b6354fdfd778e7fa60541ddacc27cd21410", size = 4916800, upload-time = "2026-03-25T23:34:20.561Z" },
+    { url = "https://files.pythonhosted.org/packages/ff/8a/b14f3101fe9c3592603339eb5d94046c3ce5f7fc76d6512a2d40efd9724e/cryptography-46.0.6-cp38-abi3-manylinux_2_28_x86_64.whl", hash = "sha256:063b67749f338ca9c5a0b7fe438a52c25f9526b851e24e6c9310e7195aad3b4d", size = 4448771, upload-time = "2026-03-25T23:34:22.406Z" },
+    { url = "https://files.pythonhosted.org/packages/01/b3/0796998056a66d1973fd52ee89dc1bb3b6581960a91ad4ac705f182d398f/cryptography-46.0.6-cp38-abi3-manylinux_2_31_armv7l.whl", hash = "sha256:02fad249cb0e090b574e30b276a3da6a149e04ee2f049725b1f69e7b8351ec70", size = 3978333, upload-time = "2026-03-25T23:34:24.281Z" },
+    { url = "https://files.pythonhosted.org/packages/c5/3d/db200af5a4ffd08918cd55c08399dc6c9c50b0bc72c00a3246e099d3a849/cryptography-46.0.6-cp38-abi3-manylinux_2_34_aarch64.whl", hash = "sha256:7e6142674f2a9291463e5e150090b95a8519b2fb6e6aaec8917dd8d094ce750d", size = 4271069, upload-time = "2026-03-25T23:34:25.895Z" },
+    { url = "https://files.pythonhosted.org/packages/d7/18/61acfd5b414309d74ee838be321c636fe71815436f53c9f0334bf19064fa/cryptography-46.0.6-cp38-abi3-manylinux_2_34_ppc64le.whl", hash = "sha256:456b3215172aeefb9284550b162801d62f5f264a081049a3e94307fe20792cfa", size = 4878358, upload-time = "2026-03-25T23:34:27.67Z" },
+    { url = "https://files.pythonhosted.org/packages/8b/65/5bf43286d566f8171917cae23ac6add941654ccf085d739195a4eacf1674/cryptography-46.0.6-cp38-abi3-manylinux_2_34_x86_64.whl", hash = "sha256:341359d6c9e68834e204ceaf25936dffeafea3829ab80e9503860dcc4f4dac58", size = 4448061, upload-time = "2026-03-25T23:34:29.375Z" },
+    { url = "https://files.pythonhosted.org/packages/e0/25/7e49c0fa7205cf3597e525d156a6bce5b5c9de1fd7e8cb01120e459f205a/cryptography-46.0.6-cp38-abi3-musllinux_1_2_aarch64.whl", hash = "sha256:9a9c42a2723999a710445bc0d974e345c32adfd8d2fac6d8a251fa829ad31cfb", size = 4399103, upload-time = "2026-03-25T23:34:32.036Z" },
+    { url = "https://files.pythonhosted.org/packages/44/46/466269e833f1c4718d6cd496ffe20c56c9c8d013486ff66b4f69c302a68d/cryptography-46.0.6-cp38-abi3-musllinux_1_2_x86_64.whl", hash = "sha256:6617f67b1606dfd9fe4dbfa354a9508d4a6d37afe30306fe6c101b7ce3274b72", size = 4659255, upload-time = "2026-03-25T23:34:33.679Z" },
+    { url = "https://files.pythonhosted.org/packages/0a/09/ddc5f630cc32287d2c953fc5d32705e63ec73e37308e5120955316f53827/cryptography-46.0.6-cp38-abi3-win32.whl", hash = "sha256:7f6690b6c55e9c5332c0b59b9c8a3fb232ebf059094c17f9019a51e9827df91c", size = 3010660, upload-time = "2026-03-25T23:34:35.418Z" },
+    { url = "https://files.pythonhosted.org/packages/1b/82/ca4893968aeb2709aacfb57a30dec6fa2ab25b10fa9f064b8882ce33f599/cryptography-46.0.6-cp38-abi3-win_amd64.whl", hash = "sha256:79e865c642cfc5c0b3eb12af83c35c5aeff4fa5c672dc28c43721c2c9fdd2f0f", size = 3471160, upload-time = "2026-03-25T23:34:37.191Z" },
+    { url = "https://files.pythonhosted.org/packages/2e/84/7ccff00ced5bac74b775ce0beb7d1be4e8637536b522b5df9b73ada42da2/cryptography-46.0.6-pp311-pypy311_pp73-macosx_11_0_arm64.whl", hash = "sha256:2ea0f37e9a9cf0df2952893ad145fd9627d326a59daec9b0802480fa3bcd2ead", size = 3475444, upload-time = "2026-03-25T23:34:38.944Z" },
+    { url = "https://files.pythonhosted.org/packages/bc/1f/4c926f50df7749f000f20eede0c896769509895e2648db5da0ed55db711d/cryptography-46.0.6-pp311-pypy311_pp73-manylinux_2_28_aarch64.whl", hash = "sha256:a3e84d5ec9ba01f8fd03802b2147ba77f0c8f2617b2aff254cedd551844209c8", size = 4218227, upload-time = "2026-03-25T23:34:40.871Z" },
+    { url = "https://files.pythonhosted.org/packages/c6/65/707be3ffbd5f786028665c3223e86e11c4cda86023adbc56bd72b1b6bab5/cryptography-46.0.6-pp311-pypy311_pp73-manylinux_2_28_x86_64.whl", hash = "sha256:12f0fa16cc247b13c43d56d7b35287ff1569b5b1f4c5e87e92cc4fcc00cd10c0", size = 4381399, upload-time = "2026-03-25T23:34:42.609Z" },
+    { url = "https://files.pythonhosted.org/packages/f3/6d/73557ed0ef7d73d04d9aba745d2c8e95218213687ee5e76b7d236a5030fc/cryptography-46.0.6-pp311-pypy311_pp73-manylinux_2_34_aarch64.whl", hash = "sha256:50575a76e2951fe7dbd1f56d181f8c5ceeeb075e9ff88e7ad997d2f42af06e7b", size = 4217595, upload-time = "2026-03-25T23:34:44.205Z" },
+    { url = "https://files.pythonhosted.org/packages/9e/c5/e1594c4eec66a567c3ac4400008108a415808be2ce13dcb9a9045c92f1a0/cryptography-46.0.6-pp311-pypy311_pp73-manylinux_2_34_x86_64.whl", hash = "sha256:90e5f0a7b3be5f40c3a0a0eafb32c681d8d2c181fc2a1bdabe9b3f611d9f6b1a", size = 4380912, upload-time = "2026-03-25T23:34:46.328Z" },
+    { url = "https://files.pythonhosted.org/packages/1a/89/843b53614b47f97fe1abc13f9a86efa5ec9e275292c457af1d4a60dc80e0/cryptography-46.0.6-pp311-pypy311_pp73-win_amd64.whl", hash = "sha256:6728c49e3b2c180ef26f8e9f0a883a2c585638db64cf265b49c9ba10652d430e", size = 3409955, upload-time = "2026-03-25T23:34:48.465Z" },
 ]
 
 [[package]]
@@ -1107,7 +1236,10 @@ version = "0.1.0"
 source = { editable = "." }
 dependencies = [
     { name = "click" },
+    { name = "cryptography" },
+    { name = "httpx" },
     { name = "pydantic" },
+    { name = "pyjwt" },
     { name = "pyyaml" },
 ]
 
@@ -1141,9 +1273,12 @@ test = [
 requires-dist = [
     { name = "accelerate", marker = "extra == 'training'", specifier = ">=1.13" },
     { name = "click", specifier = ">=8.1" },
+    { name = "cryptography", specifier = ">=44.0" },
     { name = "datasets", marker = "extra == 'training'", specifier = ">=4.3" },
+    { name = "httpx", specifier = ">=0.27" },
     { name = "peft", marker = "extra == 'training'", specifier = ">=0.18" },
     { name = "pydantic", specifier = ">=2.0.0" },
+    { name = "pyjwt", specifier = ">=2.10" },
     { name = "pyyaml", specifier = ">=6.0" },
     { name = "torch", marker = "extra == 'training'", specifier = ">=2.10" },
     { name = "transformers", marker = "extra == 'training'", specifier = ">=5.2" },
@@ -1463,6 +1598,15 @@ wheels = [
 ]
 
 [[package]]
+name = "pycparser"
+version = "3.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/1b/7d/92392ff7815c21062bea51aa7b87d45576f649f16458d78b7cf94b9ab2e6/pycparser-3.0.tar.gz", hash = "sha256:600f49d217304a5902ac3c37e1281c9fe94e4d0489de643a9504c5cdfdfc6b29", size = 103492, upload-time = "2026-01-21T14:26:51.89Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/0c/c3/44f3fbbfa403ea2a7c779186dc20772604442dde72947e7d01069cbe98e3/pycparser-3.0-py3-none-any.whl", hash = "sha256:b727414169a36b7d524c1c3e31839a521725078d7b2ff038656844266160a992", size = 48172, upload-time = "2026-01-21T14:26:50.693Z" },
+]
+
+[[package]]
 name = "pydantic"
 version = "2.12.5"
 source = { registry = "https://pypi.org/simple" }
@@ -1581,6 +1725,15 @@ source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/b0/77/a5b8c569bf593b0140bde72ea885a803b82086995367bf2037de0159d924/pygments-2.19.2.tar.gz", hash = "sha256:636cb2477cec7f8952536970bc533bc43743542f70392ae026374600add5b887", size = 4968631, upload-time = "2025-06-21T13:39:12.283Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/c7/21/705964c7812476f378728bdf590ca4b771ec72385c533964653c68e86bdc/pygments-2.19.2-py3-none-any.whl", hash = "sha256:86540386c03d588bb81d44bc3928634ff26449851e99741617ecb9037ee5ec0b", size = 1225217, upload-time = "2025-06-21T13:39:07.939Z" },
+]
+
+[[package]]
+name = "pyjwt"
+version = "2.12.1"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/c2/27/a3b6e5bf6ff856d2509292e95c8f57f0df7017cf5394921fc4e4ef40308a/pyjwt-2.12.1.tar.gz", hash = "sha256:c74a7a2adf861c04d002db713dd85f84beb242228e671280bf709d765b03672b", size = 102564, upload-time = "2026-03-13T19:27:37.25Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/e5/7a/8dd906bd22e79e47397a61742927f6747fe93242ef86645ee9092e610244/pyjwt-2.12.1-py3-none-any.whl", hash = "sha256:28ca37c070cad8ba8cd9790cd940535d40274d22f80ab87f3ac6a713e6e8454c", size = 29726, upload-time = "2026-03-13T19:27:35.677Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
## Summary

Preserve the k3s platform add-on branch and align it to the current standalone/v1 contract instead of pruning features.

This wires the core-adjacent pieces through the real build/admit path:
- add `BuildConfig` knobs for security tier, cluster backend, k3d settings, and network policy backend
- select `k3d` rendering/live backends through pipeline, CLI, and admission auto-live detection
- register the security enforcement checks and carry security integration output into rendered artifact metadata
- stage the missing identity-provider helper file, normalize service-id scope aliases, and clean up stale pre-v1 references in the optional helper docs

It also keeps Anto's optional platform/helper surfaces in-tree while making the current v1 surfaces understand them more cleanly.

## Testing

- `tmpdir=$(mktemp -d /tmp/openrange-align-XXXXXX)`
- `uv run -m open_range.cli build -m src/open_range/_resources/manifests/tier1_basic.yaml -o "$tmpdir/build" --security-tier 3 --cluster-backend k3d --network-policy-backend cilium`
- `uv run -m open_range.cli admit -m src/open_range/_resources/manifests/tier1_basic.yaml -o "$tmpdir/admit" --store-dir "$tmpdir/store" --validation-profile graph_only --security-tier 3 --cluster-backend k3d --network-policy-backend cilium`

## Review Notes

The preserved branch still contains optional repo-side platform helpers like Argo CD, Vault, Hubble, Prometheus, and GitOps publishing. This PR does not delete them; it aligns the current v1 build/admit/runtime surfaces around the pieces that need first-class integration now and updates the helper/docs surfaces so they no longer point back at the deleted server-era architecture.
